### PR TITLE
Fix MultiPV Output

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -379,6 +379,13 @@ namespace Lizard.Logic.Search
                     continue;
                 }
 
+                if (isRoot && thisThread.RootMoves.FindIndex(thisThread.PVIndex, r => r.Move == m) == -1)
+                {
+                    //  For multipv to work properly, we need to skip root moves that are ordered before this one
+                    //  since they've already been searched and we don't want them as options again.
+                    continue;
+                }
+
                 if (EnableAssertions)
                 {
                     Assert(pos.IsPseudoLegal(m),

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -405,9 +405,9 @@ namespace Lizard.Logic.Threads
                         window += window / 2;
                     }
 
-                    StableSort(ref RootMoves, 0);
+                    StableSort(ref RootMoves, 0, PVIndex + 1);
 
-                    if (IsMain && (SearchPool.StopThreads || PVIndex == multiPV - 1 || tm.GetSearchTime() > 3000))
+                    if (IsMain && (SearchPool.StopThreads || PVIndex == multiPV - 1))
                     {
                         info.OnDepthFinish?.Invoke(ref info);
                     }


### PR DESCRIPTION
MultiPV (incorrectly) allowed moves sorted before the current root move to be searched, which caused issues with the root move scores and messy output. 