### PR TITLE
Choose to enable pext at startup

### DIFF
--- a/Logic/Magic/MagicBitboards.cs
+++ b/Logic/Magic/MagicBitboards.cs
@@ -1,16 +1,15 @@
-﻿namespace Lizard.Logic.Magic
+﻿using System.Runtime.InteropServices;
+
+namespace Lizard.Logic.Magic
 {
     public static unsafe class MagicBitboards
     {
-
-#if PEXT
         public static FancyMagicSquare* FancyRookMagics;
         public static FancyMagicSquare* FancyBishopMagics;
 
         private static ulong* RookTable;
         private static ulong* BishopTable;
 
-#else
         /// <summary>
         /// Contains bitboards whose bits are set where blockers for a rook on a given square could be
         /// </summary>
@@ -37,33 +36,90 @@
         public static MagicSquare[] RookMagics;
         public static MagicSquare[] BishopMagics;
 
-#endif
 
+        public static readonly bool UsePext = true;
         static MagicBitboards()
         {
-#if PEXT
-            if (!System.Runtime.Intrinsics.X86.Bmi2.X64.IsSupported)
-            {
-                Log("Warning: This binary was compiled with PEXT defined, but your CPU does not support Bmi2!");
-                Log("This means a non-intrinsic fallback will have to be used, which will probably be slower " +
-                    "than using the non-pext binary.");
-            }
-#endif
-            Initialize();
-        }
-
-        public static void Initialize()
-        {
-#if PEXT
             RookTable = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * 0x19000), AllocAlignment);
             BishopTable = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * 0x19000), AllocAlignment);
             FancyRookMagics = InitializeFancyMagics(Piece.Rook, RookTable);
             FancyBishopMagics = InitializeFancyMagics(Piece.Bishop, BishopTable);
-#else
+
             GenAllBlockerBoards();
             RookMagics = InitializeMagics(Piece.Rook);
             BishopMagics = InitializeMagics(Piece.Bishop);
-#endif
+
+            {
+                ulong temp = 0;
+
+                Stopwatch sw = Stopwatch.StartNew();
+                long fancyElapsed = 0;
+                long normalElapsed = 0;
+                for (int n = 0; n < 100; n++)
+                {
+                    sw.Restart();
+                    for (int m = 0; m < 100; m++)
+                        foreach ((int sq, ulong blockers) in pextTests)
+                            temp ^= TestPextFancy(blockers, sq);
+
+                    sw.Stop();
+                    if (n > 0)
+                        fancyElapsed += sw.ElapsedTicks;
+
+
+                    sw.Restart();
+                    for (int m = 0; m < 100; m++)
+                        foreach ((int sq, ulong blockers) in pextTests)
+                            temp ^= TestPextNormal(blockers, sq);
+                    sw.Stop();
+                    if (n > 0)
+                        normalElapsed += sw.ElapsedTicks;
+                }
+
+                UsePext = (fancyElapsed < normalElapsed);
+            }
+
+            if (UsePext)
+            {
+                Console.WriteLine("PEXT is enabled.");
+                RookMagics = null;
+                RookAttackBoards = null;
+                RookBlockerBoards = null;
+                RookBlockerMask = null;
+
+                BishopMagics = null;
+                BishopAttackBoards = null;
+                BishopBlockerBoards = null;
+                BishopBlockerMask = null;
+            }
+            else
+            {
+                Console.WriteLine("PEXT is disabled.");
+                NativeMemory.AlignedFree(RookTable);
+                NativeMemory.AlignedFree(FancyRookMagics);
+
+                NativeMemory.AlignedFree(BishopTable);
+                NativeMemory.AlignedFree(FancyBishopMagics);
+            }
+
+            //Initialize();
+        }
+
+        public static void Initialize()
+        {
+            if (UsePext)
+            {
+                RookTable = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * 0x19000), AllocAlignment);
+                BishopTable = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * 0x19000), AllocAlignment);
+                FancyRookMagics = InitializeFancyMagics(Piece.Rook, RookTable);
+                FancyBishopMagics = InitializeFancyMagics(Piece.Bishop, BishopTable);
+            }
+            else
+            {
+                GenAllBlockerBoards();
+                RookMagics = InitializeMagics(Piece.Rook);
+                BishopMagics = InitializeMagics(Piece.Bishop);
+            }
         }
 
 
