### PR TITLE
Split score and static eval fields in TT entries

### DIFF
--- a/Logic/Transposition/TTEntry.cs
+++ b/Logic/Transposition/TTEntry.cs
@@ -25,7 +25,10 @@ namespace Lizard.Logic.Transposition
         public const int DepthNone = -6;
 
         [FieldOffset(0)]
-        public int _ScoreStatEval;      //  4 = 16 bits + 16 bits
+        public short _Score;            //  2 = 16 bits
+
+        [FieldOffset(2)]
+        public short _StatEval;           //  2 = 16 bits
 
         [FieldOffset(4)]
         public Move BestMove;           //  2 = 16 bits
@@ -42,14 +45,14 @@ namespace Lizard.Logic.Transposition
 
         public short Score
         {
-            get => (short)(_ScoreStatEval & 0xFFFF);
-            set => _ScoreStatEval = (_ScoreStatEval & ~0xFFFF) | value;
+            get => _Score;
+            set => _Score = value;
         }
 
         public short StatEval
         {
-            get => (short)((_ScoreStatEval & 0xFFFF0000) >> 16);
-            set => _ScoreStatEval = (int)((_ScoreStatEval & 0x0000FFFF) | (value << 16));
+            get => _StatEval;
+            set => _StatEval = value;
         }
 
         public int Age


### PR DESCRIPTION
No functional change. This only avoids masking and shifting by changing how the data is stored.

```
Elo   | 0.12 +- 2.77 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | -0.85 (-2.94, 2.94) [-1.00, 3.00]
Games | N: 32394 W: 8710 L: 8699 D: 14985
Penta | [439, 3656, 7981, 3697, 424]
http://somelizard.pythonanywhere.com/test/492/
```