### PR TITLE
History Cleanups 

### DIFF
--- a/Logic/Search/History/CaptureHistoryTable.cs
+++ b/Logic/Search/History/CaptureHistoryTable.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.InteropServices;
+
+using Lizard.Logic.Search.History;
+
+namespace Lizard.Logic.Search.History
+{
+    public unsafe readonly struct CaptureHistoryTable
+    {
+        private readonly StatEntry* _History;
+        public const int CaptureHistoryElements = ColorNB * (PieceNB) * SquareNB * (PieceNB);
+
+        public CaptureHistoryTable()
+        {
+            _History = (StatEntry*)AlignedAllocZeroed((nuint)sizeof(StatEntry) * CaptureHistoryElements, AllocAlignment);
+        }
+
+        public StatEntry this[int idx]
+        {
+            get => _History[idx];
+            set => _History[idx] = value;
+        }
+
+        public StatEntry this[int pc, int pt, int toSquare, int capturedPt]
+        {
+            get => _History[CapIndex(pc, pt, toSquare, capturedPt)];
+            set => _History[CapIndex(pc, pt, toSquare, capturedPt)] = value;
+        }
+
+        public void Dispose()
+        {
+            NativeMemory.AlignedFree(_History);
+        }
+
+        public void Clear()
+        {
+            NativeMemory.Clear(_History, (nuint)sizeof(StatEntry) * CaptureHistoryElements);
+        }
+
+        /// <summary>
+        /// Returns the index of the score that should be applied to a piece of type <paramref name="pt"/> and color <paramref name="pc"/> 
+        /// capturing a piece of type <paramref name="capturedPt"/> on the square <paramref name="toSquare"/>.
+        /// <br></br>
+        /// This just calculates the flattened 3D array index for 
+        /// <see cref="CaptureHistory"/>[<paramref name="pt"/> + <paramref name="pc"/>][<paramref name="toSquare"/>][<paramref name="capturedPt"/>].
+        /// </summary>
+        public static int CapIndex(int pc, int pt, int toSquare, int capturedPt)
+        {
+            return (capturedPt * 768) + (toSquare * 12) + (pt + (pc * 6));
+        }
+    }
+}

--- a/Logic/Search/History/ContinuationHistory.cs
+++ b/Logic/Search/History/ContinuationHistory.cs
@@ -1,0 +1,76 @@
+﻿using System.Runtime.InteropServices;
+
+using Lizard.Logic.Search.Ordering;
+
+namespace Lizard.Logic.Search.History
+{
+    /// <summary>
+    /// Records the history for a pair of moves.
+    /// <br></br>
+    /// This is an array of <see cref="PieceToHistory"/> [12][64], with a size of <inheritdoc cref="ByteSize"/>.
+    /// </summary>
+    public unsafe struct ContinuationHistory
+    {
+        private PieceToHistory* _History;
+
+        private const int DimX = PieceNB * 2;
+        private const int DimY = SquareNB;
+
+        /// <summary>
+        /// 12 * 64 == 768 elements
+        /// </summary>
+        public const nuint Length = DimX * DimY;
+
+        /// <summary>
+        /// 8 * (<inheritdoc cref="Length"/>) == 6144 bytes
+        /// </summary>
+        private const nuint ByteSize = (nuint)(sizeof(ulong) * Length);
+
+        public ContinuationHistory()
+        {
+            _History = (PieceToHistory*)AlignedAllocZeroed(ByteSize, AllocAlignment);
+
+            for (nuint i = 0; i < Length; i++)
+            {
+                (_History + i)->Alloc();
+            }
+        }
+
+        public void Dispose()
+        {
+            for (nuint i = 0; i < Length; i++)
+            {
+                (_History + i)->Dispose();
+            }
+
+            NativeMemory.AlignedFree(_History);
+        }
+
+
+        public PieceToHistory* this[int pc, int pt, int sq]
+        {
+            get
+            {
+                int idx = PieceToHistory.GetIndex(pc, pt, sq);
+                return &_History[idx];
+            }
+        }
+
+        public PieceToHistory* this[int idx]
+        {
+            get
+            {
+                return &_History[idx];
+            }
+        }
+
+
+        public void Clear()
+        {
+            for (nuint i = 0; i < Length; i++)
+            {
+                _History[i].Clear();
+            }
+        }
+    }
+}