@@ -77,14 +133,17 @@
         /// </summary>
         public static ulong GetRookMoves(ulong boardAll, int idx)
         {
-#if PEXT
-            FancyMagicSquare m = FancyRookMagics[idx];
-            return m.attacks[pext(boardAll, m.mask)];
-#else
-            MagicSquare m = RookMagics[idx];
-            return m.attacks[((boardAll & m.mask) * m.number) >> m.shift];
-#endif
+            if (UsePext)
+            {
+                FancyMagicSquare m = FancyRookMagics[idx];
+                return m.attacks[pext(boardAll, m.mask)];
             }
+            else
+            {
+                MagicSquare m = RookMagics[idx];
+                return m.attacks[((boardAll & m.mask) * m.number) >> m.shift];
+            }
+        }
 
         /// <summary>
         /// Returns all of the squares that a bishop on <paramref name="idx"/> could move to.
@@ -95,16 +154,33 @@
         /// </summary>
         public static ulong GetBishopMoves(ulong boardAll, int idx)
         {
-#if PEXT
-            FancyMagicSquare m = FancyBishopMagics[idx];
-            return m.attacks[pext(boardAll, m.mask)];
-#else
-            MagicSquare m = BishopMagics[idx];
-            return m.attacks[((boardAll & m.mask) * m.number) >> m.shift];
-#endif
+            if (UsePext)
+            {
+                FancyMagicSquare m = FancyBishopMagics[idx];
+                return m.attacks[pext(boardAll, m.mask)];
+            }
+            else
+            {
+                MagicSquare m = BishopMagics[idx];
+                return m.attacks[((boardAll & m.mask) * m.number) >> m.shift];
+            }
         }
 
-#if PEXT
+        private static ulong TestPextFancy(ulong boardAll, int idx)
+        {
+            FancyMagicSquare bm = FancyBishopMagics[idx];
+            FancyMagicSquare rm = FancyRookMagics[idx];
+            return (bm.attacks[pext(boardAll, bm.mask)] | rm.attacks[pext(boardAll, rm.mask)]);
+        }
+
+        private static ulong TestPextNormal(ulong boardAll, int idx)
+        {
+            MagicSquare bm = BishopMagics[idx];
+            MagicSquare rm = RookMagics[idx];
+            return (bm.attacks[((boardAll & bm.mask) * bm.number) >> bm.shift] | rm.attacks[((boardAll & rm.mask) * rm.number) >> rm.shift]);
+        }
+
+
         /// <summary>
         /// Sets up the "fancy" magic squares for the given piece type <paramref name="pt"/>.
         /// <br></br>
@@ -148,8 +224,6 @@
 
             return magicArray;
         }
-
-#else
 
         private static MagicSquare[] InitializeMagics(int pt)
         {
@@ -273,7 +347,6 @@
             6, 5, 5, 5, 5, 5, 5, 6,
         };
 
-#endif
 
         /// <summary>
         /// Returns a mask containing every square the piece on <paramref name="idx"/> can move to on the board <paramref name="occupied"/>.
@@ -416,5 +489,25 @@
             0xFC0FF2865334F576, 0xFC0BF6CE5924F576, 0x0102010041100810, 0x0202000020881080, 0x0302004110824100, 0xA084C00803010000, 0xC3FFB7DC36CA8C89, 0xC3FF8A54F4CA2C89,
             0xFFFFFCFCFD79EDFF, 0xFC0863FCCB147576, 0x0100112201048800, 0x0800000080208838, 0x8080200010020202, 0x42002C0484080201, 0xFC087E8E4BB2F736, 0x43FF9E4EF4CA2C89,
         };
+
+        private static readonly (int sq, ulong blockers)[] pextTests =
+        [
+            (56, 0x69EB3C000828EF65ul), (29, 0x000002C424040000ul), (58, 0x042001002080A000ul), (49, 0x0002B001A0284100ul),
+            ( 8, 0x40E0080C2430F308ul), (56, 0x6DF96604043AF36Bul), (35, 0x000046E84EAC0048ul), (56, 0x6DE0221C033CC795ul),
+            (57, 0x0262A21050244000ul), (27, 0x08080DA019C42442ul), ( 9, 0x7987100B8D00F261ul), (56, 0x01500060E6240501ul),
+            ( 9, 0x52E23D10A650CA68ul), (56, 0x51EE490308CC6B60ul), (46, 0x0001400441500000ul), ( 0, 0xC07E095897602461ul),
+            (19, 0xB4EB34080A987D62ul), (10, 0x11466094516C850Cul), (30, 0x08C4200748824001ul), (57, 0x4200789228408000ul),
+            (26, 0x08AA3180B46A0B00ul), (62, 0x4080000000200001ul), (12, 0x943413C00E10578Eul), (56, 0x416A7104003FC248ul),
+            (33, 0x0010006301060000ul), (29, 0x00000501E6120000ul), (59, 0x2C36C611159654A1ul), (19, 0x00000402A2082000ul),
+            (41, 0x0001235050000000ul), (47, 0xDDA3E41890265F8Cul), (43, 0x00002CAC8C407100ul), (51, 0x00894A0A49202000ul),
+            (62, 0xC0A1F21848218860ul), (26, 0x00B04A8505B06042ul), (26, 0x00100022A4048500ul), (37, 0x400106240E010002ul),
+            (10, 0x404040C283010600ul), (19, 0x2860A4002AE86000ul), (20, 0x80211A00F011DA40ul), (35, 0x0018208802D00000ul),
+            (16, 0x5860C22B9D557808ul), (19, 0x59C75430A98CDA71ul), (20, 0x4010684B08110060ul), (61, 0x206C38851F9A49A2ul),
+            (14, 0x0079D1048C487040ul), (58, 0x14EE8C033816C260ul), (21, 0xB6E42D101126FB69ul), (56, 0x9572B1118806D68Cul),
+            (59, 0x68E2570C04D46F49ul), (38, 0x9979D4580825E361ul), (59, 0x68E10422005AF000ul), (60, 0x50622404A088E000ul),
+            (12, 0x0586C0350002F388ul), (56, 0x6DFF00901900E744ul), (14, 0x2861A8AA74004302ul), (38, 0x040101F498522144ul),
+            (34, 0x0206115C00800002ul), (20, 0x606B907808B06B44ul), (59, 0x0880DA200C6BC910ul), (23, 0x01001011058C0000ul),
+            (58, 0x84C129100444B040ul), (50, 0x0004408839418000ul), (56, 0xB5E912143408C961ul), ( 0, 0x00C2220C00D2A195ul)
+        ];
     }
 }

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
 
+using Lizard.Logic.Magic;
 using Lizard.Logic.Threads;
 
 namespace Lizard.Logic.Util
@@ -242,17 +243,12 @@ namespace Lizard.Logic.Util
             }
 
             sb.Append(Avx2.IsSupported ? "Avx2 " : string.Empty);
-            sb.Append(AvxVnni.IsSupported ? "AvxVnni " : string.Empty);
             sb.Append(Bmi2.IsSupported ? "Bmi2 " : string.Empty);
             sb.Append(Sse3.IsSupported ? "Sse3 " : string.Empty);
             sb.Append(Sse42.IsSupported ? "Sse42 " : string.Empty);
-
             sb.Append(Sse.IsSupported ? "Prefetch " : string.Empty);
             sb.Append(Popcnt.X64.IsSupported ? "Popcount " : string.Empty);
-#if PEXT
-            //  Magic bitboards will only use Pext if "PEXT" is also defined
-            sb.Append(Bmi2.X64.IsSupported ? "Pext " : string.Empty);
-#endif
+            sb.Append(Bmi2.X64.IsSupported && MagicBitboards.UsePext ? "Pext " : string.Empty);
             sb.Append(Lzcnt.X64.IsSupported ? "Lzcnt " : string.Empty);
 
             return sb.ToString();

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ BUILD_OPTS = --self-contained -v quiet --property WarningLevel=0 -o ./ -c Releas
 #	Try building the non-AOT version first, and then try to build the AOT version if possible.
 #   This recipe should always work, but AOT requires some additional setup so the aot recipe may fail.
 release:
-	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="$(DefineConstants)PEXT" -p:EVALFILE=$(EVALFILE)
+	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="$(DefineConstants)" -p:EVALFILE=$(EVALFILE)
 	-rmdir /s /q .\bin\Release
 	$(MAKE) aot
 
@@ -30,7 +30,7 @@ release:
 #	-p:DebugType=embedded apparently just... doesn't embed it? So this will delete the pdb as well.	
 #	https://github.com/dotnet/sdk/issues/35798
 aot:
-	-dotnet publish . $(BUILD_OPTS) -p:PublishAOT=true -p:PublishSingleFile=false -p:DefineConstants="$(DefineConstants)PUBLISH_AOT%3BPEXT" -p:EVALFILE=$(EVALFILE)
+	-dotnet publish . $(BUILD_OPTS) -p:PublishAOT=true -p:PublishSingleFile=false -p:DefineConstants="$(DefineConstants)PUBLISH_AOT" -p:EVALFILE=$(EVALFILE)
 	-rmdir /s /q .\bin\Release\native
 	-rmdir /s /q .\bin\Release
 	-del .\Lizard.pdb


### PR DESCRIPTION
No significant change in performance for most CPU's, but should help AMD processors earlier than Zen 3.

```
Elo   | 2.00 +- 5.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.47 (-2.94, 2.94) [0.00, 3.00]
Games | N: 8862 W: 2288 L: 2237 D: 4337
Penta | [82, 995, 2209, 1080, 65]
http://somelizard.pythonanywhere.com/test/488/
```