--- a/Logic/Search/History/MainHistoryTable.cs
+++ b/Logic/Search/History/MainHistoryTable.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.InteropServices;
+
+using Lizard.Logic.Search.Ordering;
+
+namespace Lizard.Logic.Search.History
+{
+    public unsafe readonly struct MainHistoryTable
+    {
+        public readonly StatEntry* _History;
+        public const int MainHistoryPCStride = 4096;
+        public const int MainHistoryElements = ColorNB * SquareNB * SquareNB;
+
+        public MainHistoryTable()
+        {
+            _History = (StatEntry*)AlignedAllocZeroed((nuint)sizeof(StatEntry) * MainHistoryElements, AllocAlignment);
+        }
+
+        public StatEntry this[int idx]
+        {
+            get => _History[idx];
+            set => _History[idx] = value;
+        }
+
+        public StatEntry this[int pc, Move m]
+        {
+            get => _History[HistoryIndex(pc, m)];
+            set => _History[HistoryIndex(pc, m)] = value;
+        }
+
+        public void Dispose()
+        {
+            NativeMemory.AlignedFree(_History);
+        }
+
+        public void Clear()
+        {
+            NativeMemory.Clear(_History, (nuint)sizeof(StatEntry) * MainHistoryElements);
+        }
+
+        public static int HistoryIndex(int pc, Move m)
+        {
+            if (EnableAssertions)
+            {
+                Assert(((pc * MainHistoryPCStride) + m.MoveMask) is >= 0 and < MainHistoryElements,
+                    "HistoryIndex(" + pc + ", " + m.MoveMask + ") is OOB! (should be 0 <= idx < " + MainHistoryElements + ")");
+            }
+
+            return (pc * MainHistoryPCStride) + m.MoveMask;
+        }
+    }
+}

--- a/Logic/Search/History/PieceToHistory.cs
+++ b/Logic/Search/History/PieceToHistory.cs
@@ -1,0 +1,84 @@
+﻿
+using System.Runtime.InteropServices;
+
+namespace Lizard.Logic.Search.History
+{
+    /// <summary>
+    /// Records how successful different moves have been in the past by recording that move's
+    /// piece type and color, and the square that it is moving to. 
+    /// <br></br>
+    /// This is a short array with dimensions [12][64], with a size of <inheritdoc cref="ByteSize"/>.
+    /// </summary>
+    public unsafe struct PieceToHistory
+    {
+        private StatEntry* _History;
+
+        private const short FillValue = -50;
+
+        private const int DimX = PieceNB * 2;
+        private const int DimY = SquareNB;
+
+        /// <summary>
+        /// 12 * 64 == 768 elements
+        /// </summary>
+        public const nuint Length = DimX * DimY;
+
+        /// <summary>
+        /// 2 * (<inheritdoc cref="Length"/>) == 1536 bytes
+        /// </summary>
+        public const nuint ByteSize = sizeof(short) * Length;
+
+        public PieceToHistory() { }
+
+        public void Dispose()
+        {
+            NativeMemory.AlignedFree(_History);
+        }
+
+        public StatEntry this[int pc, int pt, int sq]
+        {
+            get => _History[GetIndex(pc, pt, sq)];
+            set => _History[GetIndex(pc, pt, sq)] = value;
+        }
+
+        public StatEntry this[int idx]
+        {
+            get => _History[idx];
+            set => _History[idx] = value;
+        }
+
+        /// <summary>
+        /// Returns the index of the score in the History array for a piece of color <paramref name="pc"/> 
+        /// and type <paramref name="pt"/> moving to the square <paramref name="sq"/>.
+        /// </summary>
+        public static int GetIndex(int pc, int pt, int sq)
+        {
+            if (EnableAssertions)
+            {
+                Assert((((pt + (PieceNB * pc)) * DimY) + sq) is >= 0 and < (int)Length,
+                    "GetIndex(" + pc + ", " + pt + ", " + sq + ") is OOB! (should be 0 <= idx < " + Length + ")");
+            }
+
+            return ((pt + (PieceNB * pc)) * DimY) + sq;
+        }
+
+        /// <summary>
+        /// Allocates memory for this instance's array.
+        /// </summary>
+        public void Alloc()
+        {
+            _History = (StatEntry*)AlignedAllocZeroed(ByteSize, AllocAlignment);
+        }
+
+        /// <summary>
+        /// Fills this instance's array with the value of <see cref="FillValue"/>.
+        /// </summary>
+        public void Clear()
+        {
+            NativeMemory.Clear(_History, ByteSize);
+            Span<StatEntry> span = new Span<StatEntry>(_History, (int)Length);
+            span.Fill(FillValue);
+        }
+    }
+
+}

--- a/Logic/Search/History/StatEntry.cs
+++ b/Logic/Search/History/StatEntry.cs
@@ -1,0 +1,14 @@
+﻿
+using static Lizard.Logic.Search.History.HistoryTable;
+
+namespace Lizard.Logic.Search.History
+{
+    public readonly struct StatEntry(short v)
+    {
+        public readonly short Value = v;
+
+        public static implicit operator short(StatEntry entry) => entry.Value;
+        public static implicit operator StatEntry(short s) => new(s);
+        public static StatEntry operator <<(StatEntry entry, int bonus) => (StatEntry)(entry + (bonus - (entry * Math.Abs(bonus) / NormalClamp)));
+    }
+}

--- a/Logic/Search/MovePicker.cs
+++ b/Logic/Search/MovePicker.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-using Lizard.Logic.Search.Ordering;
+using Lizard.Logic.Search.History;
 
 using static Lizard.Logic.Search.MovePicker.MovePickerStage;
 
@@ -465,8 +465,7 @@ namespace Lizard.Logic.Search
                     capturedPiece = Rook;
                 }
 
-                int capIdx = HistoryTable.CapIndex(pos.ToMove, pos.bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece);
-                iter->Score = (13 * GetPieceValue(capturedPiece)) + (captureHistory[capIdx] / 12);
+                iter->Score = (13 * GetPieceValue(capturedPiece)) + -9999;// (captureHistory[pos.ToMove, pos.bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece] / 12);
             }
         }
 
@@ -476,7 +475,7 @@ namespace Lizard.Logic.Search
             {
                 int contIdx = PieceToHistory.GetIndex(pos.ToMove, pos.bb.GetPieceAtIndex(iter->Move.From), iter->Move.To);
 
-                iter->Score = (2 * mainHistory[HistoryTable.HistoryIndex(pos.ToMove, iter->Move)]) +
+                iter->Score = -9999 + //(2 * mainHistory[HistoryTable.HistoryIndex(pos.ToMove, iter->Move)]) +
                               (2 * (*continuations[0])[contIdx]) +
                                   (*continuations[1])[contIdx] +
                                   (*continuations[3])[contIdx] +
@@ -511,7 +510,7 @@ namespace Lizard.Logic.Search
                 {
                     int contIdx = PieceToHistory.GetIndex(pos.ToMove, pos.bb.GetPieceAtIndex(iter->Move.From), iter->Move.To);
 
-                    iter->Score = (2 * mainHistory[HistoryTable.HistoryIndex(pos.ToMove, iter->Move)]) +
+                    iter->Score = -9999 + //(2 * mainHistory[HistoryTable.HistoryIndex(pos.ToMove, iter->Move)]) +
                                   (2 * (*continuations[0])[contIdx]) +
                                       (*continuations[1])[contIdx] +
                                       (*continuations[3])[contIdx] +

--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -1,4 +1,7 @@
-﻿namespace Lizard.Logic.Search.Ordering
+﻿
+using Lizard.Logic.Search.History;
+
+namespace Lizard.Logic.Search.Ordering
 {
     public static unsafe class MoveOrdering
     {
@@ -37,15 +40,15 @@
                 else if (bb.GetPieceAtIndex(moveTo) != None && !m.Castle)
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
-                    int capIdx = HistoryTable.CapIndex(pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece);
-                    sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + (history.CaptureHistory[capIdx] / OrderingHistoryDivisor);
+                    sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
+                               (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece] / OrderingHistoryDivisor);
                 }
                 else
                 {
                     int pt = bb.GetPieceAtIndex(moveFrom);
                     int contIdx = PieceToHistory.GetIndex(pc, pt, moveTo);
 
-                    sm.Score = 2 * history.MainHistory[HistoryTable.HistoryIndex(pc, m)];
+                    sm.Score = 2 * history.MainHistory[pc, m];
                     sm.Score += 2 * (*(ss - 1)->ContinuationHistory)[contIdx];
                     sm.Score += (*(ss - 2)->ContinuationHistory)[contIdx];
                     sm.Score += (*(ss - 4)->ContinuationHistory)[contIdx];
@@ -85,19 +88,19 @@
                 else if (bb.GetPieceAtIndex(moveTo) != None && !m.Castle)
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
-                    int capIdx = HistoryTable.CapIndex(pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece);
-                    sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + (history.CaptureHistory[capIdx] / OrderingHistoryDivisor);
+                    sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
+                               (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece] / OrderingHistoryDivisor);
                 }
                 else
                 {
                     int pt = bb.GetPieceAtIndex(moveFrom);
                     int contIdx = PieceToHistory.GetIndex(pc, pt, moveTo);
 
-                    sm.Score = 2 * history.MainHistory[HistoryTable.HistoryIndex(pc, m)];
+                    sm.Score = 2 * history.MainHistory[pc, m];
                     sm.Score += 2 * (*(ss - 1)->ContinuationHistory)[contIdx];
-                    sm.Score += (*(ss - 2)->ContinuationHistory)[contIdx];
-                    sm.Score += (*(ss - 4)->ContinuationHistory)[contIdx];
-                    sm.Score += (*(ss - 6)->ContinuationHistory)[contIdx];
+                    sm.Score +=     (*(ss - 2)->ContinuationHistory)[contIdx];
+                    sm.Score +=     (*(ss - 4)->ContinuationHistory)[contIdx];
+                    sm.Score +=     (*(ss - 6)->ContinuationHistory)[contIdx];
 
                     if ((pos.State->CheckSquares[pt] & SquareBB[moveTo]) != 0)
                     {

--- a/Logic/Search/SearchStackEntry.cs
+++ b/Logic/Search/SearchStackEntry.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text;
 
-using Lizard.Logic.Search.Ordering;
+using Lizard.Logic.Search.History;
 
 namespace Lizard.Logic.Search
 {

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text;
 
 using Lizard.Logic.NN;
-using Lizard.Logic.Search.Ordering;
+using Lizard.Logic.Search.History;
 using Lizard.Logic.Threads;
 
 using static Lizard.Logic.Search.Ordering.MoveOrdering;
@@ -520,7 +520,7 @@ namespace Lizard.Logic.Search
                     if (m.Equals(ss->Killer0) || m.Equals(ss->Killer1))
                         R--;
 
-                    ss->StatScore = 2 * history.MainHistory[HistoryTable.HistoryIndex(ourColor, m)] +
+                    ss->StatScore = 2 * history.MainHistory[ourColor, m] +
                                         (*(ss - 1)->ContinuationHistory)[histIdx] +
                                         (*(ss - 2)->ContinuationHistory)[histIdx] +
                                         (*(ss - 4)->ContinuationHistory)[histIdx];
@@ -1004,8 +1004,7 @@ namespace Lizard.Logic.Search
 
             if (capturedPiece != None && !bestMove.Castle)
             {
-                int idx = HistoryTable.CapIndex(thisColor, thisPiece, moveTo, capturedPiece);
-                history.ApplyBonus(history.CaptureHistory, idx, quietMoveBonus, HistoryTable.CaptureClamp);
+                history.CaptureHistory[thisColor, thisPiece, moveTo, capturedPiece] <<= quietMoveBonus;
             }
             else
             {
@@ -1018,21 +1017,21 @@ namespace Lizard.Logic.Search
                     ss->Killer0 = bestMove;
                 }
 
-                history.ApplyBonus(history.MainHistory, HistoryTable.HistoryIndex(thisColor, bestMove), bestMoveBonus, HistoryTable.MainHistoryClamp);
+                history.MainHistory[thisColor, bestMove] <<= bestMoveBonus;
                 UpdateContinuations(ss, thisColor, thisPiece, moveTo, bestMoveBonus);
 
                 for (int i = 0; i < quietCount; i++)
                 {
                     Move m = quietMoves[i];
-                    history.ApplyBonus(history.MainHistory, HistoryTable.HistoryIndex(thisColor, m), -quietMovePenalty, HistoryTable.MainHistoryClamp);
+                    history.MainHistory[thisColor, m] <<= -quietMovePenalty;
                     UpdateContinuations(ss, thisColor, bb.GetPieceAtIndex(m.From), m.To, -quietMovePenalty);
                 }
             }
 
             for (int i = 0; i < captureCount; i++)
             {
-                int idx = HistoryTable.CapIndex(thisColor, bb.GetPieceAtIndex(captureMoves[i].From), captureMoves[i].To, bb.GetPieceAtIndex(captureMoves[i].To));
-                history.ApplyBonus(history.CaptureHistory, idx, -quietMoveBonus, HistoryTable.CaptureClamp);
+                Move m = captureMoves[i];
+                history.CaptureHistory[thisColor, bb.GetPieceAtIndex(m.From), m.To, bb.GetPieceAtIndex(m.To)] <<= -quietMoveBonus;
             }
         }
 
@@ -1053,8 +1052,7 @@ namespace Lizard.Logic.Search
 
                 if ((ss - i)->CurrentMove != Move.Null)
                 {
-                    (*(ss - i)->ContinuationHistory)[pc, pt, sq] += (short)(bonus -
-                    ((*(ss - i)->ContinuationHistory)[pc, pt, sq] * Math.Abs(bonus) / PieceToHistory.Clamp));
+                    (*(ss - i)->ContinuationHistory)[pc, pt, sq] <<= bonus;
                 }
             }
         }

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-using Lizard.Logic.Search.Ordering;
+using Lizard.Logic.Search.History;
 
 namespace Lizard.Logic.Threads
 {
@@ -548,8 +548,8 @@ namespace Lizard.Logic.Threads
         /// </summary>
         public void Clear()
         {
-            NativeMemory.Clear(History.MainHistory, sizeof(short) * HistoryTable.MainHistoryElements);
-            NativeMemory.Clear(History.CaptureHistory, sizeof(short) * HistoryTable.CaptureHistoryElements);
+            History.MainHistory.Clear();
+            History.CaptureHistory.Clear();
 
             for (int i = 0; i < 2; i++)
             {


### PR DESCRIPTION
- Main/Capture histories are now in their own files and are now indexed implicitly with `HistoryIndex`/`CapIndex`, which is easier to work with.
- History is now stored in `StatEntry`, which is just a wrapper over a `short`. 
- Bonuses are applied using the `<<=` operator, instead of `history.ApplyBonus`.