### PR TITLE
Added AVX-512 SIMD

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,37 @@
+name: Makefile CI
+
+on:
+  workflow_dispatch:
+
+env:
+    DOTNET_VERSION: 9.0.x
+
+jobs:
+
+  build-and-publish:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        include:
+          - os: ubuntu-latest
+            runtime-identifier: linux-x64
+          - os: windows-latest
+            runtime-identifier: win-x64
+          - os: macOS-latest
+            runtime-identifier: osx-x64
+          - os: macos-14
+            runtime-identifier: osx-arm64
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Run Make
+      run: make

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /Properties/PublishProfiles/*.user
 /Properties/launchSettings.json
 /*.exe
+/*.pdb

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -119,6 +119,14 @@
       <_Parameter1>$(EVALFILE)</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
+
+  <!-- Targeting the "aot" recipe in the makefile will set this to true.
+  -->
+  <ItemGroup>
+    <AssemblyAttribute Include="Lizard.Logic.Util.IsAOTAttribute">
+      <_Parameter1>$(IS_AOT)</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
   
   
 

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -18,6 +18,10 @@
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GenerateDependencyFile>False</GenerateDependencyFile>
 
+    <!-- https://github.com/dotnet/runtime/issues/3735#issuecomment-666641134 maybe? 
+    -->
+    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <NeutralLanguage>en</NeutralLanguage>
 

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -18,10 +18,6 @@
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
     <GenerateDependencyFile>False</GenerateDependencyFile>
 
-    <!-- https://github.com/dotnet/runtime/issues/3735#issuecomment-666641134 maybe? 
-    -->
-    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
-
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <NeutralLanguage>en</NeutralLanguage>
 

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -13,16 +13,17 @@ namespace Lizard.Logic.NN
         private const int InputBuckets = 4;
         public const int InputSize = 768;
         public const int HiddenSize = 1024;
-        private const int OutputBuckets = 8;
+        public const int OutputBuckets = 8;
 
-        private const int QA = 255;
-        private const int QB = 64;
+        public const int QA = 255;
+        public const int QB = 64;
         private const int QAB = QA * QB;
 
         public const int OutputScale = 400;
         private const bool SelectOutputBucket = (OutputBuckets != 1);
 
-        public static readonly int SIMD_CHUNKS = HiddenSize / Vector256<short>.Count;
+        public static readonly int SIMD_CHUNKS_512 = HiddenSize / Vector512<short>.Count;
+        public static readonly int SIMD_CHUNKS_256 = HiddenSize / Vector256<short>.Count;
 
         /// <summary>
         /// 
@@ -31,34 +32,11 @@ namespace Lizard.Logic.NN
         /// </summary>
         public const string NetworkName = "lizard-1024_4_8_gauss-600.bin";
 
-        /// <summary>
-        /// The values applied according to the active features and current bucket.
-        /// <para></para>
-        /// This is the 768 -> 1024 part of the architecture.
-        /// </summary>
-        public static readonly Vector256<short>* FeatureWeights;
 
-        /// <summary>
-        /// The initial values that are placed into the accumulators.
-        /// <para></para>
-        /// When doing a full refresh, both accumulators are filled with these.
-        /// </summary>
-        public static readonly Vector256<short>* FeatureBiases;
-
-        /// <summary>
-        /// The values that are multiplied with the SCRelu-activated output from the feature transformer 
-        /// to produce the final sum.
-        /// <para></para>
-        /// This is the (1024)x2 -> 1 part.
-        /// </summary>
-        public static readonly Vector256<short>* LayerWeights;
-
-        /// <summary>
-        /// The value(s) applied to the final output.
-        /// <para></para>
-        /// There is exactly 1 bias for each output bucket, so this currently contains only 1 number (followed by 15 zeroes).
-        /// </summary>
-        public static readonly Vector256<short>* LayerBiases;
+        public static readonly short* FeatureWeights;
+        public static readonly short* FeatureBiases;
+        public static readonly short* LayerWeights;
+        public static readonly short* LayerBiases;
 
         private const int FeatureWeightElements = InputSize * HiddenSize * InputBuckets;
         private const int FeatureBiasElements = HiddenSize;
@@ -82,11 +60,11 @@ namespace Lizard.Logic.NN
 
         static Bucketed768()
         {
-            FeatureWeights = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * FeatureWeightElements);
-            FeatureBiases = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * FeatureBiasElements);
+            FeatureWeights = (short*)AlignedAllocZeroed(sizeof(short) * FeatureWeightElements);
+            FeatureBiases = (short*)AlignedAllocZeroed(sizeof(short) * FeatureBiasElements);
 
-            LayerWeights = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * LayerWeightElements);
-            LayerBiases = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * (nuint)Math.Max(LayerBiasElements, VSize.Short));
+            LayerWeights = (short*)AlignedAllocZeroed(sizeof(short) * LayerWeightElements);
+            LayerBiases = (short*)AlignedAllocZeroed(sizeof(short) * (nuint)Math.Max(LayerBiasElements, VSize.Short));
 
             string networkToLoad = NetworkName;
 
@@ -122,42 +100,30 @@ namespace Lizard.Logic.NN
                 }
             }
 
-            for (int i = 0; i < FeatureWeightElements / VSize.Short; i++)
+            for (int i = 0; i < FeatureWeightElements; i++)
             {
-                FeatureWeights[i] = Vector256.Create(br.ReadInt64(), br.ReadInt64(), br.ReadInt64(), br.ReadInt64()).AsInt16();
+                FeatureWeights[i] = br.ReadInt16();
             }
 
-            for (int i = 0; i < FeatureBiasElements / VSize.Short; i++)
+            for (int i = 0; i < FeatureBiasElements; i++)
             {
-                FeatureBiases[i] = Vector256.Create(br.ReadInt64(), br.ReadInt64(), br.ReadInt64(), br.ReadInt64()).AsInt16();
+                FeatureBiases[i] = br.ReadInt16();
             }
 
-            for (int i = 0; i < LayerWeightElements / VSize.Short; i++)
+            for (int i = 0; i < LayerWeightElements; i++)
             {
-                LayerWeights[i] = Vector256.Create(br.ReadInt64(), br.ReadInt64(), br.ReadInt64(), br.ReadInt64()).AsInt16();
+                LayerWeights[i] = br.ReadInt16();
+            }
+
+            for (int i = 0; i < LayerBiasElements; i++)
+            {
+                LayerBiases[i] = br.ReadInt16();
             }
 
             //  These weights are stored in column major order, but they are easier to use in row major order.
             //  The first 8 weights in the binary file are actually the first weight for each of the 8 output buckets,
             //  so we will transpose them so that the all of the weights for each output bucket are contiguous.
             TransposeLayerWeights((short*)LayerWeights, HiddenSize * 2, OutputBuckets);
-
-            //  Round LayerBiasElements to the next highest multiple of VSize.Short
-            //  i.e. if LayerBiasElements is <= 15, totalBiases = 16.
-            int totalBiases = ((LayerBiasElements + VSize.Short - 1) / VSize.Short) * VSize.Short;
-
-            short[] _Biases = new short[totalBiases];
-            Array.Fill(_Biases, (short)0);
-
-            for (int i = 0; i < LayerBiasElements; i++)
-            {
-                _Biases[i] = br.ReadInt16();
-            }
-
-            for (int i = 0; i < totalBiases / VSize.Short; i++)
-            {
-                LayerBiases[i] = Vector256.Create(_Biases, (i * VSize.Short));
-            }
 
 #if DEBUG
             NetStats("ft weight", FeatureWeights, FeatureWeightElements);
@@ -172,32 +138,8 @@ namespace Lizard.Logic.NN
 
         public static void RefreshAccumulator(Position pos)
         {
-            ref Accumulator accumulator = ref *pos.State->Accumulator;
-            ref Bitboard bb = ref pos.bb;
-
-            Unsafe.CopyBlock(accumulator.White, FeatureBiases, sizeof(short) * HiddenSize);
-            Unsafe.CopyBlock(accumulator.Black, FeatureBiases, sizeof(short) * HiddenSize);
-
-            int wk = pos.State->KingSquares[White];
-            int bk = pos.State->KingSquares[Black];
-
-            ulong occ = bb.Occupancy;
-            while (occ != 0)
-            {
-                int pieceIdx = poplsb(&occ);
-
-                int pt = bb.GetPieceAtIndex(pieceIdx);
-                int pc = bb.GetColorAtIndex(pieceIdx);
-
-                (int wIdx, int bIdx) = FeatureIndex(pc, pt, pieceIdx, wk, bk);
-                for (int i = 0; i < SIMD_CHUNKS; i++)
-                {
-                    accumulator.White[i] = Vector256.Add(accumulator.White[i], FeatureWeights[wIdx + i]);
-                    accumulator.Black[i] = Vector256.Add(accumulator.Black[i], FeatureWeights[bIdx + i]);
-                }
-            }
-
-            accumulator.NeedsRefresh[White] = accumulator.NeedsRefresh[Black] = false;
+            RefreshAccumulatorPerspective(pos, White);
+            RefreshAccumulatorPerspective(pos, Black);
         }
 
         public static void RefreshAccumulatorPerspective(Position pos, int perspective)
@@ -205,7 +147,7 @@ namespace Lizard.Logic.NN
             ref Accumulator accumulator = ref *pos.State->Accumulator;
             ref Bitboard bb = ref pos.bb;
 
-            var ourAccumulation = accumulator[perspective];
+            var ourAccumulation = (Vector512<short>*) accumulator[perspective];
             Unsafe.CopyBlock(ourAccumulation, FeatureBiases, sizeof(short) * HiddenSize);
 
             int ourKing = pos.State->KingSquares[perspective];
@@ -219,9 +161,11 @@ namespace Lizard.Logic.NN
                 int pc = bb.GetColorAtIndex(pieceIdx);
 
                 int idx = FeatureIndexSingle(pc, pt, pieceIdx, ourKing, perspective);
-                for (int i = 0; i < SIMD_CHUNKS; i++)
+                var ourWeights = (Vector512<short>*)(FeatureWeights + idx);
+
+                for (int i = 0; i < SIMD_CHUNKS_512; i++)
                 {
-                    ourAccumulation[i] = Vector256.Add(ourAccumulation[i], FeatureWeights[idx + i]);
+                    ourAccumulation[i] = Vector512.Add(ourAccumulation[i], ourWeights[i]);
                 }
             }
 
@@ -241,58 +185,41 @@ namespace Lizard.Logic.NN
                 RefreshAccumulatorPerspective(pos, Black);
             }
 
-            Vector256<short> ClampMax = Vector256.Create((short)QA);
-            Vector256<int> normalSum = Vector256<int>.Zero;
+            Vector256<short> maxVec = Vector256.Create((short)QA);
+            Vector256<short> zeroVec = Vector256<short>.Zero;
+            Vector256<int> sum = Vector256<int>.Zero;
 
-            int outputBucket = (int)((popcount(pos.bb.Occupancy) - 2) / 4);
-            Vector256<short>* bucketWeights = LayerWeights + (outputBucket * (SIMD_CHUNKS * 2));
+            int outputBucket = SelectOutputBucket ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
+            var ourData =   (accumulator[pos.ToMove]);
+            var theirData = (accumulator[Not(pos.ToMove)]);
+            var ourWeights =   (Vector256<short>*)(LayerWeights + (outputBucket * (HiddenSize * 2)));
+            var theirWeights = (Vector256<short>*)(LayerWeights + (outputBucket * (HiddenSize * 2)) + HiddenSize);
 
-            for (int i = 0; i < SIMD_CHUNKS; i++)
+            for (int i = 0; i < SIMD_CHUNKS_256; i++)
             {
-                //  Clamp each feature between [0, QA]
-                Vector256<short> clamp = Vector256.Min(ClampMax, Vector256.Max(Vector256<short>.Zero, accumulator[pos.ToMove][i]));
+                Vector256<short> clamp = Vector256.Min(maxVec, Vector256.Max(zeroVec, ourData[i]));
+                Vector256<short> mult = clamp * ourWeights[i];
 
-                //  Multiply the clamped feature by its corresponding weight.
-                //  We can do this with short values since the weights are always between [-127, 127]
-                //  (and the product will always be < short.MaxValue) so this will never overflow.
-                Vector256<short> mult = clamp * bucketWeights[i];
-                
-                if (NNUE.UseAvx)
-                {
-                    normalSum = Vector256.Add(normalSum, Avx2.MultiplyAddAdjacent(mult, clamp));
-                }
-                else
-                {
-                    (var loMult, var hiMult) = Vector256.Widen(mult);
-                    (var loClamp, var hiClamp) = Vector256.Widen(clamp);
+                (var loMult, var hiMult) = Vector256.Widen(mult);
+                (var loClamp, var hiClamp) = Vector256.Widen(clamp);
 
-                    normalSum = Vector256.Add(normalSum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
-                }
+                sum = Vector256.Add(sum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
             }
 
-            for (int i = 0; i < SIMD_CHUNKS; i++)
+            for (int i = 0; i < SIMD_CHUNKS_256; i++)
             {
-                Vector256<short> clamp = Vector256.Min(ClampMax, Vector256.Max(Vector256<short>.Zero, accumulator[Not(pos.ToMove)][i]));
-                Vector256<short> mult = clamp * bucketWeights[i + SIMD_CHUNKS];
+                Vector256<short> clamp = Vector256.Min(maxVec, Vector256.Max(zeroVec, theirData[i]));
+                Vector256<short> mult = clamp * theirWeights[i];
 
-                if (NNUE.UseAvx)
-                {
-                    normalSum = Vector256.Add(normalSum, Avx2.MultiplyAddAdjacent(mult, clamp));
-                }
-                else
-                {
-                    (var loMult, var hiMult) = Vector256.Widen(mult);
-                    (var loClamp, var hiClamp) = Vector256.Widen(clamp);
+                (var loMult, var hiMult) = Vector256.Widen(mult);
+                (var loClamp, var hiClamp) = Vector256.Widen(clamp);
 
-                    normalSum = Vector256.Add(normalSum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
-                }
+                sum = Vector256.Add(sum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
             }
 
-            //  Now sum the summation vector, preferably without vphaddd (which Vector256.Sum appears to use)
-            //  because it can be quite a bit slower on some architectures.
-            int output = SumVector256NoHadd(normalSum);
+            int output = Vector256.Sum(sum);
 
-            return (output / QA + LayerBiases[0][outputBucket]) * OutputScale / QAB;
+            return (output / QA + LayerBiases[outputBucket]) * OutputScale / QAB;
         }
 
         private static int FeatureIndexSingle(int pc, int pt, int sq, int kingSq, int perspective)
@@ -312,7 +239,7 @@ namespace Lizard.Logic.NN
                 kingSq ^= 7;
             }
 
-            return ((768 * KingBuckets[kingSq]) + ((pc ^ perspective) * ColorStride) + (pt * PieceStride) + (sq)) * SIMD_CHUNKS;
+            return ((768 * KingBuckets[kingSq]) + ((pc ^ perspective) * ColorStride) + (pt * PieceStride) + (sq)) * HiddenSize;
         }
 
         private static (int, int) FeatureIndex(int pc, int pt, int sq, int wk, int bk)
@@ -339,7 +266,7 @@ namespace Lizard.Logic.NN
             int whiteIndex = (768 * KingBuckets[wk]) + (pc * ColorStride) + (pt * PieceStride) + (wSq);
             int blackIndex = (768 * KingBuckets[bk]) + (Not(pc) * ColorStride) + (pt * PieceStride) + (bSq);
 
-            return (whiteIndex * SIMD_CHUNKS, blackIndex * SIMD_CHUNKS);
+            return (whiteIndex * HiddenSize, blackIndex * HiddenSize);
         }
 
         public static void MakeMove(Position pos, Move m)
@@ -385,9 +312,9 @@ namespace Lizard.Logic.NN
                     int cap = FeatureIndexSingle(them, theirPiece, moveTo, theirKing, them);
 
                     SubSubAdd((short*)theirSrc, (short*)theirDst,
-                        (short*)(FeatureWeights + from),
-                        (short*)(FeatureWeights + cap),
-                        (short*)(FeatureWeights + to));
+                              (FeatureWeights + from),
+                              (FeatureWeights + cap),
+                              (FeatureWeights + to));
                 }
                 else if (m.Castle)
                 {
@@ -400,16 +327,16 @@ namespace Lizard.Logic.NN
                     int rookTo = FeatureIndexSingle(us, Rook, rookToSq, theirKing, them);
 
                     SubSubAddAdd((short*)theirSrc, (short*)theirDst,
-                        (short*)(FeatureWeights + from),
-                        (short*)(FeatureWeights + rookFrom),
-                        (short*)(FeatureWeights + to),
-                        (short*)(FeatureWeights + rookTo));
+                                 (FeatureWeights + from),
+                                 (FeatureWeights + rookFrom),
+                                 (FeatureWeights + to),
+                                 (FeatureWeights + rookTo));
                 }
                 else
                 {
                     SubAdd((short*)theirSrc, (short*)theirDst,
-                        (short*)(FeatureWeights + from),
-                        (short*)(FeatureWeights + to));
+                           (FeatureWeights + from),
+                           (FeatureWeights + to));
                 }
             }
             else
@@ -425,14 +352,14 @@ namespace Lizard.Logic.NN
                     (int wCap, int bCap) = FeatureIndex(them, theirPiece, moveTo, wKing, bKing);
 
                     SubSubAdd((short*)srcWhite, (short*)dstWhite,
-                        (short*)(FeatureWeights + wFrom),
-                        (short*)(FeatureWeights + wCap),
-                        (short*)(FeatureWeights + wTo));
+                              (FeatureWeights + wFrom),
+                              (FeatureWeights + wCap),
+                              (FeatureWeights + wTo));
 
                     SubSubAdd((short*)srcBlack, (short*)dstBlack,
-                        (short*)(FeatureWeights + bFrom),
-                        (short*)(FeatureWeights + bCap),
-                        (short*)(FeatureWeights + bTo));
+                              (FeatureWeights + bFrom),
+                              (FeatureWeights + bCap),
+                              (FeatureWeights + bTo));
                 }
                 else if (m.EnPassant)
                 {
@@ -441,90 +368,26 @@ namespace Lizard.Logic.NN
                     (int wCap, int bCap) = FeatureIndex(them, Pawn, idxPawn, wKing, bKing);
 
                     SubSubAdd((short*)srcWhite, (short*)dstWhite,
-                        (short*)(FeatureWeights + wFrom),
-                        (short*)(FeatureWeights + wCap),
-                        (short*)(FeatureWeights + wTo));
+                              (FeatureWeights + wFrom),
+                              (FeatureWeights + wCap),
+                              (FeatureWeights + wTo));
 
                     SubSubAdd((short*)srcBlack, (short*)dstBlack,
-                        (short*)(FeatureWeights + bFrom),
-                        (short*)(FeatureWeights + bCap),
-                        (short*)(FeatureWeights + bTo));
+                              (FeatureWeights + bFrom),
+                              (FeatureWeights + bCap),
+                              (FeatureWeights + bTo));
                 }
                 else
                 {
                     SubAdd((short*)srcWhite, (short*)dstWhite,
-                        (short*)(FeatureWeights + wFrom),
-                        (short*)(FeatureWeights + wTo));
+                           (FeatureWeights + wFrom),
+                           (FeatureWeights + wTo));
 
                     SubAdd((short*)srcBlack, (short*)dstBlack,
-                        (short*)(FeatureWeights + bFrom),
-                        (short*)(FeatureWeights + bTo));
+                           (FeatureWeights + bFrom),
+                           (FeatureWeights + bTo));
                 }
             }
         }
-
-
-
-
-        private static int SumVector256NoHadd(Vector256<int> vect)
-        {
-            Vector128<int> lo = vect.GetLower();
-            Vector128<int> hi = Avx.ExtractVector128(vect, 1);
-            Vector128<int> sum128 = Sse2.Add(lo, hi);
-
-            sum128 = Sse2.Add(sum128, Sse2.Shuffle(sum128, 0b_10_11_00_01));
-            sum128 = Sse2.Add(sum128, Sse2.Shuffle(sum128, 0b_01_00_11_10));
-
-            //  Something along the lines of Add(sum128, UnpackHigh(sum128, sum128))
-            //  would also work here but it is occasionally off by +- 1.
-            //  The JIT also seems to replace the unpack with a shuffle anyways depending on the instruction order,
-            //  and who am I to not trust the JIT? :)
-
-            return Sse2.ConvertToInt32(sum128);
-        }
-
-
-        /// <summary>
-        /// Transposes the weights stored in <paramref name="block"/>
-        /// </summary>
-        private static void TransposeLayerWeights(short* block, int columnLength, int rowLength)
-        {
-            short* temp = stackalloc short[columnLength * rowLength];
-            Unsafe.CopyBlock(temp, block, (uint)(sizeof(short) * columnLength * rowLength));
-
-            for (int bucket = 0; bucket < rowLength; bucket++)
-            {
-                short* thisBucket = block + (bucket * columnLength);
-
-                for (int i = 0; i < columnLength; i++)
-                {
-                    thisBucket[i] = temp[(rowLength * i) + bucket];
-                }
-            }
-        }
-
-
-        private static void NetStats(string layerName, void* layer, int n)
-        {
-            long avg = 0;
-            int max = int.MinValue;
-            int min = int.MaxValue;
-            short* ptr = (short*)layer;
-            for (int i = 0; i < n; i++)
-            {
-                if (ptr[i] > max)
-                {
-                    max = ptr[i];
-                }
-                if (ptr[i] < min)
-                {
-                    min = ptr[i];
-                }
-                avg += ptr[i];
-            }
-
-            Log(layerName + "\tmin: " + min + ", max: " + max + ", avg: " + (double)avg / n);
-        }
-
     }
 }

--- a/Logic/NN/Bucketed768Unroll.cs
+++ b/Logic/NN/Bucketed768Unroll.cs
@@ -1,15 +1,44 @@
-﻿using System.Runtime.Intrinsics;
+﻿
+#if AVX512
+using SIMDClass = System.Runtime.Intrinsics.X86.Avx512BW;
+using VectorT = System.Runtime.Intrinsics.Vector512;
+using VShort = System.Runtime.Intrinsics.Vector512<short>;
+using VInt = System.Runtime.Intrinsics.Vector512<int>;
+#else
+using SIMDClass = System.Runtime.Intrinsics.X86.Avx2;
+using VectorT = System.Runtime.Intrinsics.Vector256;
+using VInt = System.Runtime.Intrinsics.Vector256<int>;
+using VShort = System.Runtime.Intrinsics.Vector256<short>;
+#endif
+
+using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
-using System.Runtime.InteropServices;
-using Lizard.Properties;
 
 namespace Lizard.Logic.NN
 {
     public static unsafe partial class Bucketed768
     {
-        public static int GetEvaluationUnrolled(Position pos)
+
+#if AVX512
+        private const int N = 32;
+#else
+        private const int N = 16;
+#endif
+
+        private const int StopBefore = HiddenSize / N;
+
+        private const int AVX512_1024HL = 1024 / 32;
+        private const int AVX512_1536HL = 1536 / 32;
+
+        private const int AVX256_1024HL = 1024 / 16;
+        private const int AVX256_1536HL = 1536 / 16;
+
+        public static int GetEvaluationUnrolled512(Position pos)
         {
             ref Accumulator accumulator = ref *pos.State->Accumulator;
+            var maxVec = VectorT.Create((short)QA);
+            var zeroVec = VShort.Zero;
+            var sumVec = VInt.Zero;
 
             if (accumulator.NeedsRefresh[White])
             {
@@ -21,443 +50,458 @@ namespace Lizard.Logic.NN
                 RefreshAccumulatorPerspective(pos, Black);
             }
 
-            Vector256<short> ClampMax = Vector256.Create((short)QA);
-            Vector256<int> normalSum = Vector256<int>.Zero;
+            int outputBucket = (SelectOutputBucket) ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
 
-            int outputBucket = SelectOutputBucket ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
-
-            var ourData = (short*)(accumulator[pos.ToMove]);
-            var ourWeights = (short*)(LayerWeights + (outputBucket * (SIMD_CHUNKS * 2)));
+            var ourData =   (short*)(accumulator[pos.ToMove]);
             var theirData = (short*)(accumulator[Not(pos.ToMove)]);
-            var theirWeights = (short*)(LayerWeights + (outputBucket * (SIMD_CHUNKS * 2)) + SIMD_CHUNKS);
+            var ourWeights =   (LayerWeights + (outputBucket * (HiddenSize * 2)));
+            var theirWeights = (LayerWeights + (outputBucket * (HiddenSize * 2)) + HiddenSize);
 
-            #region STM
+            #region R_STM
 
-            Vector256<short> clamp_us_0 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 0)));
-            Vector256<short> clamp_us_16 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 16)));
-            Vector256<short> clamp_us_32 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 32)));
-            Vector256<short> clamp_us_48 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 48)));
-            Vector256<short> clamp_us_64 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 64)));
-            Vector256<short> clamp_us_80 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 80)));
-            Vector256<short> clamp_us_96 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 96)));
-            Vector256<short> clamp_us_112 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 112)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_0, Avx2.MultiplyLow(clamp_us_0, Avx2.LoadAlignedVector256(ourWeights + 0))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_16, Avx2.MultiplyLow(clamp_us_16, Avx2.LoadAlignedVector256(ourWeights + 16))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_32, Avx2.MultiplyLow(clamp_us_32, Avx2.LoadAlignedVector256(ourWeights + 32))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_48, Avx2.MultiplyLow(clamp_us_48, Avx2.LoadAlignedVector256(ourWeights + 48))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_64, Avx2.MultiplyLow(clamp_us_64, Avx2.LoadAlignedVector256(ourWeights + 64))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_80, Avx2.MultiplyLow(clamp_us_80, Avx2.LoadAlignedVector256(ourWeights + 80))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_96, Avx2.MultiplyLow(clamp_us_96, Avx2.LoadAlignedVector256(ourWeights + 96))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_112, Avx2.MultiplyLow(clamp_us_112, Avx2.LoadAlignedVector256(ourWeights + 112))));
+            var c_us_0 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 0 * N)));
+            var c_us_1 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 1 * N)));
+            var c_us_2 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 2 * N)));
+            var c_us_3 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 3 * N)));
+            var c_us_4 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 4 * N)));
+            var c_us_5 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 5 * N)));
+            var c_us_6 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 6 * N)));
+            var c_us_7 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 7 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_0, SIMDClass.MultiplyLow(c_us_0, VectorT.LoadAligned(ourWeights + 0 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_1, SIMDClass.MultiplyLow(c_us_1, VectorT.LoadAligned(ourWeights + 1 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_2, SIMDClass.MultiplyLow(c_us_2, VectorT.LoadAligned(ourWeights + 2 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_3, SIMDClass.MultiplyLow(c_us_3, VectorT.LoadAligned(ourWeights + 3 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_4, SIMDClass.MultiplyLow(c_us_4, VectorT.LoadAligned(ourWeights + 4 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_5, SIMDClass.MultiplyLow(c_us_5, VectorT.LoadAligned(ourWeights + 5 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_6, SIMDClass.MultiplyLow(c_us_6, VectorT.LoadAligned(ourWeights + 6 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_7, SIMDClass.MultiplyLow(c_us_7, VectorT.LoadAligned(ourWeights + 7 * N))));
 
-            Vector256<short> clamp_us_128 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 128)));
-            Vector256<short> clamp_us_144 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 144)));
-            Vector256<short> clamp_us_160 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 160)));
-            Vector256<short> clamp_us_176 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 176)));
-            Vector256<short> clamp_us_192 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 192)));
-            Vector256<short> clamp_us_208 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 208)));
-            Vector256<short> clamp_us_224 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 224)));
-            Vector256<short> clamp_us_240 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 240)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_128, Avx2.MultiplyLow(clamp_us_128, Avx2.LoadAlignedVector256(ourWeights + 128))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_144, Avx2.MultiplyLow(clamp_us_144, Avx2.LoadAlignedVector256(ourWeights + 144))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_160, Avx2.MultiplyLow(clamp_us_160, Avx2.LoadAlignedVector256(ourWeights + 160))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_176, Avx2.MultiplyLow(clamp_us_176, Avx2.LoadAlignedVector256(ourWeights + 176))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_192, Avx2.MultiplyLow(clamp_us_192, Avx2.LoadAlignedVector256(ourWeights + 192))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_208, Avx2.MultiplyLow(clamp_us_208, Avx2.LoadAlignedVector256(ourWeights + 208))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_224, Avx2.MultiplyLow(clamp_us_224, Avx2.LoadAlignedVector256(ourWeights + 224))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_240, Avx2.MultiplyLow(clamp_us_240, Avx2.LoadAlignedVector256(ourWeights + 240))));
+            var c_us_8 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 8 * N)));
+            var c_us_9 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 9 * N)));
+            var c_us_10 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 10 * N)));
+            var c_us_11 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 11 * N)));
+            var c_us_12 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 12 * N)));
+            var c_us_13 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 13 * N)));
+            var c_us_14 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 14 * N)));
+            var c_us_15 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 15 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_8, SIMDClass.MultiplyLow(c_us_8, VectorT.LoadAligned(ourWeights + 8 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_9, SIMDClass.MultiplyLow(c_us_9, VectorT.LoadAligned(ourWeights + 9 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_10, SIMDClass.MultiplyLow(c_us_10, VectorT.LoadAligned(ourWeights + 10 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_11, SIMDClass.MultiplyLow(c_us_11, VectorT.LoadAligned(ourWeights + 11 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_12, SIMDClass.MultiplyLow(c_us_12, VectorT.LoadAligned(ourWeights + 12 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_13, SIMDClass.MultiplyLow(c_us_13, VectorT.LoadAligned(ourWeights + 13 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_14, SIMDClass.MultiplyLow(c_us_14, VectorT.LoadAligned(ourWeights + 14 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_15, SIMDClass.MultiplyLow(c_us_15, VectorT.LoadAligned(ourWeights + 15 * N))));
 
-            Vector256<short> clamp_us_256 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 256)));
-            Vector256<short> clamp_us_272 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 272)));
-            Vector256<short> clamp_us_288 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 288)));
-            Vector256<short> clamp_us_304 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 304)));
-            Vector256<short> clamp_us_320 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 320)));
-            Vector256<short> clamp_us_336 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 336)));
-            Vector256<short> clamp_us_352 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 352)));
-            Vector256<short> clamp_us_368 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 368)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_256, Avx2.MultiplyLow(clamp_us_256, Avx2.LoadAlignedVector256(ourWeights + 256))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_272, Avx2.MultiplyLow(clamp_us_272, Avx2.LoadAlignedVector256(ourWeights + 272))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_288, Avx2.MultiplyLow(clamp_us_288, Avx2.LoadAlignedVector256(ourWeights + 288))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_304, Avx2.MultiplyLow(clamp_us_304, Avx2.LoadAlignedVector256(ourWeights + 304))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_320, Avx2.MultiplyLow(clamp_us_320, Avx2.LoadAlignedVector256(ourWeights + 320))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_336, Avx2.MultiplyLow(clamp_us_336, Avx2.LoadAlignedVector256(ourWeights + 336))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_352, Avx2.MultiplyLow(clamp_us_352, Avx2.LoadAlignedVector256(ourWeights + 352))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_368, Avx2.MultiplyLow(clamp_us_368, Avx2.LoadAlignedVector256(ourWeights + 368))));
+            var c_us_16 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 16 * N)));
+            var c_us_17 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 17 * N)));
+            var c_us_18 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 18 * N)));
+            var c_us_19 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 19 * N)));
+            var c_us_20 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 20 * N)));
+            var c_us_21 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 21 * N)));
+            var c_us_22 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 22 * N)));
+            var c_us_23 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 23 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_16, SIMDClass.MultiplyLow(c_us_16, VectorT.LoadAligned(ourWeights + 16 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_17, SIMDClass.MultiplyLow(c_us_17, VectorT.LoadAligned(ourWeights + 17 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_18, SIMDClass.MultiplyLow(c_us_18, VectorT.LoadAligned(ourWeights + 18 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_19, SIMDClass.MultiplyLow(c_us_19, VectorT.LoadAligned(ourWeights + 19 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_20, SIMDClass.MultiplyLow(c_us_20, VectorT.LoadAligned(ourWeights + 20 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_21, SIMDClass.MultiplyLow(c_us_21, VectorT.LoadAligned(ourWeights + 21 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_22, SIMDClass.MultiplyLow(c_us_22, VectorT.LoadAligned(ourWeights + 22 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_23, SIMDClass.MultiplyLow(c_us_23, VectorT.LoadAligned(ourWeights + 23 * N))));
 
-            Vector256<short> clamp_us_384 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 384)));
-            Vector256<short> clamp_us_400 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 400)));
-            Vector256<short> clamp_us_416 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 416)));
-            Vector256<short> clamp_us_432 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 432)));
-            Vector256<short> clamp_us_448 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 448)));
-            Vector256<short> clamp_us_464 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 464)));
-            Vector256<short> clamp_us_480 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 480)));
-            Vector256<short> clamp_us_496 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 496)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_384, Avx2.MultiplyLow(clamp_us_384, Avx2.LoadAlignedVector256(ourWeights + 384))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_400, Avx2.MultiplyLow(clamp_us_400, Avx2.LoadAlignedVector256(ourWeights + 400))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_416, Avx2.MultiplyLow(clamp_us_416, Avx2.LoadAlignedVector256(ourWeights + 416))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_432, Avx2.MultiplyLow(clamp_us_432, Avx2.LoadAlignedVector256(ourWeights + 432))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_448, Avx2.MultiplyLow(clamp_us_448, Avx2.LoadAlignedVector256(ourWeights + 448))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_464, Avx2.MultiplyLow(clamp_us_464, Avx2.LoadAlignedVector256(ourWeights + 464))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_480, Avx2.MultiplyLow(clamp_us_480, Avx2.LoadAlignedVector256(ourWeights + 480))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_496, Avx2.MultiplyLow(clamp_us_496, Avx2.LoadAlignedVector256(ourWeights + 496))));
+            var c_us_24 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 24 * N)));
+            var c_us_25 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 25 * N)));
+            var c_us_26 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 26 * N)));
+            var c_us_27 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 27 * N)));
+            var c_us_28 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 28 * N)));
+            var c_us_29 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 29 * N)));
+            var c_us_30 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 30 * N)));
+            var c_us_31 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 31 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_24, SIMDClass.MultiplyLow(c_us_24, VectorT.LoadAligned(ourWeights + 24 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_25, SIMDClass.MultiplyLow(c_us_25, VectorT.LoadAligned(ourWeights + 25 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_26, SIMDClass.MultiplyLow(c_us_26, VectorT.LoadAligned(ourWeights + 26 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_27, SIMDClass.MultiplyLow(c_us_27, VectorT.LoadAligned(ourWeights + 27 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_28, SIMDClass.MultiplyLow(c_us_28, VectorT.LoadAligned(ourWeights + 28 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_29, SIMDClass.MultiplyLow(c_us_29, VectorT.LoadAligned(ourWeights + 29 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_30, SIMDClass.MultiplyLow(c_us_30, VectorT.LoadAligned(ourWeights + 30 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_31, SIMDClass.MultiplyLow(c_us_31, VectorT.LoadAligned(ourWeights + 31 * N))));
 
-            Vector256<short> clamp_us_512 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 512)));
-            Vector256<short> clamp_us_528 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 528)));
-            Vector256<short> clamp_us_544 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 544)));
-            Vector256<short> clamp_us_560 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 560)));
-            Vector256<short> clamp_us_576 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 576)));
-            Vector256<short> clamp_us_592 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 592)));
-            Vector256<short> clamp_us_608 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 608)));
-            Vector256<short> clamp_us_624 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 624)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_512, Avx2.MultiplyLow(clamp_us_512, Avx2.LoadAlignedVector256(ourWeights + 512))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_528, Avx2.MultiplyLow(clamp_us_528, Avx2.LoadAlignedVector256(ourWeights + 528))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_544, Avx2.MultiplyLow(clamp_us_544, Avx2.LoadAlignedVector256(ourWeights + 544))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_560, Avx2.MultiplyLow(clamp_us_560, Avx2.LoadAlignedVector256(ourWeights + 560))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_576, Avx2.MultiplyLow(clamp_us_576, Avx2.LoadAlignedVector256(ourWeights + 576))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_592, Avx2.MultiplyLow(clamp_us_592, Avx2.LoadAlignedVector256(ourWeights + 592))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_608, Avx2.MultiplyLow(clamp_us_608, Avx2.LoadAlignedVector256(ourWeights + 608))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_624, Avx2.MultiplyLow(clamp_us_624, Avx2.LoadAlignedVector256(ourWeights + 624))));
+            if (StopBefore == AVX512_1024HL)
+                goto NSTM;
 
-            Vector256<short> clamp_us_640 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 640)));
-            Vector256<short> clamp_us_656 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 656)));
-            Vector256<short> clamp_us_672 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 672)));
-            Vector256<short> clamp_us_688 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 688)));
-            Vector256<short> clamp_us_704 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 704)));
-            Vector256<short> clamp_us_720 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 720)));
-            Vector256<short> clamp_us_736 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 736)));
-            Vector256<short> clamp_us_752 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 752)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_640, Avx2.MultiplyLow(clamp_us_640, Avx2.LoadAlignedVector256(ourWeights + 640))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_656, Avx2.MultiplyLow(clamp_us_656, Avx2.LoadAlignedVector256(ourWeights + 656))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_672, Avx2.MultiplyLow(clamp_us_672, Avx2.LoadAlignedVector256(ourWeights + 672))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_688, Avx2.MultiplyLow(clamp_us_688, Avx2.LoadAlignedVector256(ourWeights + 688))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_704, Avx2.MultiplyLow(clamp_us_704, Avx2.LoadAlignedVector256(ourWeights + 704))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_720, Avx2.MultiplyLow(clamp_us_720, Avx2.LoadAlignedVector256(ourWeights + 720))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_736, Avx2.MultiplyLow(clamp_us_736, Avx2.LoadAlignedVector256(ourWeights + 736))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_752, Avx2.MultiplyLow(clamp_us_752, Avx2.LoadAlignedVector256(ourWeights + 752))));
+            var c_us_32 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 32 * N)));
+            var c_us_33 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 33 * N)));
+            var c_us_34 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 34 * N)));
+            var c_us_35 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 35 * N)));
+            var c_us_36 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 36 * N)));
+            var c_us_37 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 37 * N)));
+            var c_us_38 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 38 * N)));
+            var c_us_39 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 39 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_32, SIMDClass.MultiplyLow(c_us_32, VectorT.LoadAligned(ourWeights + 32 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_33, SIMDClass.MultiplyLow(c_us_33, VectorT.LoadAligned(ourWeights + 33 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_34, SIMDClass.MultiplyLow(c_us_34, VectorT.LoadAligned(ourWeights + 34 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_35, SIMDClass.MultiplyLow(c_us_35, VectorT.LoadAligned(ourWeights + 35 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_36, SIMDClass.MultiplyLow(c_us_36, VectorT.LoadAligned(ourWeights + 36 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_37, SIMDClass.MultiplyLow(c_us_37, VectorT.LoadAligned(ourWeights + 37 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_38, SIMDClass.MultiplyLow(c_us_38, VectorT.LoadAligned(ourWeights + 38 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_39, SIMDClass.MultiplyLow(c_us_39, VectorT.LoadAligned(ourWeights + 39 * N))));
 
-            Vector256<short> clamp_us_768 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 768)));
-            Vector256<short> clamp_us_784 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 784)));
-            Vector256<short> clamp_us_800 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 800)));
-            Vector256<short> clamp_us_816 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 816)));
-            Vector256<short> clamp_us_832 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 832)));
-            Vector256<short> clamp_us_848 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 848)));
-            Vector256<short> clamp_us_864 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 864)));
-            Vector256<short> clamp_us_880 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 880)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_768, Avx2.MultiplyLow(clamp_us_768, Avx2.LoadAlignedVector256(ourWeights + 768))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_784, Avx2.MultiplyLow(clamp_us_784, Avx2.LoadAlignedVector256(ourWeights + 784))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_800, Avx2.MultiplyLow(clamp_us_800, Avx2.LoadAlignedVector256(ourWeights + 800))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_816, Avx2.MultiplyLow(clamp_us_816, Avx2.LoadAlignedVector256(ourWeights + 816))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_832, Avx2.MultiplyLow(clamp_us_832, Avx2.LoadAlignedVector256(ourWeights + 832))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_848, Avx2.MultiplyLow(clamp_us_848, Avx2.LoadAlignedVector256(ourWeights + 848))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_864, Avx2.MultiplyLow(clamp_us_864, Avx2.LoadAlignedVector256(ourWeights + 864))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_880, Avx2.MultiplyLow(clamp_us_880, Avx2.LoadAlignedVector256(ourWeights + 880))));
+            var c_us_40 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 40 * N)));
+            var c_us_41 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 41 * N)));
+            var c_us_42 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 42 * N)));
+            var c_us_43 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 43 * N)));
+            var c_us_44 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 44 * N)));
+            var c_us_45 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 45 * N)));
+            var c_us_46 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 46 * N)));
+            var c_us_47 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 47 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_40, SIMDClass.MultiplyLow(c_us_40, VectorT.LoadAligned(ourWeights + 40 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_41, SIMDClass.MultiplyLow(c_us_41, VectorT.LoadAligned(ourWeights + 41 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_42, SIMDClass.MultiplyLow(c_us_42, VectorT.LoadAligned(ourWeights + 42 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_43, SIMDClass.MultiplyLow(c_us_43, VectorT.LoadAligned(ourWeights + 43 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_44, SIMDClass.MultiplyLow(c_us_44, VectorT.LoadAligned(ourWeights + 44 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_45, SIMDClass.MultiplyLow(c_us_45, VectorT.LoadAligned(ourWeights + 45 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_46, SIMDClass.MultiplyLow(c_us_46, VectorT.LoadAligned(ourWeights + 46 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_47, SIMDClass.MultiplyLow(c_us_47, VectorT.LoadAligned(ourWeights + 47 * N))));
 
-            Vector256<short> clamp_us_896 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 896)));
-            Vector256<short> clamp_us_912 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 912)));
-            Vector256<short> clamp_us_928 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 928)));
-            Vector256<short> clamp_us_944 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 944)));
-            Vector256<short> clamp_us_960 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 960)));
-            Vector256<short> clamp_us_976 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 976)));
-            Vector256<short> clamp_us_992 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 992)));
-            Vector256<short> clamp_us_1008 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1008)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_896, Avx2.MultiplyLow(clamp_us_896, Avx2.LoadAlignedVector256(ourWeights + 896))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_912, Avx2.MultiplyLow(clamp_us_912, Avx2.LoadAlignedVector256(ourWeights + 912))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_928, Avx2.MultiplyLow(clamp_us_928, Avx2.LoadAlignedVector256(ourWeights + 928))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_944, Avx2.MultiplyLow(clamp_us_944, Avx2.LoadAlignedVector256(ourWeights + 944))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_960, Avx2.MultiplyLow(clamp_us_960, Avx2.LoadAlignedVector256(ourWeights + 960))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_976, Avx2.MultiplyLow(clamp_us_976, Avx2.LoadAlignedVector256(ourWeights + 976))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_992, Avx2.MultiplyLow(clamp_us_992, Avx2.LoadAlignedVector256(ourWeights + 992))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1008, Avx2.MultiplyLow(clamp_us_1008, Avx2.LoadAlignedVector256(ourWeights + 1008))));
+            if (StopBefore == AVX512_1536HL)
+                goto NSTM;
 
-            if (Bucketed768.HiddenSize > 1024)
-            {
-                Vector256<short> clamp_us_1024 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1024)));
-                Vector256<short> clamp_us_1040 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1040)));
-                Vector256<short> clamp_us_1056 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1056)));
-                Vector256<short> clamp_us_1072 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1072)));
-                Vector256<short> clamp_us_1088 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1088)));
-                Vector256<short> clamp_us_1104 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1104)));
-                Vector256<short> clamp_us_1120 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1120)));
-                Vector256<short> clamp_us_1136 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1136)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1024, Avx2.MultiplyLow(clamp_us_1024, Avx2.LoadAlignedVector256(ourWeights + 1024))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1040, Avx2.MultiplyLow(clamp_us_1040, Avx2.LoadAlignedVector256(ourWeights + 1040))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1056, Avx2.MultiplyLow(clamp_us_1056, Avx2.LoadAlignedVector256(ourWeights + 1056))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1072, Avx2.MultiplyLow(clamp_us_1072, Avx2.LoadAlignedVector256(ourWeights + 1072))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1088, Avx2.MultiplyLow(clamp_us_1088, Avx2.LoadAlignedVector256(ourWeights + 1088))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1104, Avx2.MultiplyLow(clamp_us_1104, Avx2.LoadAlignedVector256(ourWeights + 1104))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1120, Avx2.MultiplyLow(clamp_us_1120, Avx2.LoadAlignedVector256(ourWeights + 1120))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1136, Avx2.MultiplyLow(clamp_us_1136, Avx2.LoadAlignedVector256(ourWeights + 1136))));
+            var c_us_48 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 48 * N)));
+            var c_us_49 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 49 * N)));
+            var c_us_50 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 50 * N)));
+            var c_us_51 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 51 * N)));
+            var c_us_52 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 52 * N)));
+            var c_us_53 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 53 * N)));
+            var c_us_54 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 54 * N)));
+            var c_us_55 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 55 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_48, SIMDClass.MultiplyLow(c_us_48, VectorT.LoadAligned(ourWeights + 48 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_49, SIMDClass.MultiplyLow(c_us_49, VectorT.LoadAligned(ourWeights + 49 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_50, SIMDClass.MultiplyLow(c_us_50, VectorT.LoadAligned(ourWeights + 50 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_51, SIMDClass.MultiplyLow(c_us_51, VectorT.LoadAligned(ourWeights + 51 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_52, SIMDClass.MultiplyLow(c_us_52, VectorT.LoadAligned(ourWeights + 52 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_53, SIMDClass.MultiplyLow(c_us_53, VectorT.LoadAligned(ourWeights + 53 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_54, SIMDClass.MultiplyLow(c_us_54, VectorT.LoadAligned(ourWeights + 54 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_55, SIMDClass.MultiplyLow(c_us_55, VectorT.LoadAligned(ourWeights + 55 * N))));
 
-                Vector256<short> clamp_us_1152 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1152)));
-                Vector256<short> clamp_us_1168 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1168)));
-                Vector256<short> clamp_us_1184 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1184)));
-                Vector256<short> clamp_us_1200 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1200)));
-                Vector256<short> clamp_us_1216 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1216)));
-                Vector256<short> clamp_us_1232 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1232)));
-                Vector256<short> clamp_us_1248 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1248)));
-                Vector256<short> clamp_us_1264 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1264)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1152, Avx2.MultiplyLow(clamp_us_1152, Avx2.LoadAlignedVector256(ourWeights + 1152))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1168, Avx2.MultiplyLow(clamp_us_1168, Avx2.LoadAlignedVector256(ourWeights + 1168))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1184, Avx2.MultiplyLow(clamp_us_1184, Avx2.LoadAlignedVector256(ourWeights + 1184))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1200, Avx2.MultiplyLow(clamp_us_1200, Avx2.LoadAlignedVector256(ourWeights + 1200))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1216, Avx2.MultiplyLow(clamp_us_1216, Avx2.LoadAlignedVector256(ourWeights + 1216))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1232, Avx2.MultiplyLow(clamp_us_1232, Avx2.LoadAlignedVector256(ourWeights + 1232))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1248, Avx2.MultiplyLow(clamp_us_1248, Avx2.LoadAlignedVector256(ourWeights + 1248))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1264, Avx2.MultiplyLow(clamp_us_1264, Avx2.LoadAlignedVector256(ourWeights + 1264))));
+            var c_us_56 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 56 * N)));
+            var c_us_57 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 57 * N)));
+            var c_us_58 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 58 * N)));
+            var c_us_59 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 59 * N)));
+            var c_us_60 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 60 * N)));
+            var c_us_61 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 61 * N)));
+            var c_us_62 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 62 * N)));
+            var c_us_63 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 63 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_56, SIMDClass.MultiplyLow(c_us_56, VectorT.LoadAligned(ourWeights + 56 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_57, SIMDClass.MultiplyLow(c_us_57, VectorT.LoadAligned(ourWeights + 57 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_58, SIMDClass.MultiplyLow(c_us_58, VectorT.LoadAligned(ourWeights + 58 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_59, SIMDClass.MultiplyLow(c_us_59, VectorT.LoadAligned(ourWeights + 59 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_60, SIMDClass.MultiplyLow(c_us_60, VectorT.LoadAligned(ourWeights + 60 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_61, SIMDClass.MultiplyLow(c_us_61, VectorT.LoadAligned(ourWeights + 61 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_62, SIMDClass.MultiplyLow(c_us_62, VectorT.LoadAligned(ourWeights + 62 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_63, SIMDClass.MultiplyLow(c_us_63, VectorT.LoadAligned(ourWeights + 63 * N))));
 
-                Vector256<short> clamp_us_1280 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1280)));
-                Vector256<short> clamp_us_1296 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1296)));
-                Vector256<short> clamp_us_1312 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1312)));
-                Vector256<short> clamp_us_1328 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1328)));
-                Vector256<short> clamp_us_1344 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1344)));
-                Vector256<short> clamp_us_1360 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1360)));
-                Vector256<short> clamp_us_1376 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1376)));
-                Vector256<short> clamp_us_1392 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1392)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1280, Avx2.MultiplyLow(clamp_us_1280, Avx2.LoadAlignedVector256(ourWeights + 1280))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1296, Avx2.MultiplyLow(clamp_us_1296, Avx2.LoadAlignedVector256(ourWeights + 1296))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1312, Avx2.MultiplyLow(clamp_us_1312, Avx2.LoadAlignedVector256(ourWeights + 1312))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1328, Avx2.MultiplyLow(clamp_us_1328, Avx2.LoadAlignedVector256(ourWeights + 1328))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1344, Avx2.MultiplyLow(clamp_us_1344, Avx2.LoadAlignedVector256(ourWeights + 1344))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1360, Avx2.MultiplyLow(clamp_us_1360, Avx2.LoadAlignedVector256(ourWeights + 1360))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1376, Avx2.MultiplyLow(clamp_us_1376, Avx2.LoadAlignedVector256(ourWeights + 1376))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1392, Avx2.MultiplyLow(clamp_us_1392, Avx2.LoadAlignedVector256(ourWeights + 1392))));
+            if (StopBefore == AVX256_1024HL)
+                goto NSTM;
 
-                Vector256<short> clamp_us_1408 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1408)));
-                Vector256<short> clamp_us_1424 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1424)));
-                Vector256<short> clamp_us_1440 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1440)));
-                Vector256<short> clamp_us_1456 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1456)));
-                Vector256<short> clamp_us_1472 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1472)));
-                Vector256<short> clamp_us_1488 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1488)));
-                Vector256<short> clamp_us_1504 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1504)));
-                Vector256<short> clamp_us_1520 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1520)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1408, Avx2.MultiplyLow(clamp_us_1408, Avx2.LoadAlignedVector256(ourWeights + 1408))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1424, Avx2.MultiplyLow(clamp_us_1424, Avx2.LoadAlignedVector256(ourWeights + 1424))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1440, Avx2.MultiplyLow(clamp_us_1440, Avx2.LoadAlignedVector256(ourWeights + 1440))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1456, Avx2.MultiplyLow(clamp_us_1456, Avx2.LoadAlignedVector256(ourWeights + 1456))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1472, Avx2.MultiplyLow(clamp_us_1472, Avx2.LoadAlignedVector256(ourWeights + 1472))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1488, Avx2.MultiplyLow(clamp_us_1488, Avx2.LoadAlignedVector256(ourWeights + 1488))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1504, Avx2.MultiplyLow(clamp_us_1504, Avx2.LoadAlignedVector256(ourWeights + 1504))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1520, Avx2.MultiplyLow(clamp_us_1520, Avx2.LoadAlignedVector256(ourWeights + 1520))));
-            }
+            var c_us_64 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 64 * N)));
+            var c_us_65 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 65 * N)));
+            var c_us_66 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 66 * N)));
+            var c_us_67 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 67 * N)));
+            var c_us_68 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 68 * N)));
+            var c_us_69 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 69 * N)));
+            var c_us_70 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 70 * N)));
+            var c_us_71 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 71 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_64, SIMDClass.MultiplyLow(c_us_64, VectorT.LoadAligned(ourWeights + 64 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_65, SIMDClass.MultiplyLow(c_us_65, VectorT.LoadAligned(ourWeights + 65 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_66, SIMDClass.MultiplyLow(c_us_66, VectorT.LoadAligned(ourWeights + 66 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_67, SIMDClass.MultiplyLow(c_us_67, VectorT.LoadAligned(ourWeights + 67 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_68, SIMDClass.MultiplyLow(c_us_68, VectorT.LoadAligned(ourWeights + 68 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_69, SIMDClass.MultiplyLow(c_us_69, VectorT.LoadAligned(ourWeights + 69 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_70, SIMDClass.MultiplyLow(c_us_70, VectorT.LoadAligned(ourWeights + 70 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_71, SIMDClass.MultiplyLow(c_us_71, VectorT.LoadAligned(ourWeights + 71 * N))));
 
-#endregion
+            var c_us_72 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 72 * N)));
+            var c_us_73 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 73 * N)));
+            var c_us_74 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 74 * N)));
+            var c_us_75 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 75 * N)));
+            var c_us_76 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 76 * N)));
+            var c_us_77 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 77 * N)));
+            var c_us_78 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 78 * N)));
+            var c_us_79 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 79 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_72, SIMDClass.MultiplyLow(c_us_72, VectorT.LoadAligned(ourWeights + 72 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_73, SIMDClass.MultiplyLow(c_us_73, VectorT.LoadAligned(ourWeights + 73 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_74, SIMDClass.MultiplyLow(c_us_74, VectorT.LoadAligned(ourWeights + 74 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_75, SIMDClass.MultiplyLow(c_us_75, VectorT.LoadAligned(ourWeights + 75 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_76, SIMDClass.MultiplyLow(c_us_76, VectorT.LoadAligned(ourWeights + 76 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_77, SIMDClass.MultiplyLow(c_us_77, VectorT.LoadAligned(ourWeights + 77 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_78, SIMDClass.MultiplyLow(c_us_78, VectorT.LoadAligned(ourWeights + 78 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_79, SIMDClass.MultiplyLow(c_us_79, VectorT.LoadAligned(ourWeights + 79 * N))));
+
+            var c_us_80 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 80 * N)));
+            var c_us_81 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 81 * N)));
+            var c_us_82 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 82 * N)));
+            var c_us_83 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 83 * N)));
+            var c_us_84 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 84 * N)));
+            var c_us_85 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 85 * N)));
+            var c_us_86 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 86 * N)));
+            var c_us_87 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 87 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_80, SIMDClass.MultiplyLow(c_us_80, VectorT.LoadAligned(ourWeights + 80 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_81, SIMDClass.MultiplyLow(c_us_81, VectorT.LoadAligned(ourWeights + 81 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_82, SIMDClass.MultiplyLow(c_us_82, VectorT.LoadAligned(ourWeights + 82 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_83, SIMDClass.MultiplyLow(c_us_83, VectorT.LoadAligned(ourWeights + 83 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_84, SIMDClass.MultiplyLow(c_us_84, VectorT.LoadAligned(ourWeights + 84 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_85, SIMDClass.MultiplyLow(c_us_85, VectorT.LoadAligned(ourWeights + 85 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_86, SIMDClass.MultiplyLow(c_us_86, VectorT.LoadAligned(ourWeights + 86 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_87, SIMDClass.MultiplyLow(c_us_87, VectorT.LoadAligned(ourWeights + 87 * N))));
+
+            var c_us_88 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 88 * N)));
+            var c_us_89 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 89 * N)));
+            var c_us_90 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 90 * N)));
+            var c_us_91 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 91 * N)));
+            var c_us_92 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 92 * N)));
+            var c_us_93 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 93 * N)));
+            var c_us_94 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 94 * N)));
+            var c_us_95 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 95 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_88, SIMDClass.MultiplyLow(c_us_88, VectorT.LoadAligned(ourWeights + 88 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_89, SIMDClass.MultiplyLow(c_us_89, VectorT.LoadAligned(ourWeights + 89 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_90, SIMDClass.MultiplyLow(c_us_90, VectorT.LoadAligned(ourWeights + 90 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_91, SIMDClass.MultiplyLow(c_us_91, VectorT.LoadAligned(ourWeights + 91 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_92, SIMDClass.MultiplyLow(c_us_92, VectorT.LoadAligned(ourWeights + 92 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_93, SIMDClass.MultiplyLow(c_us_93, VectorT.LoadAligned(ourWeights + 93 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_94, SIMDClass.MultiplyLow(c_us_94, VectorT.LoadAligned(ourWeights + 94 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_95, SIMDClass.MultiplyLow(c_us_95, VectorT.LoadAligned(ourWeights + 95 * N))));
+
+            #endregion
 
 
 
-            #region NSTM
+            NSTM:
 
-            Vector256<short> clamp_them_0 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 0)));
-            Vector256<short> clamp_them_16 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 16)));
-            Vector256<short> clamp_them_32 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 32)));
-            Vector256<short> clamp_them_48 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 48)));
-            Vector256<short> clamp_them_64 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 64)));
-            Vector256<short> clamp_them_80 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 80)));
-            Vector256<short> clamp_them_96 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 96)));
-            Vector256<short> clamp_them_112 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 112)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_0, Avx2.MultiplyLow(clamp_them_0, Avx2.LoadAlignedVector256(theirWeights + 0))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_16, Avx2.MultiplyLow(clamp_them_16, Avx2.LoadAlignedVector256(theirWeights + 16))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_32, Avx2.MultiplyLow(clamp_them_32, Avx2.LoadAlignedVector256(theirWeights + 32))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_48, Avx2.MultiplyLow(clamp_them_48, Avx2.LoadAlignedVector256(theirWeights + 48))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_64, Avx2.MultiplyLow(clamp_them_64, Avx2.LoadAlignedVector256(theirWeights + 64))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_80, Avx2.MultiplyLow(clamp_them_80, Avx2.LoadAlignedVector256(theirWeights + 80))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_96, Avx2.MultiplyLow(clamp_them_96, Avx2.LoadAlignedVector256(theirWeights + 96))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_112, Avx2.MultiplyLow(clamp_them_112, Avx2.LoadAlignedVector256(theirWeights + 112))));
+            #region R_NSTM
 
-            Vector256<short> clamp_them_128 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 128)));
-            Vector256<short> clamp_them_144 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 144)));
-            Vector256<short> clamp_them_160 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 160)));
-            Vector256<short> clamp_them_176 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 176)));
-            Vector256<short> clamp_them_192 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 192)));
-            Vector256<short> clamp_them_208 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 208)));
-            Vector256<short> clamp_them_224 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 224)));
-            Vector256<short> clamp_them_240 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 240)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_128, Avx2.MultiplyLow(clamp_them_128, Avx2.LoadAlignedVector256(theirWeights + 128))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_144, Avx2.MultiplyLow(clamp_them_144, Avx2.LoadAlignedVector256(theirWeights + 144))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_160, Avx2.MultiplyLow(clamp_them_160, Avx2.LoadAlignedVector256(theirWeights + 160))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_176, Avx2.MultiplyLow(clamp_them_176, Avx2.LoadAlignedVector256(theirWeights + 176))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_192, Avx2.MultiplyLow(clamp_them_192, Avx2.LoadAlignedVector256(theirWeights + 192))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_208, Avx2.MultiplyLow(clamp_them_208, Avx2.LoadAlignedVector256(theirWeights + 208))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_224, Avx2.MultiplyLow(clamp_them_224, Avx2.LoadAlignedVector256(theirWeights + 224))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_240, Avx2.MultiplyLow(clamp_them_240, Avx2.LoadAlignedVector256(theirWeights + 240))));
+            var c_them_0 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 0 * N)));
+            var c_them_1 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 1 * N)));
+            var c_them_2 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 2 * N)));
+            var c_them_3 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 3 * N)));
+            var c_them_4 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 4 * N)));
+            var c_them_5 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 5 * N)));
+            var c_them_6 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 6 * N)));
+            var c_them_7 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 7 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_0, SIMDClass.MultiplyLow(c_them_0, VectorT.LoadAligned(theirWeights + 0 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_1, SIMDClass.MultiplyLow(c_them_1, VectorT.LoadAligned(theirWeights + 1 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_2, SIMDClass.MultiplyLow(c_them_2, VectorT.LoadAligned(theirWeights + 2 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_3, SIMDClass.MultiplyLow(c_them_3, VectorT.LoadAligned(theirWeights + 3 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_4, SIMDClass.MultiplyLow(c_them_4, VectorT.LoadAligned(theirWeights + 4 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_5, SIMDClass.MultiplyLow(c_them_5, VectorT.LoadAligned(theirWeights + 5 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_6, SIMDClass.MultiplyLow(c_them_6, VectorT.LoadAligned(theirWeights + 6 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_7, SIMDClass.MultiplyLow(c_them_7, VectorT.LoadAligned(theirWeights + 7 * N))));
 
-            Vector256<short> clamp_them_256 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 256)));
-            Vector256<short> clamp_them_272 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 272)));
-            Vector256<short> clamp_them_288 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 288)));
-            Vector256<short> clamp_them_304 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 304)));
-            Vector256<short> clamp_them_320 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 320)));
-            Vector256<short> clamp_them_336 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 336)));
-            Vector256<short> clamp_them_352 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 352)));
-            Vector256<short> clamp_them_368 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 368)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_256, Avx2.MultiplyLow(clamp_them_256, Avx2.LoadAlignedVector256(theirWeights + 256))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_272, Avx2.MultiplyLow(clamp_them_272, Avx2.LoadAlignedVector256(theirWeights + 272))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_288, Avx2.MultiplyLow(clamp_them_288, Avx2.LoadAlignedVector256(theirWeights + 288))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_304, Avx2.MultiplyLow(clamp_them_304, Avx2.LoadAlignedVector256(theirWeights + 304))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_320, Avx2.MultiplyLow(clamp_them_320, Avx2.LoadAlignedVector256(theirWeights + 320))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_336, Avx2.MultiplyLow(clamp_them_336, Avx2.LoadAlignedVector256(theirWeights + 336))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_352, Avx2.MultiplyLow(clamp_them_352, Avx2.LoadAlignedVector256(theirWeights + 352))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_368, Avx2.MultiplyLow(clamp_them_368, Avx2.LoadAlignedVector256(theirWeights + 368))));
+            var c_them_8 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 8 * N)));
+            var c_them_9 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 9 * N)));
+            var c_them_10 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 10 * N)));
+            var c_them_11 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 11 * N)));
+            var c_them_12 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 12 * N)));
+            var c_them_13 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 13 * N)));
+            var c_them_14 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 14 * N)));
+            var c_them_15 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 15 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_8, SIMDClass.MultiplyLow(c_them_8, VectorT.LoadAligned(theirWeights + 8 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_9, SIMDClass.MultiplyLow(c_them_9, VectorT.LoadAligned(theirWeights + 9 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_10, SIMDClass.MultiplyLow(c_them_10, VectorT.LoadAligned(theirWeights + 10 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_11, SIMDClass.MultiplyLow(c_them_11, VectorT.LoadAligned(theirWeights + 11 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_12, SIMDClass.MultiplyLow(c_them_12, VectorT.LoadAligned(theirWeights + 12 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_13, SIMDClass.MultiplyLow(c_them_13, VectorT.LoadAligned(theirWeights + 13 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_14, SIMDClass.MultiplyLow(c_them_14, VectorT.LoadAligned(theirWeights + 14 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_15, SIMDClass.MultiplyLow(c_them_15, VectorT.LoadAligned(theirWeights + 15 * N))));
 
-            Vector256<short> clamp_them_384 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 384)));
-            Vector256<short> clamp_them_400 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 400)));
-            Vector256<short> clamp_them_416 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 416)));
-            Vector256<short> clamp_them_432 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 432)));
-            Vector256<short> clamp_them_448 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 448)));
-            Vector256<short> clamp_them_464 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 464)));
-            Vector256<short> clamp_them_480 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 480)));
-            Vector256<short> clamp_them_496 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 496)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_384, Avx2.MultiplyLow(clamp_them_384, Avx2.LoadAlignedVector256(theirWeights + 384))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_400, Avx2.MultiplyLow(clamp_them_400, Avx2.LoadAlignedVector256(theirWeights + 400))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_416, Avx2.MultiplyLow(clamp_them_416, Avx2.LoadAlignedVector256(theirWeights + 416))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_432, Avx2.MultiplyLow(clamp_them_432, Avx2.LoadAlignedVector256(theirWeights + 432))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_448, Avx2.MultiplyLow(clamp_them_448, Avx2.LoadAlignedVector256(theirWeights + 448))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_464, Avx2.MultiplyLow(clamp_them_464, Avx2.LoadAlignedVector256(theirWeights + 464))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_480, Avx2.MultiplyLow(clamp_them_480, Avx2.LoadAlignedVector256(theirWeights + 480))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_496, Avx2.MultiplyLow(clamp_them_496, Avx2.LoadAlignedVector256(theirWeights + 496))));
+            var c_them_16 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 16 * N)));
+            var c_them_17 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 17 * N)));
+            var c_them_18 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 18 * N)));
+            var c_them_19 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 19 * N)));
+            var c_them_20 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 20 * N)));
+            var c_them_21 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 21 * N)));
+            var c_them_22 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 22 * N)));
+            var c_them_23 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 23 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_16, SIMDClass.MultiplyLow(c_them_16, VectorT.LoadAligned(theirWeights + 16 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_17, SIMDClass.MultiplyLow(c_them_17, VectorT.LoadAligned(theirWeights + 17 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_18, SIMDClass.MultiplyLow(c_them_18, VectorT.LoadAligned(theirWeights + 18 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_19, SIMDClass.MultiplyLow(c_them_19, VectorT.LoadAligned(theirWeights + 19 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_20, SIMDClass.MultiplyLow(c_them_20, VectorT.LoadAligned(theirWeights + 20 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_21, SIMDClass.MultiplyLow(c_them_21, VectorT.LoadAligned(theirWeights + 21 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_22, SIMDClass.MultiplyLow(c_them_22, VectorT.LoadAligned(theirWeights + 22 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_23, SIMDClass.MultiplyLow(c_them_23, VectorT.LoadAligned(theirWeights + 23 * N))));
 
-            Vector256<short> clamp_them_512 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 512)));
-            Vector256<short> clamp_them_528 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 528)));
-            Vector256<short> clamp_them_544 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 544)));
-            Vector256<short> clamp_them_560 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 560)));
-            Vector256<short> clamp_them_576 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 576)));
-            Vector256<short> clamp_them_592 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 592)));
-            Vector256<short> clamp_them_608 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 608)));
-            Vector256<short> clamp_them_624 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 624)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_512, Avx2.MultiplyLow(clamp_them_512, Avx2.LoadAlignedVector256(theirWeights + 512))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_528, Avx2.MultiplyLow(clamp_them_528, Avx2.LoadAlignedVector256(theirWeights + 528))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_544, Avx2.MultiplyLow(clamp_them_544, Avx2.LoadAlignedVector256(theirWeights + 544))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_560, Avx2.MultiplyLow(clamp_them_560, Avx2.LoadAlignedVector256(theirWeights + 560))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_576, Avx2.MultiplyLow(clamp_them_576, Avx2.LoadAlignedVector256(theirWeights + 576))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_592, Avx2.MultiplyLow(clamp_them_592, Avx2.LoadAlignedVector256(theirWeights + 592))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_608, Avx2.MultiplyLow(clamp_them_608, Avx2.LoadAlignedVector256(theirWeights + 608))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_624, Avx2.MultiplyLow(clamp_them_624, Avx2.LoadAlignedVector256(theirWeights + 624))));
+            var c_them_24 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 24 * N)));
+            var c_them_25 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 25 * N)));
+            var c_them_26 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 26 * N)));
+            var c_them_27 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 27 * N)));
+            var c_them_28 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 28 * N)));
+            var c_them_29 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 29 * N)));
+            var c_them_30 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 30 * N)));
+            var c_them_31 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 31 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_24, SIMDClass.MultiplyLow(c_them_24, VectorT.LoadAligned(theirWeights + 24 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_25, SIMDClass.MultiplyLow(c_them_25, VectorT.LoadAligned(theirWeights + 25 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_26, SIMDClass.MultiplyLow(c_them_26, VectorT.LoadAligned(theirWeights + 26 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_27, SIMDClass.MultiplyLow(c_them_27, VectorT.LoadAligned(theirWeights + 27 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_28, SIMDClass.MultiplyLow(c_them_28, VectorT.LoadAligned(theirWeights + 28 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_29, SIMDClass.MultiplyLow(c_them_29, VectorT.LoadAligned(theirWeights + 29 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_30, SIMDClass.MultiplyLow(c_them_30, VectorT.LoadAligned(theirWeights + 30 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_31, SIMDClass.MultiplyLow(c_them_31, VectorT.LoadAligned(theirWeights + 31 * N))));
 
-            Vector256<short> clamp_them_640 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 640)));
-            Vector256<short> clamp_them_656 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 656)));
-            Vector256<short> clamp_them_672 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 672)));
-            Vector256<short> clamp_them_688 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 688)));
-            Vector256<short> clamp_them_704 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 704)));
-            Vector256<short> clamp_them_720 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 720)));
-            Vector256<short> clamp_them_736 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 736)));
-            Vector256<short> clamp_them_752 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 752)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_640, Avx2.MultiplyLow(clamp_them_640, Avx2.LoadAlignedVector256(theirWeights + 640))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_656, Avx2.MultiplyLow(clamp_them_656, Avx2.LoadAlignedVector256(theirWeights + 656))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_672, Avx2.MultiplyLow(clamp_them_672, Avx2.LoadAlignedVector256(theirWeights + 672))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_688, Avx2.MultiplyLow(clamp_them_688, Avx2.LoadAlignedVector256(theirWeights + 688))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_704, Avx2.MultiplyLow(clamp_them_704, Avx2.LoadAlignedVector256(theirWeights + 704))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_720, Avx2.MultiplyLow(clamp_them_720, Avx2.LoadAlignedVector256(theirWeights + 720))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_736, Avx2.MultiplyLow(clamp_them_736, Avx2.LoadAlignedVector256(theirWeights + 736))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_752, Avx2.MultiplyLow(clamp_them_752, Avx2.LoadAlignedVector256(theirWeights + 752))));
+            if (StopBefore == AVX512_1024HL)
+                goto END;
 
-            Vector256<short> clamp_them_768 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 768)));
-            Vector256<short> clamp_them_784 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 784)));
-            Vector256<short> clamp_them_800 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 800)));
-            Vector256<short> clamp_them_816 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 816)));
-            Vector256<short> clamp_them_832 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 832)));
-            Vector256<short> clamp_them_848 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 848)));
-            Vector256<short> clamp_them_864 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 864)));
-            Vector256<short> clamp_them_880 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 880)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_768, Avx2.MultiplyLow(clamp_them_768, Avx2.LoadAlignedVector256(theirWeights + 768))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_784, Avx2.MultiplyLow(clamp_them_784, Avx2.LoadAlignedVector256(theirWeights + 784))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_800, Avx2.MultiplyLow(clamp_them_800, Avx2.LoadAlignedVector256(theirWeights + 800))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_816, Avx2.MultiplyLow(clamp_them_816, Avx2.LoadAlignedVector256(theirWeights + 816))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_832, Avx2.MultiplyLow(clamp_them_832, Avx2.LoadAlignedVector256(theirWeights + 832))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_848, Avx2.MultiplyLow(clamp_them_848, Avx2.LoadAlignedVector256(theirWeights + 848))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_864, Avx2.MultiplyLow(clamp_them_864, Avx2.LoadAlignedVector256(theirWeights + 864))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_880, Avx2.MultiplyLow(clamp_them_880, Avx2.LoadAlignedVector256(theirWeights + 880))));
+            var c_them_32 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 32 * N)));
+            var c_them_33 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 33 * N)));
+            var c_them_34 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 34 * N)));
+            var c_them_35 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 35 * N)));
+            var c_them_36 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 36 * N)));
+            var c_them_37 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 37 * N)));
+            var c_them_38 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 38 * N)));
+            var c_them_39 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 39 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_32, SIMDClass.MultiplyLow(c_them_32, VectorT.LoadAligned(theirWeights + 32 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_33, SIMDClass.MultiplyLow(c_them_33, VectorT.LoadAligned(theirWeights + 33 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_34, SIMDClass.MultiplyLow(c_them_34, VectorT.LoadAligned(theirWeights + 34 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_35, SIMDClass.MultiplyLow(c_them_35, VectorT.LoadAligned(theirWeights + 35 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_36, SIMDClass.MultiplyLow(c_them_36, VectorT.LoadAligned(theirWeights + 36 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_37, SIMDClass.MultiplyLow(c_them_37, VectorT.LoadAligned(theirWeights + 37 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_38, SIMDClass.MultiplyLow(c_them_38, VectorT.LoadAligned(theirWeights + 38 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_39, SIMDClass.MultiplyLow(c_them_39, VectorT.LoadAligned(theirWeights + 39 * N))));
 
-            Vector256<short> clamp_them_896 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 896)));
-            Vector256<short> clamp_them_912 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 912)));
-            Vector256<short> clamp_them_928 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 928)));
-            Vector256<short> clamp_them_944 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 944)));
-            Vector256<short> clamp_them_960 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 960)));
-            Vector256<short> clamp_them_976 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 976)));
-            Vector256<short> clamp_them_992 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 992)));
-            Vector256<short> clamp_them_1008 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1008)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_896, Avx2.MultiplyLow(clamp_them_896, Avx2.LoadAlignedVector256(theirWeights + 896))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_912, Avx2.MultiplyLow(clamp_them_912, Avx2.LoadAlignedVector256(theirWeights + 912))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_928, Avx2.MultiplyLow(clamp_them_928, Avx2.LoadAlignedVector256(theirWeights + 928))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_944, Avx2.MultiplyLow(clamp_them_944, Avx2.LoadAlignedVector256(theirWeights + 944))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_960, Avx2.MultiplyLow(clamp_them_960, Avx2.LoadAlignedVector256(theirWeights + 960))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_976, Avx2.MultiplyLow(clamp_them_976, Avx2.LoadAlignedVector256(theirWeights + 976))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_992, Avx2.MultiplyLow(clamp_them_992, Avx2.LoadAlignedVector256(theirWeights + 992))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1008, Avx2.MultiplyLow(clamp_them_1008, Avx2.LoadAlignedVector256(theirWeights + 1008))));
+            var c_them_40 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 40 * N)));
+            var c_them_41 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 41 * N)));
+            var c_them_42 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 42 * N)));
+            var c_them_43 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 43 * N)));
+            var c_them_44 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 44 * N)));
+            var c_them_45 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 45 * N)));
+            var c_them_46 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 46 * N)));
+            var c_them_47 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 47 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_40, SIMDClass.MultiplyLow(c_them_40, VectorT.LoadAligned(theirWeights + 40 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_41, SIMDClass.MultiplyLow(c_them_41, VectorT.LoadAligned(theirWeights + 41 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_42, SIMDClass.MultiplyLow(c_them_42, VectorT.LoadAligned(theirWeights + 42 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_43, SIMDClass.MultiplyLow(c_them_43, VectorT.LoadAligned(theirWeights + 43 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_44, SIMDClass.MultiplyLow(c_them_44, VectorT.LoadAligned(theirWeights + 44 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_45, SIMDClass.MultiplyLow(c_them_45, VectorT.LoadAligned(theirWeights + 45 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_46, SIMDClass.MultiplyLow(c_them_46, VectorT.LoadAligned(theirWeights + 46 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_47, SIMDClass.MultiplyLow(c_them_47, VectorT.LoadAligned(theirWeights + 47 * N))));
 
-            if (Bucketed768.HiddenSize > 1024)
-            {
-                Vector256<short> clamp_them_1024 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1024)));
-                Vector256<short> clamp_them_1040 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1040)));
-                Vector256<short> clamp_them_1056 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1056)));
-                Vector256<short> clamp_them_1072 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1072)));
-                Vector256<short> clamp_them_1088 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1088)));
-                Vector256<short> clamp_them_1104 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1104)));
-                Vector256<short> clamp_them_1120 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1120)));
-                Vector256<short> clamp_them_1136 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1136)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1024, Avx2.MultiplyLow(clamp_them_1024, Avx2.LoadAlignedVector256(theirWeights + 1024))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1040, Avx2.MultiplyLow(clamp_them_1040, Avx2.LoadAlignedVector256(theirWeights + 1040))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1056, Avx2.MultiplyLow(clamp_them_1056, Avx2.LoadAlignedVector256(theirWeights + 1056))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1072, Avx2.MultiplyLow(clamp_them_1072, Avx2.LoadAlignedVector256(theirWeights + 1072))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1088, Avx2.MultiplyLow(clamp_them_1088, Avx2.LoadAlignedVector256(theirWeights + 1088))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1104, Avx2.MultiplyLow(clamp_them_1104, Avx2.LoadAlignedVector256(theirWeights + 1104))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1120, Avx2.MultiplyLow(clamp_them_1120, Avx2.LoadAlignedVector256(theirWeights + 1120))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1136, Avx2.MultiplyLow(clamp_them_1136, Avx2.LoadAlignedVector256(theirWeights + 1136))));
+            if (StopBefore == AVX512_1536HL)
+                goto END;
 
-                Vector256<short> clamp_them_1152 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1152)));
-                Vector256<short> clamp_them_1168 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1168)));
-                Vector256<short> clamp_them_1184 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1184)));
-                Vector256<short> clamp_them_1200 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1200)));
-                Vector256<short> clamp_them_1216 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1216)));
-                Vector256<short> clamp_them_1232 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1232)));
-                Vector256<short> clamp_them_1248 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1248)));
-                Vector256<short> clamp_them_1264 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1264)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1152, Avx2.MultiplyLow(clamp_them_1152, Avx2.LoadAlignedVector256(theirWeights + 1152))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1168, Avx2.MultiplyLow(clamp_them_1168, Avx2.LoadAlignedVector256(theirWeights + 1168))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1184, Avx2.MultiplyLow(clamp_them_1184, Avx2.LoadAlignedVector256(theirWeights + 1184))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1200, Avx2.MultiplyLow(clamp_them_1200, Avx2.LoadAlignedVector256(theirWeights + 1200))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1216, Avx2.MultiplyLow(clamp_them_1216, Avx2.LoadAlignedVector256(theirWeights + 1216))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1232, Avx2.MultiplyLow(clamp_them_1232, Avx2.LoadAlignedVector256(theirWeights + 1232))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1248, Avx2.MultiplyLow(clamp_them_1248, Avx2.LoadAlignedVector256(theirWeights + 1248))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1264, Avx2.MultiplyLow(clamp_them_1264, Avx2.LoadAlignedVector256(theirWeights + 1264))));
+            var c_them_48 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 48 * N)));
+            var c_them_49 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 49 * N)));
+            var c_them_50 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 50 * N)));
+            var c_them_51 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 51 * N)));
+            var c_them_52 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 52 * N)));
+            var c_them_53 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 53 * N)));
+            var c_them_54 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 54 * N)));
+            var c_them_55 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 55 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_48, SIMDClass.MultiplyLow(c_them_48, VectorT.LoadAligned(theirWeights + 48 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_49, SIMDClass.MultiplyLow(c_them_49, VectorT.LoadAligned(theirWeights + 49 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_50, SIMDClass.MultiplyLow(c_them_50, VectorT.LoadAligned(theirWeights + 50 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_51, SIMDClass.MultiplyLow(c_them_51, VectorT.LoadAligned(theirWeights + 51 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_52, SIMDClass.MultiplyLow(c_them_52, VectorT.LoadAligned(theirWeights + 52 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_53, SIMDClass.MultiplyLow(c_them_53, VectorT.LoadAligned(theirWeights + 53 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_54, SIMDClass.MultiplyLow(c_them_54, VectorT.LoadAligned(theirWeights + 54 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_55, SIMDClass.MultiplyLow(c_them_55, VectorT.LoadAligned(theirWeights + 55 * N))));
 
-                Vector256<short> clamp_them_1280 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1280)));
-                Vector256<short> clamp_them_1296 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1296)));
-                Vector256<short> clamp_them_1312 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1312)));
-                Vector256<short> clamp_them_1328 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1328)));
-                Vector256<short> clamp_them_1344 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1344)));
-                Vector256<short> clamp_them_1360 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1360)));
-                Vector256<short> clamp_them_1376 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1376)));
-                Vector256<short> clamp_them_1392 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1392)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1280, Avx2.MultiplyLow(clamp_them_1280, Avx2.LoadAlignedVector256(theirWeights + 1280))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1296, Avx2.MultiplyLow(clamp_them_1296, Avx2.LoadAlignedVector256(theirWeights + 1296))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1312, Avx2.MultiplyLow(clamp_them_1312, Avx2.LoadAlignedVector256(theirWeights + 1312))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1328, Avx2.MultiplyLow(clamp_them_1328, Avx2.LoadAlignedVector256(theirWeights + 1328))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1344, Avx2.MultiplyLow(clamp_them_1344, Avx2.LoadAlignedVector256(theirWeights + 1344))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1360, Avx2.MultiplyLow(clamp_them_1360, Avx2.LoadAlignedVector256(theirWeights + 1360))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1376, Avx2.MultiplyLow(clamp_them_1376, Avx2.LoadAlignedVector256(theirWeights + 1376))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1392, Avx2.MultiplyLow(clamp_them_1392, Avx2.LoadAlignedVector256(theirWeights + 1392))));
+            var c_them_56 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 56 * N)));
+            var c_them_57 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 57 * N)));
+            var c_them_58 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 58 * N)));
+            var c_them_59 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 59 * N)));
+            var c_them_60 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 60 * N)));
+            var c_them_61 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 61 * N)));
+            var c_them_62 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 62 * N)));
+            var c_them_63 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 63 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_56, SIMDClass.MultiplyLow(c_them_56, VectorT.LoadAligned(theirWeights + 56 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_57, SIMDClass.MultiplyLow(c_them_57, VectorT.LoadAligned(theirWeights + 57 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_58, SIMDClass.MultiplyLow(c_them_58, VectorT.LoadAligned(theirWeights + 58 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_59, SIMDClass.MultiplyLow(c_them_59, VectorT.LoadAligned(theirWeights + 59 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_60, SIMDClass.MultiplyLow(c_them_60, VectorT.LoadAligned(theirWeights + 60 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_61, SIMDClass.MultiplyLow(c_them_61, VectorT.LoadAligned(theirWeights + 61 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_62, SIMDClass.MultiplyLow(c_them_62, VectorT.LoadAligned(theirWeights + 62 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_63, SIMDClass.MultiplyLow(c_them_63, VectorT.LoadAligned(theirWeights + 63 * N))));
 
-                Vector256<short> clamp_them_1408 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1408)));
-                Vector256<short> clamp_them_1424 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1424)));
-                Vector256<short> clamp_them_1440 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1440)));
-                Vector256<short> clamp_them_1456 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1456)));
-                Vector256<short> clamp_them_1472 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1472)));
-                Vector256<short> clamp_them_1488 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1488)));
-                Vector256<short> clamp_them_1504 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1504)));
-                Vector256<short> clamp_them_1520 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1520)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1408, Avx2.MultiplyLow(clamp_them_1408, Avx2.LoadAlignedVector256(theirWeights + 1408))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1424, Avx2.MultiplyLow(clamp_them_1424, Avx2.LoadAlignedVector256(theirWeights + 1424))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1440, Avx2.MultiplyLow(clamp_them_1440, Avx2.LoadAlignedVector256(theirWeights + 1440))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1456, Avx2.MultiplyLow(clamp_them_1456, Avx2.LoadAlignedVector256(theirWeights + 1456))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1472, Avx2.MultiplyLow(clamp_them_1472, Avx2.LoadAlignedVector256(theirWeights + 1472))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1488, Avx2.MultiplyLow(clamp_them_1488, Avx2.LoadAlignedVector256(theirWeights + 1488))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1504, Avx2.MultiplyLow(clamp_them_1504, Avx2.LoadAlignedVector256(theirWeights + 1504))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1520, Avx2.MultiplyLow(clamp_them_1520, Avx2.LoadAlignedVector256(theirWeights + 1520))));
-            }
+            if (StopBefore == AVX256_1024HL)
+                goto END;
 
-#endregion
+            var c_them_64 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 64 * N)));
+            var c_them_65 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 65 * N)));
+            var c_them_66 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 66 * N)));
+            var c_them_67 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 67 * N)));
+            var c_them_68 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 68 * N)));
+            var c_them_69 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 69 * N)));
+            var c_them_70 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 70 * N)));
+            var c_them_71 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 71 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_64, SIMDClass.MultiplyLow(c_them_64, VectorT.LoadAligned(theirWeights + 64 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_65, SIMDClass.MultiplyLow(c_them_65, VectorT.LoadAligned(theirWeights + 65 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_66, SIMDClass.MultiplyLow(c_them_66, VectorT.LoadAligned(theirWeights + 66 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_67, SIMDClass.MultiplyLow(c_them_67, VectorT.LoadAligned(theirWeights + 67 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_68, SIMDClass.MultiplyLow(c_them_68, VectorT.LoadAligned(theirWeights + 68 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_69, SIMDClass.MultiplyLow(c_them_69, VectorT.LoadAligned(theirWeights + 69 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_70, SIMDClass.MultiplyLow(c_them_70, VectorT.LoadAligned(theirWeights + 70 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_71, SIMDClass.MultiplyLow(c_them_71, VectorT.LoadAligned(theirWeights + 71 * N))));
 
-            int output = SumVector256NoHadd(normalSum);
+            var c_them_72 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 72 * N)));
+            var c_them_73 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 73 * N)));
+            var c_them_74 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 74 * N)));
+            var c_them_75 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 75 * N)));
+            var c_them_76 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 76 * N)));
+            var c_them_77 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 77 * N)));
+            var c_them_78 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 78 * N)));
+            var c_them_79 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 79 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_72, SIMDClass.MultiplyLow(c_them_72, VectorT.LoadAligned(theirWeights + 72 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_73, SIMDClass.MultiplyLow(c_them_73, VectorT.LoadAligned(theirWeights + 73 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_74, SIMDClass.MultiplyLow(c_them_74, VectorT.LoadAligned(theirWeights + 74 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_75, SIMDClass.MultiplyLow(c_them_75, VectorT.LoadAligned(theirWeights + 75 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_76, SIMDClass.MultiplyLow(c_them_76, VectorT.LoadAligned(theirWeights + 76 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_77, SIMDClass.MultiplyLow(c_them_77, VectorT.LoadAligned(theirWeights + 77 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_78, SIMDClass.MultiplyLow(c_them_78, VectorT.LoadAligned(theirWeights + 78 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_79, SIMDClass.MultiplyLow(c_them_79, VectorT.LoadAligned(theirWeights + 79 * N))));
 
-            return (output / QA + LayerBiases[0][outputBucket]) * OutputScale / QAB;
+            var c_them_80 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 80 * N)));
+            var c_them_81 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 81 * N)));
+            var c_them_82 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 82 * N)));
+            var c_them_83 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 83 * N)));
+            var c_them_84 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 84 * N)));
+            var c_them_85 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 85 * N)));
+            var c_them_86 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 86 * N)));
+            var c_them_87 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 87 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_80, SIMDClass.MultiplyLow(c_them_80, VectorT.LoadAligned(theirWeights + 80 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_81, SIMDClass.MultiplyLow(c_them_81, VectorT.LoadAligned(theirWeights + 81 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_82, SIMDClass.MultiplyLow(c_them_82, VectorT.LoadAligned(theirWeights + 82 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_83, SIMDClass.MultiplyLow(c_them_83, VectorT.LoadAligned(theirWeights + 83 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_84, SIMDClass.MultiplyLow(c_them_84, VectorT.LoadAligned(theirWeights + 84 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_85, SIMDClass.MultiplyLow(c_them_85, VectorT.LoadAligned(theirWeights + 85 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_86, SIMDClass.MultiplyLow(c_them_86, VectorT.LoadAligned(theirWeights + 86 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_87, SIMDClass.MultiplyLow(c_them_87, VectorT.LoadAligned(theirWeights + 87 * N))));
+
+            var c_them_88 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 88 * N)));
+            var c_them_89 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 89 * N)));
+            var c_them_90 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 90 * N)));
+            var c_them_91 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 91 * N)));
+            var c_them_92 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 92 * N)));
+            var c_them_93 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 93 * N)));
+            var c_them_94 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 94 * N)));
+            var c_them_95 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 95 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_88, SIMDClass.MultiplyLow(c_them_88, VectorT.LoadAligned(theirWeights + 88 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_89, SIMDClass.MultiplyLow(c_them_89, VectorT.LoadAligned(theirWeights + 89 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_90, SIMDClass.MultiplyLow(c_them_90, VectorT.LoadAligned(theirWeights + 90 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_91, SIMDClass.MultiplyLow(c_them_91, VectorT.LoadAligned(theirWeights + 91 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_92, SIMDClass.MultiplyLow(c_them_92, VectorT.LoadAligned(theirWeights + 92 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_93, SIMDClass.MultiplyLow(c_them_93, VectorT.LoadAligned(theirWeights + 93 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_94, SIMDClass.MultiplyLow(c_them_94, VectorT.LoadAligned(theirWeights + 94 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_95, SIMDClass.MultiplyLow(c_them_95, VectorT.LoadAligned(theirWeights + 95 * N))));
+
+            #endregion
+
+
+
+            END:
+
+            int output = NNUE.SumVectorNoHadd(sumVec);
+
+            return (output / QA + LayerBiases[outputBucket]) * 400 / (QA * QB);
         }
 
     }

--- a/Logic/NN/FunUnrollThings.cs
+++ b/Logic/NN/FunUnrollThings.cs
@@ -1,326 +1,370 @@
-﻿using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
+﻿
+#if AVX512
+using VectorT = System.Runtime.Intrinsics.Vector512;
+#else
+using VectorT = System.Runtime.Intrinsics.Vector256;
+#endif
 
 namespace Lizard.Logic.NN
 {
     public static unsafe class FunUnrollThings
     {
 
+#if AVX512
+        private const int N = 32;
+#else
+        private const int N = 16;
+#endif
+
+        private const int HL = (NNUE.NetArch == NetworkArchitecture.Simple768) ? Simple768.HiddenSize : Bucketed768.HiddenSize;
+        private const int StopBefore = HL / N;
+
+        private const int AVX512_1024HL = 1024 / 32;
+        private const int AVX512_1536HL = 1536 / 32;
+
+        private const int AVX256_1024HL = 1024 / 16;
+        private const int AVX256_1536HL = 1536 / 16;
+
+
         public static void SubAdd(short* src, short* dst, short* sub1, short* add1)
         {
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 0), Vector256.Load(add1 + 0)), Vector256.Load(sub1 + 0)), dst + 0);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 16), Vector256.Load(add1 + 16)), Vector256.Load(sub1 + 16)), dst + 16);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 32), Vector256.Load(add1 + 32)), Vector256.Load(sub1 + 32)), dst + 32);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 48), Vector256.Load(add1 + 48)), Vector256.Load(sub1 + 48)), dst + 48);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 64), Vector256.Load(add1 + 64)), Vector256.Load(sub1 + 64)), dst + 64);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 80), Vector256.Load(add1 + 80)), Vector256.Load(sub1 + 80)), dst + 80);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 96), Vector256.Load(add1 + 96)), Vector256.Load(sub1 + 96)), dst + 96);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 112), Vector256.Load(add1 + 112)), Vector256.Load(sub1 + 112)), dst + 112);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 128), Vector256.Load(add1 + 128)), Vector256.Load(sub1 + 128)), dst + 128);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 144), Vector256.Load(add1 + 144)), Vector256.Load(sub1 + 144)), dst + 144);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 160), Vector256.Load(add1 + 160)), Vector256.Load(sub1 + 160)), dst + 160);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 176), Vector256.Load(add1 + 176)), Vector256.Load(sub1 + 176)), dst + 176);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 192), Vector256.Load(add1 + 192)), Vector256.Load(sub1 + 192)), dst + 192);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 208), Vector256.Load(add1 + 208)), Vector256.Load(sub1 + 208)), dst + 208);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 224), Vector256.Load(add1 + 224)), Vector256.Load(sub1 + 224)), dst + 224);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 240), Vector256.Load(add1 + 240)), Vector256.Load(sub1 + 240)), dst + 240);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 256), Vector256.Load(add1 + 256)), Vector256.Load(sub1 + 256)), dst + 256);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 272), Vector256.Load(add1 + 272)), Vector256.Load(sub1 + 272)), dst + 272);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 288), Vector256.Load(add1 + 288)), Vector256.Load(sub1 + 288)), dst + 288);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 304), Vector256.Load(add1 + 304)), Vector256.Load(sub1 + 304)), dst + 304);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 320), Vector256.Load(add1 + 320)), Vector256.Load(sub1 + 320)), dst + 320);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 336), Vector256.Load(add1 + 336)), Vector256.Load(sub1 + 336)), dst + 336);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 352), Vector256.Load(add1 + 352)), Vector256.Load(sub1 + 352)), dst + 352);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 368), Vector256.Load(add1 + 368)), Vector256.Load(sub1 + 368)), dst + 368);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 384), Vector256.Load(add1 + 384)), Vector256.Load(sub1 + 384)), dst + 384);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 400), Vector256.Load(add1 + 400)), Vector256.Load(sub1 + 400)), dst + 400);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 416), Vector256.Load(add1 + 416)), Vector256.Load(sub1 + 416)), dst + 416);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 432), Vector256.Load(add1 + 432)), Vector256.Load(sub1 + 432)), dst + 432);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 448), Vector256.Load(add1 + 448)), Vector256.Load(sub1 + 448)), dst + 448);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 464), Vector256.Load(add1 + 464)), Vector256.Load(sub1 + 464)), dst + 464);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 480), Vector256.Load(add1 + 480)), Vector256.Load(sub1 + 480)), dst + 480);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 496), Vector256.Load(add1 + 496)), Vector256.Load(sub1 + 496)), dst + 496);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 512), Vector256.Load(add1 + 512)), Vector256.Load(sub1 + 512)), dst + 512);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 528), Vector256.Load(add1 + 528)), Vector256.Load(sub1 + 528)), dst + 528);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 544), Vector256.Load(add1 + 544)), Vector256.Load(sub1 + 544)), dst + 544);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 560), Vector256.Load(add1 + 560)), Vector256.Load(sub1 + 560)), dst + 560);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 576), Vector256.Load(add1 + 576)), Vector256.Load(sub1 + 576)), dst + 576);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 592), Vector256.Load(add1 + 592)), Vector256.Load(sub1 + 592)), dst + 592);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 608), Vector256.Load(add1 + 608)), Vector256.Load(sub1 + 608)), dst + 608);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 624), Vector256.Load(add1 + 624)), Vector256.Load(sub1 + 624)), dst + 624);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 640), Vector256.Load(add1 + 640)), Vector256.Load(sub1 + 640)), dst + 640);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 656), Vector256.Load(add1 + 656)), Vector256.Load(sub1 + 656)), dst + 656);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 672), Vector256.Load(add1 + 672)), Vector256.Load(sub1 + 672)), dst + 672);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 688), Vector256.Load(add1 + 688)), Vector256.Load(sub1 + 688)), dst + 688);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 704), Vector256.Load(add1 + 704)), Vector256.Load(sub1 + 704)), dst + 704);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 720), Vector256.Load(add1 + 720)), Vector256.Load(sub1 + 720)), dst + 720);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 736), Vector256.Load(add1 + 736)), Vector256.Load(sub1 + 736)), dst + 736);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 752), Vector256.Load(add1 + 752)), Vector256.Load(sub1 + 752)), dst + 752);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 768), Vector256.Load(add1 + 768)), Vector256.Load(sub1 + 768)), dst + 768);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 784), Vector256.Load(add1 + 784)), Vector256.Load(sub1 + 784)), dst + 784);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 800), Vector256.Load(add1 + 800)), Vector256.Load(sub1 + 800)), dst + 800);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 816), Vector256.Load(add1 + 816)), Vector256.Load(sub1 + 816)), dst + 816);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 832), Vector256.Load(add1 + 832)), Vector256.Load(sub1 + 832)), dst + 832);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 848), Vector256.Load(add1 + 848)), Vector256.Load(sub1 + 848)), dst + 848);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 864), Vector256.Load(add1 + 864)), Vector256.Load(sub1 + 864)), dst + 864);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 880), Vector256.Load(add1 + 880)), Vector256.Load(sub1 + 880)), dst + 880);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 896), Vector256.Load(add1 + 896)), Vector256.Load(sub1 + 896)), dst + 896);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 912), Vector256.Load(add1 + 912)), Vector256.Load(sub1 + 912)), dst + 912);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 928), Vector256.Load(add1 + 928)), Vector256.Load(sub1 + 928)), dst + 928);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 944), Vector256.Load(add1 + 944)), Vector256.Load(sub1 + 944)), dst + 944);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 960), Vector256.Load(add1 + 960)), Vector256.Load(sub1 + 960)), dst + 960);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 976), Vector256.Load(add1 + 976)), Vector256.Load(sub1 + 976)), dst + 976);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 992), Vector256.Load(add1 + 992)), Vector256.Load(sub1 + 992)), dst + 992);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1008), Vector256.Load(add1 + 1008)), Vector256.Load(sub1 + 1008)), dst + 1008);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 0 * N), VectorT.Load(add1 + 0 * N)), VectorT.Load(sub1 + 0 * N)), dst + 0 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 1 * N), VectorT.Load(add1 + 1 * N)), VectorT.Load(sub1 + 1 * N)), dst + 1 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 2 * N), VectorT.Load(add1 + 2 * N)), VectorT.Load(sub1 + 2 * N)), dst + 2 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 3 * N), VectorT.Load(add1 + 3 * N)), VectorT.Load(sub1 + 3 * N)), dst + 3 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 4 * N), VectorT.Load(add1 + 4 * N)), VectorT.Load(sub1 + 4 * N)), dst + 4 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 5 * N), VectorT.Load(add1 + 5 * N)), VectorT.Load(sub1 + 5 * N)), dst + 5 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 6 * N), VectorT.Load(add1 + 6 * N)), VectorT.Load(sub1 + 6 * N)), dst + 6 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 7 * N), VectorT.Load(add1 + 7 * N)), VectorT.Load(sub1 + 7 * N)), dst + 7 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 8 * N), VectorT.Load(add1 + 8 * N)), VectorT.Load(sub1 + 8 * N)), dst + 8 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 9 * N), VectorT.Load(add1 + 9 * N)), VectorT.Load(sub1 + 9 * N)), dst + 9 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 10 * N), VectorT.Load(add1 + 10 * N)), VectorT.Load(sub1 + 10 * N)), dst + 10 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 11 * N), VectorT.Load(add1 + 11 * N)), VectorT.Load(sub1 + 11 * N)), dst + 11 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 12 * N), VectorT.Load(add1 + 12 * N)), VectorT.Load(sub1 + 12 * N)), dst + 12 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 13 * N), VectorT.Load(add1 + 13 * N)), VectorT.Load(sub1 + 13 * N)), dst + 13 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 14 * N), VectorT.Load(add1 + 14 * N)), VectorT.Load(sub1 + 14 * N)), dst + 14 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 15 * N), VectorT.Load(add1 + 15 * N)), VectorT.Load(sub1 + 15 * N)), dst + 15 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 16 * N), VectorT.Load(add1 + 16 * N)), VectorT.Load(sub1 + 16 * N)), dst + 16 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 17 * N), VectorT.Load(add1 + 17 * N)), VectorT.Load(sub1 + 17 * N)), dst + 17 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 18 * N), VectorT.Load(add1 + 18 * N)), VectorT.Load(sub1 + 18 * N)), dst + 18 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 19 * N), VectorT.Load(add1 + 19 * N)), VectorT.Load(sub1 + 19 * N)), dst + 19 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 20 * N), VectorT.Load(add1 + 20 * N)), VectorT.Load(sub1 + 20 * N)), dst + 20 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 21 * N), VectorT.Load(add1 + 21 * N)), VectorT.Load(sub1 + 21 * N)), dst + 21 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 22 * N), VectorT.Load(add1 + 22 * N)), VectorT.Load(sub1 + 22 * N)), dst + 22 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 23 * N), VectorT.Load(add1 + 23 * N)), VectorT.Load(sub1 + 23 * N)), dst + 23 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 24 * N), VectorT.Load(add1 + 24 * N)), VectorT.Load(sub1 + 24 * N)), dst + 24 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 25 * N), VectorT.Load(add1 + 25 * N)), VectorT.Load(sub1 + 25 * N)), dst + 25 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 26 * N), VectorT.Load(add1 + 26 * N)), VectorT.Load(sub1 + 26 * N)), dst + 26 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 27 * N), VectorT.Load(add1 + 27 * N)), VectorT.Load(sub1 + 27 * N)), dst + 27 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 28 * N), VectorT.Load(add1 + 28 * N)), VectorT.Load(sub1 + 28 * N)), dst + 28 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 29 * N), VectorT.Load(add1 + 29 * N)), VectorT.Load(sub1 + 29 * N)), dst + 29 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 30 * N), VectorT.Load(add1 + 30 * N)), VectorT.Load(sub1 + 30 * N)), dst + 30 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 31 * N), VectorT.Load(add1 + 31 * N)), VectorT.Load(sub1 + 31 * N)), dst + 31 * N);
 
-            if (NNUE.NetArch == NetworkArchitecture.Simple768 && Simple768.HiddenSize <= 1024 ||
-                NNUE.NetArch == NetworkArchitecture.Bucketed768 && Bucketed768.HiddenSize <= 1024)
+            if (StopBefore == AVX512_1024HL)
                 return;
 
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1024), Vector256.Load(add1 + 1024)), Vector256.Load(sub1 + 1024)), dst + 1024);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1040), Vector256.Load(add1 + 1040)), Vector256.Load(sub1 + 1040)), dst + 1040);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1056), Vector256.Load(add1 + 1056)), Vector256.Load(sub1 + 1056)), dst + 1056);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1072), Vector256.Load(add1 + 1072)), Vector256.Load(sub1 + 1072)), dst + 1072);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1088), Vector256.Load(add1 + 1088)), Vector256.Load(sub1 + 1088)), dst + 1088);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1104), Vector256.Load(add1 + 1104)), Vector256.Load(sub1 + 1104)), dst + 1104);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1120), Vector256.Load(add1 + 1120)), Vector256.Load(sub1 + 1120)), dst + 1120);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1136), Vector256.Load(add1 + 1136)), Vector256.Load(sub1 + 1136)), dst + 1136);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1152), Vector256.Load(add1 + 1152)), Vector256.Load(sub1 + 1152)), dst + 1152);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1168), Vector256.Load(add1 + 1168)), Vector256.Load(sub1 + 1168)), dst + 1168);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1184), Vector256.Load(add1 + 1184)), Vector256.Load(sub1 + 1184)), dst + 1184);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1200), Vector256.Load(add1 + 1200)), Vector256.Load(sub1 + 1200)), dst + 1200);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1216), Vector256.Load(add1 + 1216)), Vector256.Load(sub1 + 1216)), dst + 1216);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1232), Vector256.Load(add1 + 1232)), Vector256.Load(sub1 + 1232)), dst + 1232);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1248), Vector256.Load(add1 + 1248)), Vector256.Load(sub1 + 1248)), dst + 1248);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1264), Vector256.Load(add1 + 1264)), Vector256.Load(sub1 + 1264)), dst + 1264);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1280), Vector256.Load(add1 + 1280)), Vector256.Load(sub1 + 1280)), dst + 1280);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1296), Vector256.Load(add1 + 1296)), Vector256.Load(sub1 + 1296)), dst + 1296);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1312), Vector256.Load(add1 + 1312)), Vector256.Load(sub1 + 1312)), dst + 1312);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1328), Vector256.Load(add1 + 1328)), Vector256.Load(sub1 + 1328)), dst + 1328);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1344), Vector256.Load(add1 + 1344)), Vector256.Load(sub1 + 1344)), dst + 1344);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1360), Vector256.Load(add1 + 1360)), Vector256.Load(sub1 + 1360)), dst + 1360);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1376), Vector256.Load(add1 + 1376)), Vector256.Load(sub1 + 1376)), dst + 1376);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1392), Vector256.Load(add1 + 1392)), Vector256.Load(sub1 + 1392)), dst + 1392);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1408), Vector256.Load(add1 + 1408)), Vector256.Load(sub1 + 1408)), dst + 1408);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1424), Vector256.Load(add1 + 1424)), Vector256.Load(sub1 + 1424)), dst + 1424);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1440), Vector256.Load(add1 + 1440)), Vector256.Load(sub1 + 1440)), dst + 1440);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1456), Vector256.Load(add1 + 1456)), Vector256.Load(sub1 + 1456)), dst + 1456);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1472), Vector256.Load(add1 + 1472)), Vector256.Load(sub1 + 1472)), dst + 1472);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1488), Vector256.Load(add1 + 1488)), Vector256.Load(sub1 + 1488)), dst + 1488);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1504), Vector256.Load(add1 + 1504)), Vector256.Load(sub1 + 1504)), dst + 1504);
-            Vector256.Store(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1520), Vector256.Load(add1 + 1520)), Vector256.Load(sub1 + 1520)), dst + 1520);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 32 * N), VectorT.Load(add1 + 32 * N)), VectorT.Load(sub1 + 32 * N)), dst + 32 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 33 * N), VectorT.Load(add1 + 33 * N)), VectorT.Load(sub1 + 33 * N)), dst + 33 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 34 * N), VectorT.Load(add1 + 34 * N)), VectorT.Load(sub1 + 34 * N)), dst + 34 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 35 * N), VectorT.Load(add1 + 35 * N)), VectorT.Load(sub1 + 35 * N)), dst + 35 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 36 * N), VectorT.Load(add1 + 36 * N)), VectorT.Load(sub1 + 36 * N)), dst + 36 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 37 * N), VectorT.Load(add1 + 37 * N)), VectorT.Load(sub1 + 37 * N)), dst + 37 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 38 * N), VectorT.Load(add1 + 38 * N)), VectorT.Load(sub1 + 38 * N)), dst + 38 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 39 * N), VectorT.Load(add1 + 39 * N)), VectorT.Load(sub1 + 39 * N)), dst + 39 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 40 * N), VectorT.Load(add1 + 40 * N)), VectorT.Load(sub1 + 40 * N)), dst + 40 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 41 * N), VectorT.Load(add1 + 41 * N)), VectorT.Load(sub1 + 41 * N)), dst + 41 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 42 * N), VectorT.Load(add1 + 42 * N)), VectorT.Load(sub1 + 42 * N)), dst + 42 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 43 * N), VectorT.Load(add1 + 43 * N)), VectorT.Load(sub1 + 43 * N)), dst + 43 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 44 * N), VectorT.Load(add1 + 44 * N)), VectorT.Load(sub1 + 44 * N)), dst + 44 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 45 * N), VectorT.Load(add1 + 45 * N)), VectorT.Load(sub1 + 45 * N)), dst + 45 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 46 * N), VectorT.Load(add1 + 46 * N)), VectorT.Load(sub1 + 46 * N)), dst + 46 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 47 * N), VectorT.Load(add1 + 47 * N)), VectorT.Load(sub1 + 47 * N)), dst + 47 * N);
+
+            if (StopBefore == AVX512_1536HL)
+                return;
+
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 48 * N), VectorT.Load(add1 + 48 * N)), VectorT.Load(sub1 + 48 * N)), dst + 48 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 49 * N), VectorT.Load(add1 + 49 * N)), VectorT.Load(sub1 + 49 * N)), dst + 49 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 50 * N), VectorT.Load(add1 + 50 * N)), VectorT.Load(sub1 + 50 * N)), dst + 50 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 51 * N), VectorT.Load(add1 + 51 * N)), VectorT.Load(sub1 + 51 * N)), dst + 51 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 52 * N), VectorT.Load(add1 + 52 * N)), VectorT.Load(sub1 + 52 * N)), dst + 52 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 53 * N), VectorT.Load(add1 + 53 * N)), VectorT.Load(sub1 + 53 * N)), dst + 53 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 54 * N), VectorT.Load(add1 + 54 * N)), VectorT.Load(sub1 + 54 * N)), dst + 54 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 55 * N), VectorT.Load(add1 + 55 * N)), VectorT.Load(sub1 + 55 * N)), dst + 55 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 56 * N), VectorT.Load(add1 + 56 * N)), VectorT.Load(sub1 + 56 * N)), dst + 56 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 57 * N), VectorT.Load(add1 + 57 * N)), VectorT.Load(sub1 + 57 * N)), dst + 57 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 58 * N), VectorT.Load(add1 + 58 * N)), VectorT.Load(sub1 + 58 * N)), dst + 58 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 59 * N), VectorT.Load(add1 + 59 * N)), VectorT.Load(sub1 + 59 * N)), dst + 59 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 60 * N), VectorT.Load(add1 + 60 * N)), VectorT.Load(sub1 + 60 * N)), dst + 60 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 61 * N), VectorT.Load(add1 + 61 * N)), VectorT.Load(sub1 + 61 * N)), dst + 61 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 62 * N), VectorT.Load(add1 + 62 * N)), VectorT.Load(sub1 + 62 * N)), dst + 62 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 63 * N), VectorT.Load(add1 + 63 * N)), VectorT.Load(sub1 + 63 * N)), dst + 63 * N);
+
+            if (StopBefore == AVX256_1024HL)
+                return;
+
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 64 * N), VectorT.Load(add1 + 64 * N)), VectorT.Load(sub1 + 64 * N)), dst + 64 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 65 * N), VectorT.Load(add1 + 65 * N)), VectorT.Load(sub1 + 65 * N)), dst + 65 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 66 * N), VectorT.Load(add1 + 66 * N)), VectorT.Load(sub1 + 66 * N)), dst + 66 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 67 * N), VectorT.Load(add1 + 67 * N)), VectorT.Load(sub1 + 67 * N)), dst + 67 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 68 * N), VectorT.Load(add1 + 68 * N)), VectorT.Load(sub1 + 68 * N)), dst + 68 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 69 * N), VectorT.Load(add1 + 69 * N)), VectorT.Load(sub1 + 69 * N)), dst + 69 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 70 * N), VectorT.Load(add1 + 70 * N)), VectorT.Load(sub1 + 70 * N)), dst + 70 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 71 * N), VectorT.Load(add1 + 71 * N)), VectorT.Load(sub1 + 71 * N)), dst + 71 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 72 * N), VectorT.Load(add1 + 72 * N)), VectorT.Load(sub1 + 72 * N)), dst + 72 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 73 * N), VectorT.Load(add1 + 73 * N)), VectorT.Load(sub1 + 73 * N)), dst + 73 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 74 * N), VectorT.Load(add1 + 74 * N)), VectorT.Load(sub1 + 74 * N)), dst + 74 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 75 * N), VectorT.Load(add1 + 75 * N)), VectorT.Load(sub1 + 75 * N)), dst + 75 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 76 * N), VectorT.Load(add1 + 76 * N)), VectorT.Load(sub1 + 76 * N)), dst + 76 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 77 * N), VectorT.Load(add1 + 77 * N)), VectorT.Load(sub1 + 77 * N)), dst + 77 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 78 * N), VectorT.Load(add1 + 78 * N)), VectorT.Load(sub1 + 78 * N)), dst + 78 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 79 * N), VectorT.Load(add1 + 79 * N)), VectorT.Load(sub1 + 79 * N)), dst + 79 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 80 * N), VectorT.Load(add1 + 80 * N)), VectorT.Load(sub1 + 80 * N)), dst + 80 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 81 * N), VectorT.Load(add1 + 81 * N)), VectorT.Load(sub1 + 81 * N)), dst + 81 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 82 * N), VectorT.Load(add1 + 82 * N)), VectorT.Load(sub1 + 82 * N)), dst + 82 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 83 * N), VectorT.Load(add1 + 83 * N)), VectorT.Load(sub1 + 83 * N)), dst + 83 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 84 * N), VectorT.Load(add1 + 84 * N)), VectorT.Load(sub1 + 84 * N)), dst + 84 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 85 * N), VectorT.Load(add1 + 85 * N)), VectorT.Load(sub1 + 85 * N)), dst + 85 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 86 * N), VectorT.Load(add1 + 86 * N)), VectorT.Load(sub1 + 86 * N)), dst + 86 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 87 * N), VectorT.Load(add1 + 87 * N)), VectorT.Load(sub1 + 87 * N)), dst + 87 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 88 * N), VectorT.Load(add1 + 88 * N)), VectorT.Load(sub1 + 88 * N)), dst + 88 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 89 * N), VectorT.Load(add1 + 89 * N)), VectorT.Load(sub1 + 89 * N)), dst + 89 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 90 * N), VectorT.Load(add1 + 90 * N)), VectorT.Load(sub1 + 90 * N)), dst + 90 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 91 * N), VectorT.Load(add1 + 91 * N)), VectorT.Load(sub1 + 91 * N)), dst + 91 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 92 * N), VectorT.Load(add1 + 92 * N)), VectorT.Load(sub1 + 92 * N)), dst + 92 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 93 * N), VectorT.Load(add1 + 93 * N)), VectorT.Load(sub1 + 93 * N)), dst + 93 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 94 * N), VectorT.Load(add1 + 94 * N)), VectorT.Load(sub1 + 94 * N)), dst + 94 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 95 * N), VectorT.Load(add1 + 95 * N)), VectorT.Load(sub1 + 95 * N)), dst + 95 * N);
+
         }
 
 
         public static void SubSubAdd(short* src, short* dst, short* sub1, short* sub2, short* add1)
         {
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 0), Vector256.Load(add1 + 0)), Vector256.Load(sub1 + 0)), Vector256.Load(sub2 + 0)),  dst + 0);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 16), Vector256.Load(add1 + 16)), Vector256.Load(sub1 + 16)), Vector256.Load(sub2 + 16)),  dst + 16);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 32), Vector256.Load(add1 + 32)), Vector256.Load(sub1 + 32)), Vector256.Load(sub2 + 32)),  dst + 32);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 48), Vector256.Load(add1 + 48)), Vector256.Load(sub1 + 48)), Vector256.Load(sub2 + 48)),  dst + 48);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 64), Vector256.Load(add1 + 64)), Vector256.Load(sub1 + 64)), Vector256.Load(sub2 + 64)),  dst + 64);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 80), Vector256.Load(add1 + 80)), Vector256.Load(sub1 + 80)), Vector256.Load(sub2 + 80)),  dst + 80);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 96), Vector256.Load(add1 + 96)), Vector256.Load(sub1 + 96)), Vector256.Load(sub2 + 96)),  dst + 96);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 112), Vector256.Load(add1 + 112)), Vector256.Load(sub1 + 112)), Vector256.Load(sub2 + 112)),  dst + 112);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 128), Vector256.Load(add1 + 128)), Vector256.Load(sub1 + 128)), Vector256.Load(sub2 + 128)),  dst + 128);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 144), Vector256.Load(add1 + 144)), Vector256.Load(sub1 + 144)), Vector256.Load(sub2 + 144)),  dst + 144);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 160), Vector256.Load(add1 + 160)), Vector256.Load(sub1 + 160)), Vector256.Load(sub2 + 160)),  dst + 160);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 176), Vector256.Load(add1 + 176)), Vector256.Load(sub1 + 176)), Vector256.Load(sub2 + 176)),  dst + 176);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 192), Vector256.Load(add1 + 192)), Vector256.Load(sub1 + 192)), Vector256.Load(sub2 + 192)),  dst + 192);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 208), Vector256.Load(add1 + 208)), Vector256.Load(sub1 + 208)), Vector256.Load(sub2 + 208)),  dst + 208);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 224), Vector256.Load(add1 + 224)), Vector256.Load(sub1 + 224)), Vector256.Load(sub2 + 224)),  dst + 224);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 240), Vector256.Load(add1 + 240)), Vector256.Load(sub1 + 240)), Vector256.Load(sub2 + 240)),  dst + 240);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 256), Vector256.Load(add1 + 256)), Vector256.Load(sub1 + 256)), Vector256.Load(sub2 + 256)),  dst + 256);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 272), Vector256.Load(add1 + 272)), Vector256.Load(sub1 + 272)), Vector256.Load(sub2 + 272)),  dst + 272);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 288), Vector256.Load(add1 + 288)), Vector256.Load(sub1 + 288)), Vector256.Load(sub2 + 288)),  dst + 288);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 304), Vector256.Load(add1 + 304)), Vector256.Load(sub1 + 304)), Vector256.Load(sub2 + 304)),  dst + 304);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 320), Vector256.Load(add1 + 320)), Vector256.Load(sub1 + 320)), Vector256.Load(sub2 + 320)),  dst + 320);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 336), Vector256.Load(add1 + 336)), Vector256.Load(sub1 + 336)), Vector256.Load(sub2 + 336)),  dst + 336);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 352), Vector256.Load(add1 + 352)), Vector256.Load(sub1 + 352)), Vector256.Load(sub2 + 352)),  dst + 352);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 368), Vector256.Load(add1 + 368)), Vector256.Load(sub1 + 368)), Vector256.Load(sub2 + 368)),  dst + 368);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 384), Vector256.Load(add1 + 384)), Vector256.Load(sub1 + 384)), Vector256.Load(sub2 + 384)),  dst + 384);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 400), Vector256.Load(add1 + 400)), Vector256.Load(sub1 + 400)), Vector256.Load(sub2 + 400)),  dst + 400);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 416), Vector256.Load(add1 + 416)), Vector256.Load(sub1 + 416)), Vector256.Load(sub2 + 416)),  dst + 416);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 432), Vector256.Load(add1 + 432)), Vector256.Load(sub1 + 432)), Vector256.Load(sub2 + 432)),  dst + 432);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 448), Vector256.Load(add1 + 448)), Vector256.Load(sub1 + 448)), Vector256.Load(sub2 + 448)),  dst + 448);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 464), Vector256.Load(add1 + 464)), Vector256.Load(sub1 + 464)), Vector256.Load(sub2 + 464)),  dst + 464);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 480), Vector256.Load(add1 + 480)), Vector256.Load(sub1 + 480)), Vector256.Load(sub2 + 480)),  dst + 480);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 496), Vector256.Load(add1 + 496)), Vector256.Load(sub1 + 496)), Vector256.Load(sub2 + 496)),  dst + 496);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 512), Vector256.Load(add1 + 512)), Vector256.Load(sub1 + 512)), Vector256.Load(sub2 + 512)),  dst + 512);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 528), Vector256.Load(add1 + 528)), Vector256.Load(sub1 + 528)), Vector256.Load(sub2 + 528)),  dst + 528);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 544), Vector256.Load(add1 + 544)), Vector256.Load(sub1 + 544)), Vector256.Load(sub2 + 544)),  dst + 544);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 560), Vector256.Load(add1 + 560)), Vector256.Load(sub1 + 560)), Vector256.Load(sub2 + 560)),  dst + 560);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 576), Vector256.Load(add1 + 576)), Vector256.Load(sub1 + 576)), Vector256.Load(sub2 + 576)),  dst + 576);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 592), Vector256.Load(add1 + 592)), Vector256.Load(sub1 + 592)), Vector256.Load(sub2 + 592)),  dst + 592);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 608), Vector256.Load(add1 + 608)), Vector256.Load(sub1 + 608)), Vector256.Load(sub2 + 608)),  dst + 608);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 624), Vector256.Load(add1 + 624)), Vector256.Load(sub1 + 624)), Vector256.Load(sub2 + 624)),  dst + 624);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 640), Vector256.Load(add1 + 640)), Vector256.Load(sub1 + 640)), Vector256.Load(sub2 + 640)),  dst + 640);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 656), Vector256.Load(add1 + 656)), Vector256.Load(sub1 + 656)), Vector256.Load(sub2 + 656)),  dst + 656);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 672), Vector256.Load(add1 + 672)), Vector256.Load(sub1 + 672)), Vector256.Load(sub2 + 672)),  dst + 672);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 688), Vector256.Load(add1 + 688)), Vector256.Load(sub1 + 688)), Vector256.Load(sub2 + 688)),  dst + 688);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 704), Vector256.Load(add1 + 704)), Vector256.Load(sub1 + 704)), Vector256.Load(sub2 + 704)),  dst + 704);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 720), Vector256.Load(add1 + 720)), Vector256.Load(sub1 + 720)), Vector256.Load(sub2 + 720)),  dst + 720);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 736), Vector256.Load(add1 + 736)), Vector256.Load(sub1 + 736)), Vector256.Load(sub2 + 736)),  dst + 736);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 752), Vector256.Load(add1 + 752)), Vector256.Load(sub1 + 752)), Vector256.Load(sub2 + 752)),  dst + 752);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 768), Vector256.Load(add1 + 768)), Vector256.Load(sub1 + 768)), Vector256.Load(sub2 + 768)),  dst + 768);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 784), Vector256.Load(add1 + 784)), Vector256.Load(sub1 + 784)), Vector256.Load(sub2 + 784)),  dst + 784);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 800), Vector256.Load(add1 + 800)), Vector256.Load(sub1 + 800)), Vector256.Load(sub2 + 800)),  dst + 800);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 816), Vector256.Load(add1 + 816)), Vector256.Load(sub1 + 816)), Vector256.Load(sub2 + 816)),  dst + 816);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 832), Vector256.Load(add1 + 832)), Vector256.Load(sub1 + 832)), Vector256.Load(sub2 + 832)),  dst + 832);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 848), Vector256.Load(add1 + 848)), Vector256.Load(sub1 + 848)), Vector256.Load(sub2 + 848)),  dst + 848);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 864), Vector256.Load(add1 + 864)), Vector256.Load(sub1 + 864)), Vector256.Load(sub2 + 864)),  dst + 864);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 880), Vector256.Load(add1 + 880)), Vector256.Load(sub1 + 880)), Vector256.Load(sub2 + 880)),  dst + 880);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 896), Vector256.Load(add1 + 896)), Vector256.Load(sub1 + 896)), Vector256.Load(sub2 + 896)),  dst + 896);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 912), Vector256.Load(add1 + 912)), Vector256.Load(sub1 + 912)), Vector256.Load(sub2 + 912)),  dst + 912);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 928), Vector256.Load(add1 + 928)), Vector256.Load(sub1 + 928)), Vector256.Load(sub2 + 928)),  dst + 928);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 944), Vector256.Load(add1 + 944)), Vector256.Load(sub1 + 944)), Vector256.Load(sub2 + 944)),  dst + 944);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 960), Vector256.Load(add1 + 960)), Vector256.Load(sub1 + 960)), Vector256.Load(sub2 + 960)),  dst + 960);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 976), Vector256.Load(add1 + 976)), Vector256.Load(sub1 + 976)), Vector256.Load(sub2 + 976)),  dst + 976);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 992), Vector256.Load(add1 + 992)), Vector256.Load(sub1 + 992)), Vector256.Load(sub2 + 992)),  dst + 992);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1008), Vector256.Load(add1 + 1008)), Vector256.Load(sub1 + 1008)), Vector256.Load(sub2 + 1008)),  dst + 1008);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 0 * N), VectorT.Load(add1 + 0 * N)), VectorT.Load(sub1 + 0 * N)), VectorT.Load(sub2 + 0 * N)), dst + 0 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 1 * N), VectorT.Load(add1 + 1 * N)), VectorT.Load(sub1 + 1 * N)), VectorT.Load(sub2 + 1 * N)), dst + 1 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 2 * N), VectorT.Load(add1 + 2 * N)), VectorT.Load(sub1 + 2 * N)), VectorT.Load(sub2 + 2 * N)), dst + 2 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 3 * N), VectorT.Load(add1 + 3 * N)), VectorT.Load(sub1 + 3 * N)), VectorT.Load(sub2 + 3 * N)), dst + 3 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 4 * N), VectorT.Load(add1 + 4 * N)), VectorT.Load(sub1 + 4 * N)), VectorT.Load(sub2 + 4 * N)), dst + 4 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 5 * N), VectorT.Load(add1 + 5 * N)), VectorT.Load(sub1 + 5 * N)), VectorT.Load(sub2 + 5 * N)), dst + 5 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 6 * N), VectorT.Load(add1 + 6 * N)), VectorT.Load(sub1 + 6 * N)), VectorT.Load(sub2 + 6 * N)), dst + 6 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 7 * N), VectorT.Load(add1 + 7 * N)), VectorT.Load(sub1 + 7 * N)), VectorT.Load(sub2 + 7 * N)), dst + 7 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 8 * N), VectorT.Load(add1 + 8 * N)), VectorT.Load(sub1 + 8 * N)), VectorT.Load(sub2 + 8 * N)), dst + 8 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 9 * N), VectorT.Load(add1 + 9 * N)), VectorT.Load(sub1 + 9 * N)), VectorT.Load(sub2 + 9 * N)), dst + 9 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 10 * N), VectorT.Load(add1 + 10 * N)), VectorT.Load(sub1 + 10 * N)), VectorT.Load(sub2 + 10 * N)), dst + 10 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 11 * N), VectorT.Load(add1 + 11 * N)), VectorT.Load(sub1 + 11 * N)), VectorT.Load(sub2 + 11 * N)), dst + 11 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 12 * N), VectorT.Load(add1 + 12 * N)), VectorT.Load(sub1 + 12 * N)), VectorT.Load(sub2 + 12 * N)), dst + 12 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 13 * N), VectorT.Load(add1 + 13 * N)), VectorT.Load(sub1 + 13 * N)), VectorT.Load(sub2 + 13 * N)), dst + 13 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 14 * N), VectorT.Load(add1 + 14 * N)), VectorT.Load(sub1 + 14 * N)), VectorT.Load(sub2 + 14 * N)), dst + 14 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 15 * N), VectorT.Load(add1 + 15 * N)), VectorT.Load(sub1 + 15 * N)), VectorT.Load(sub2 + 15 * N)), dst + 15 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 16 * N), VectorT.Load(add1 + 16 * N)), VectorT.Load(sub1 + 16 * N)), VectorT.Load(sub2 + 16 * N)), dst + 16 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 17 * N), VectorT.Load(add1 + 17 * N)), VectorT.Load(sub1 + 17 * N)), VectorT.Load(sub2 + 17 * N)), dst + 17 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 18 * N), VectorT.Load(add1 + 18 * N)), VectorT.Load(sub1 + 18 * N)), VectorT.Load(sub2 + 18 * N)), dst + 18 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 19 * N), VectorT.Load(add1 + 19 * N)), VectorT.Load(sub1 + 19 * N)), VectorT.Load(sub2 + 19 * N)), dst + 19 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 20 * N), VectorT.Load(add1 + 20 * N)), VectorT.Load(sub1 + 20 * N)), VectorT.Load(sub2 + 20 * N)), dst + 20 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 21 * N), VectorT.Load(add1 + 21 * N)), VectorT.Load(sub1 + 21 * N)), VectorT.Load(sub2 + 21 * N)), dst + 21 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 22 * N), VectorT.Load(add1 + 22 * N)), VectorT.Load(sub1 + 22 * N)), VectorT.Load(sub2 + 22 * N)), dst + 22 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 23 * N), VectorT.Load(add1 + 23 * N)), VectorT.Load(sub1 + 23 * N)), VectorT.Load(sub2 + 23 * N)), dst + 23 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 24 * N), VectorT.Load(add1 + 24 * N)), VectorT.Load(sub1 + 24 * N)), VectorT.Load(sub2 + 24 * N)), dst + 24 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 25 * N), VectorT.Load(add1 + 25 * N)), VectorT.Load(sub1 + 25 * N)), VectorT.Load(sub2 + 25 * N)), dst + 25 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 26 * N), VectorT.Load(add1 + 26 * N)), VectorT.Load(sub1 + 26 * N)), VectorT.Load(sub2 + 26 * N)), dst + 26 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 27 * N), VectorT.Load(add1 + 27 * N)), VectorT.Load(sub1 + 27 * N)), VectorT.Load(sub2 + 27 * N)), dst + 27 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 28 * N), VectorT.Load(add1 + 28 * N)), VectorT.Load(sub1 + 28 * N)), VectorT.Load(sub2 + 28 * N)), dst + 28 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 29 * N), VectorT.Load(add1 + 29 * N)), VectorT.Load(sub1 + 29 * N)), VectorT.Load(sub2 + 29 * N)), dst + 29 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 30 * N), VectorT.Load(add1 + 30 * N)), VectorT.Load(sub1 + 30 * N)), VectorT.Load(sub2 + 30 * N)), dst + 30 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 31 * N), VectorT.Load(add1 + 31 * N)), VectorT.Load(sub1 + 31 * N)), VectorT.Load(sub2 + 31 * N)), dst + 31 * N);
 
-            if (NNUE.NetArch == NetworkArchitecture.Simple768 && Simple768.HiddenSize <= 1024 ||
-                NNUE.NetArch == NetworkArchitecture.Bucketed768 && Bucketed768.HiddenSize <= 1024)
+            if (StopBefore == AVX512_1024HL)
                 return;
 
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1024), Vector256.Load(add1 + 1024)), Vector256.Load(sub1 + 1024)), Vector256.Load(sub2 + 1024)),  dst + 1024);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1040), Vector256.Load(add1 + 1040)), Vector256.Load(sub1 + 1040)), Vector256.Load(sub2 + 1040)),  dst + 1040);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1056), Vector256.Load(add1 + 1056)), Vector256.Load(sub1 + 1056)), Vector256.Load(sub2 + 1056)),  dst + 1056);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1072), Vector256.Load(add1 + 1072)), Vector256.Load(sub1 + 1072)), Vector256.Load(sub2 + 1072)),  dst + 1072);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1088), Vector256.Load(add1 + 1088)), Vector256.Load(sub1 + 1088)), Vector256.Load(sub2 + 1088)),  dst + 1088);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1104), Vector256.Load(add1 + 1104)), Vector256.Load(sub1 + 1104)), Vector256.Load(sub2 + 1104)),  dst + 1104);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1120), Vector256.Load(add1 + 1120)), Vector256.Load(sub1 + 1120)), Vector256.Load(sub2 + 1120)),  dst + 1120);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1136), Vector256.Load(add1 + 1136)), Vector256.Load(sub1 + 1136)), Vector256.Load(sub2 + 1136)),  dst + 1136);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1152), Vector256.Load(add1 + 1152)), Vector256.Load(sub1 + 1152)), Vector256.Load(sub2 + 1152)),  dst + 1152);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1168), Vector256.Load(add1 + 1168)), Vector256.Load(sub1 + 1168)), Vector256.Load(sub2 + 1168)),  dst + 1168);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1184), Vector256.Load(add1 + 1184)), Vector256.Load(sub1 + 1184)), Vector256.Load(sub2 + 1184)),  dst + 1184);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1200), Vector256.Load(add1 + 1200)), Vector256.Load(sub1 + 1200)), Vector256.Load(sub2 + 1200)),  dst + 1200);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1216), Vector256.Load(add1 + 1216)), Vector256.Load(sub1 + 1216)), Vector256.Load(sub2 + 1216)),  dst + 1216);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1232), Vector256.Load(add1 + 1232)), Vector256.Load(sub1 + 1232)), Vector256.Load(sub2 + 1232)),  dst + 1232);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1248), Vector256.Load(add1 + 1248)), Vector256.Load(sub1 + 1248)), Vector256.Load(sub2 + 1248)),  dst + 1248);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1264), Vector256.Load(add1 + 1264)), Vector256.Load(sub1 + 1264)), Vector256.Load(sub2 + 1264)),  dst + 1264);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1280), Vector256.Load(add1 + 1280)), Vector256.Load(sub1 + 1280)), Vector256.Load(sub2 + 1280)),  dst + 1280);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1296), Vector256.Load(add1 + 1296)), Vector256.Load(sub1 + 1296)), Vector256.Load(sub2 + 1296)),  dst + 1296);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1312), Vector256.Load(add1 + 1312)), Vector256.Load(sub1 + 1312)), Vector256.Load(sub2 + 1312)),  dst + 1312);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1328), Vector256.Load(add1 + 1328)), Vector256.Load(sub1 + 1328)), Vector256.Load(sub2 + 1328)),  dst + 1328);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1344), Vector256.Load(add1 + 1344)), Vector256.Load(sub1 + 1344)), Vector256.Load(sub2 + 1344)),  dst + 1344);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1360), Vector256.Load(add1 + 1360)), Vector256.Load(sub1 + 1360)), Vector256.Load(sub2 + 1360)),  dst + 1360);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1376), Vector256.Load(add1 + 1376)), Vector256.Load(sub1 + 1376)), Vector256.Load(sub2 + 1376)),  dst + 1376);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1392), Vector256.Load(add1 + 1392)), Vector256.Load(sub1 + 1392)), Vector256.Load(sub2 + 1392)),  dst + 1392);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1408), Vector256.Load(add1 + 1408)), Vector256.Load(sub1 + 1408)), Vector256.Load(sub2 + 1408)),  dst + 1408);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1424), Vector256.Load(add1 + 1424)), Vector256.Load(sub1 + 1424)), Vector256.Load(sub2 + 1424)),  dst + 1424);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1440), Vector256.Load(add1 + 1440)), Vector256.Load(sub1 + 1440)), Vector256.Load(sub2 + 1440)),  dst + 1440);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1456), Vector256.Load(add1 + 1456)), Vector256.Load(sub1 + 1456)), Vector256.Load(sub2 + 1456)),  dst + 1456);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1472), Vector256.Load(add1 + 1472)), Vector256.Load(sub1 + 1472)), Vector256.Load(sub2 + 1472)),  dst + 1472);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1488), Vector256.Load(add1 + 1488)), Vector256.Load(sub1 + 1488)), Vector256.Load(sub2 + 1488)),  dst + 1488);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1504), Vector256.Load(add1 + 1504)), Vector256.Load(sub1 + 1504)), Vector256.Load(sub2 + 1504)),  dst + 1504);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Load(src + 1520), Vector256.Load(add1 + 1520)), Vector256.Load(sub1 + 1520)), Vector256.Load(sub2 + 1520)),  dst + 1520);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 32 * N), VectorT.Load(add1 + 32 * N)), VectorT.Load(sub1 + 32 * N)), VectorT.Load(sub2 + 32 * N)), dst + 32 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 33 * N), VectorT.Load(add1 + 33 * N)), VectorT.Load(sub1 + 33 * N)), VectorT.Load(sub2 + 33 * N)), dst + 33 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 34 * N), VectorT.Load(add1 + 34 * N)), VectorT.Load(sub1 + 34 * N)), VectorT.Load(sub2 + 34 * N)), dst + 34 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 35 * N), VectorT.Load(add1 + 35 * N)), VectorT.Load(sub1 + 35 * N)), VectorT.Load(sub2 + 35 * N)), dst + 35 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 36 * N), VectorT.Load(add1 + 36 * N)), VectorT.Load(sub1 + 36 * N)), VectorT.Load(sub2 + 36 * N)), dst + 36 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 37 * N), VectorT.Load(add1 + 37 * N)), VectorT.Load(sub1 + 37 * N)), VectorT.Load(sub2 + 37 * N)), dst + 37 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 38 * N), VectorT.Load(add1 + 38 * N)), VectorT.Load(sub1 + 38 * N)), VectorT.Load(sub2 + 38 * N)), dst + 38 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 39 * N), VectorT.Load(add1 + 39 * N)), VectorT.Load(sub1 + 39 * N)), VectorT.Load(sub2 + 39 * N)), dst + 39 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 40 * N), VectorT.Load(add1 + 40 * N)), VectorT.Load(sub1 + 40 * N)), VectorT.Load(sub2 + 40 * N)), dst + 40 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 41 * N), VectorT.Load(add1 + 41 * N)), VectorT.Load(sub1 + 41 * N)), VectorT.Load(sub2 + 41 * N)), dst + 41 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 42 * N), VectorT.Load(add1 + 42 * N)), VectorT.Load(sub1 + 42 * N)), VectorT.Load(sub2 + 42 * N)), dst + 42 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 43 * N), VectorT.Load(add1 + 43 * N)), VectorT.Load(sub1 + 43 * N)), VectorT.Load(sub2 + 43 * N)), dst + 43 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 44 * N), VectorT.Load(add1 + 44 * N)), VectorT.Load(sub1 + 44 * N)), VectorT.Load(sub2 + 44 * N)), dst + 44 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 45 * N), VectorT.Load(add1 + 45 * N)), VectorT.Load(sub1 + 45 * N)), VectorT.Load(sub2 + 45 * N)), dst + 45 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 46 * N), VectorT.Load(add1 + 46 * N)), VectorT.Load(sub1 + 46 * N)), VectorT.Load(sub2 + 46 * N)), dst + 46 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 47 * N), VectorT.Load(add1 + 47 * N)), VectorT.Load(sub1 + 47 * N)), VectorT.Load(sub2 + 47 * N)), dst + 47 * N);
+
+            if (StopBefore == AVX512_1536HL)
+                return;
+
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 48 * N), VectorT.Load(add1 + 48 * N)), VectorT.Load(sub1 + 48 * N)), VectorT.Load(sub2 + 48 * N)), dst + 48 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 49 * N), VectorT.Load(add1 + 49 * N)), VectorT.Load(sub1 + 49 * N)), VectorT.Load(sub2 + 49 * N)), dst + 49 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 50 * N), VectorT.Load(add1 + 50 * N)), VectorT.Load(sub1 + 50 * N)), VectorT.Load(sub2 + 50 * N)), dst + 50 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 51 * N), VectorT.Load(add1 + 51 * N)), VectorT.Load(sub1 + 51 * N)), VectorT.Load(sub2 + 51 * N)), dst + 51 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 52 * N), VectorT.Load(add1 + 52 * N)), VectorT.Load(sub1 + 52 * N)), VectorT.Load(sub2 + 52 * N)), dst + 52 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 53 * N), VectorT.Load(add1 + 53 * N)), VectorT.Load(sub1 + 53 * N)), VectorT.Load(sub2 + 53 * N)), dst + 53 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 54 * N), VectorT.Load(add1 + 54 * N)), VectorT.Load(sub1 + 54 * N)), VectorT.Load(sub2 + 54 * N)), dst + 54 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 55 * N), VectorT.Load(add1 + 55 * N)), VectorT.Load(sub1 + 55 * N)), VectorT.Load(sub2 + 55 * N)), dst + 55 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 56 * N), VectorT.Load(add1 + 56 * N)), VectorT.Load(sub1 + 56 * N)), VectorT.Load(sub2 + 56 * N)), dst + 56 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 57 * N), VectorT.Load(add1 + 57 * N)), VectorT.Load(sub1 + 57 * N)), VectorT.Load(sub2 + 57 * N)), dst + 57 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 58 * N), VectorT.Load(add1 + 58 * N)), VectorT.Load(sub1 + 58 * N)), VectorT.Load(sub2 + 58 * N)), dst + 58 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 59 * N), VectorT.Load(add1 + 59 * N)), VectorT.Load(sub1 + 59 * N)), VectorT.Load(sub2 + 59 * N)), dst + 59 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 60 * N), VectorT.Load(add1 + 60 * N)), VectorT.Load(sub1 + 60 * N)), VectorT.Load(sub2 + 60 * N)), dst + 60 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 61 * N), VectorT.Load(add1 + 61 * N)), VectorT.Load(sub1 + 61 * N)), VectorT.Load(sub2 + 61 * N)), dst + 61 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 62 * N), VectorT.Load(add1 + 62 * N)), VectorT.Load(sub1 + 62 * N)), VectorT.Load(sub2 + 62 * N)), dst + 62 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 63 * N), VectorT.Load(add1 + 63 * N)), VectorT.Load(sub1 + 63 * N)), VectorT.Load(sub2 + 63 * N)), dst + 63 * N);
+
+            if (StopBefore == AVX256_1024HL)
+                return;
+
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 64 * N), VectorT.Load(add1 + 64 * N)), VectorT.Load(sub1 + 64 * N)), VectorT.Load(sub2 + 64 * N)), dst + 64 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 65 * N), VectorT.Load(add1 + 65 * N)), VectorT.Load(sub1 + 65 * N)), VectorT.Load(sub2 + 65 * N)), dst + 65 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 66 * N), VectorT.Load(add1 + 66 * N)), VectorT.Load(sub1 + 66 * N)), VectorT.Load(sub2 + 66 * N)), dst + 66 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 67 * N), VectorT.Load(add1 + 67 * N)), VectorT.Load(sub1 + 67 * N)), VectorT.Load(sub2 + 67 * N)), dst + 67 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 68 * N), VectorT.Load(add1 + 68 * N)), VectorT.Load(sub1 + 68 * N)), VectorT.Load(sub2 + 68 * N)), dst + 68 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 69 * N), VectorT.Load(add1 + 69 * N)), VectorT.Load(sub1 + 69 * N)), VectorT.Load(sub2 + 69 * N)), dst + 69 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 70 * N), VectorT.Load(add1 + 70 * N)), VectorT.Load(sub1 + 70 * N)), VectorT.Load(sub2 + 70 * N)), dst + 70 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 71 * N), VectorT.Load(add1 + 71 * N)), VectorT.Load(sub1 + 71 * N)), VectorT.Load(sub2 + 71 * N)), dst + 71 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 72 * N), VectorT.Load(add1 + 72 * N)), VectorT.Load(sub1 + 72 * N)), VectorT.Load(sub2 + 72 * N)), dst + 72 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 73 * N), VectorT.Load(add1 + 73 * N)), VectorT.Load(sub1 + 73 * N)), VectorT.Load(sub2 + 73 * N)), dst + 73 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 74 * N), VectorT.Load(add1 + 74 * N)), VectorT.Load(sub1 + 74 * N)), VectorT.Load(sub2 + 74 * N)), dst + 74 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 75 * N), VectorT.Load(add1 + 75 * N)), VectorT.Load(sub1 + 75 * N)), VectorT.Load(sub2 + 75 * N)), dst + 75 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 76 * N), VectorT.Load(add1 + 76 * N)), VectorT.Load(sub1 + 76 * N)), VectorT.Load(sub2 + 76 * N)), dst + 76 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 77 * N), VectorT.Load(add1 + 77 * N)), VectorT.Load(sub1 + 77 * N)), VectorT.Load(sub2 + 77 * N)), dst + 77 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 78 * N), VectorT.Load(add1 + 78 * N)), VectorT.Load(sub1 + 78 * N)), VectorT.Load(sub2 + 78 * N)), dst + 78 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 79 * N), VectorT.Load(add1 + 79 * N)), VectorT.Load(sub1 + 79 * N)), VectorT.Load(sub2 + 79 * N)), dst + 79 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 80 * N), VectorT.Load(add1 + 80 * N)), VectorT.Load(sub1 + 80 * N)), VectorT.Load(sub2 + 80 * N)), dst + 80 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 81 * N), VectorT.Load(add1 + 81 * N)), VectorT.Load(sub1 + 81 * N)), VectorT.Load(sub2 + 81 * N)), dst + 81 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 82 * N), VectorT.Load(add1 + 82 * N)), VectorT.Load(sub1 + 82 * N)), VectorT.Load(sub2 + 82 * N)), dst + 82 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 83 * N), VectorT.Load(add1 + 83 * N)), VectorT.Load(sub1 + 83 * N)), VectorT.Load(sub2 + 83 * N)), dst + 83 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 84 * N), VectorT.Load(add1 + 84 * N)), VectorT.Load(sub1 + 84 * N)), VectorT.Load(sub2 + 84 * N)), dst + 84 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 85 * N), VectorT.Load(add1 + 85 * N)), VectorT.Load(sub1 + 85 * N)), VectorT.Load(sub2 + 85 * N)), dst + 85 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 86 * N), VectorT.Load(add1 + 86 * N)), VectorT.Load(sub1 + 86 * N)), VectorT.Load(sub2 + 86 * N)), dst + 86 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 87 * N), VectorT.Load(add1 + 87 * N)), VectorT.Load(sub1 + 87 * N)), VectorT.Load(sub2 + 87 * N)), dst + 87 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 88 * N), VectorT.Load(add1 + 88 * N)), VectorT.Load(sub1 + 88 * N)), VectorT.Load(sub2 + 88 * N)), dst + 88 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 89 * N), VectorT.Load(add1 + 89 * N)), VectorT.Load(sub1 + 89 * N)), VectorT.Load(sub2 + 89 * N)), dst + 89 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 90 * N), VectorT.Load(add1 + 90 * N)), VectorT.Load(sub1 + 90 * N)), VectorT.Load(sub2 + 90 * N)), dst + 90 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 91 * N), VectorT.Load(add1 + 91 * N)), VectorT.Load(sub1 + 91 * N)), VectorT.Load(sub2 + 91 * N)), dst + 91 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 92 * N), VectorT.Load(add1 + 92 * N)), VectorT.Load(sub1 + 92 * N)), VectorT.Load(sub2 + 92 * N)), dst + 92 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 93 * N), VectorT.Load(add1 + 93 * N)), VectorT.Load(sub1 + 93 * N)), VectorT.Load(sub2 + 93 * N)), dst + 93 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 94 * N), VectorT.Load(add1 + 94 * N)), VectorT.Load(sub1 + 94 * N)), VectorT.Load(sub2 + 94 * N)), dst + 94 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Load(src + 95 * N), VectorT.Load(add1 + 95 * N)), VectorT.Load(sub1 + 95 * N)), VectorT.Load(sub2 + 95 * N)), dst + 95 * N);
+
         }
 
 
         public static void SubSubAddAdd(short* src, short* dst, short* sub1, short* sub2, short* add1, short* add2)
         {
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 0), Vector256.Load(add1 + 0)), Vector256.Load(add2 + 0)), Vector256.Load(sub1 + 0)), Vector256.Load(sub2 + 0)), dst + 0);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 16), Vector256.Load(add1 + 16)), Vector256.Load(add2 + 16)), Vector256.Load(sub1 + 16)), Vector256.Load(sub2 + 16)), dst + 16);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 32), Vector256.Load(add1 + 32)), Vector256.Load(add2 + 32)), Vector256.Load(sub1 + 32)), Vector256.Load(sub2 + 32)), dst + 32);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 48), Vector256.Load(add1 + 48)), Vector256.Load(add2 + 48)), Vector256.Load(sub1 + 48)), Vector256.Load(sub2 + 48)), dst + 48);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 64), Vector256.Load(add1 + 64)), Vector256.Load(add2 + 64)), Vector256.Load(sub1 + 64)), Vector256.Load(sub2 + 64)), dst + 64);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 80), Vector256.Load(add1 + 80)), Vector256.Load(add2 + 80)), Vector256.Load(sub1 + 80)), Vector256.Load(sub2 + 80)), dst + 80);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 96), Vector256.Load(add1 + 96)), Vector256.Load(add2 + 96)), Vector256.Load(sub1 + 96)), Vector256.Load(sub2 + 96)), dst + 96);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 112), Vector256.Load(add1 + 112)), Vector256.Load(add2 + 112)), Vector256.Load(sub1 + 112)), Vector256.Load(sub2 + 112)), dst + 112);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 128), Vector256.Load(add1 + 128)), Vector256.Load(add2 + 128)), Vector256.Load(sub1 + 128)), Vector256.Load(sub2 + 128)), dst + 128);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 144), Vector256.Load(add1 + 144)), Vector256.Load(add2 + 144)), Vector256.Load(sub1 + 144)), Vector256.Load(sub2 + 144)), dst + 144);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 160), Vector256.Load(add1 + 160)), Vector256.Load(add2 + 160)), Vector256.Load(sub1 + 160)), Vector256.Load(sub2 + 160)), dst + 160);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 176), Vector256.Load(add1 + 176)), Vector256.Load(add2 + 176)), Vector256.Load(sub1 + 176)), Vector256.Load(sub2 + 176)), dst + 176);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 192), Vector256.Load(add1 + 192)), Vector256.Load(add2 + 192)), Vector256.Load(sub1 + 192)), Vector256.Load(sub2 + 192)), dst + 192);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 208), Vector256.Load(add1 + 208)), Vector256.Load(add2 + 208)), Vector256.Load(sub1 + 208)), Vector256.Load(sub2 + 208)), dst + 208);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 224), Vector256.Load(add1 + 224)), Vector256.Load(add2 + 224)), Vector256.Load(sub1 + 224)), Vector256.Load(sub2 + 224)), dst + 224);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 240), Vector256.Load(add1 + 240)), Vector256.Load(add2 + 240)), Vector256.Load(sub1 + 240)), Vector256.Load(sub2 + 240)), dst + 240);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 256), Vector256.Load(add1 + 256)), Vector256.Load(add2 + 256)), Vector256.Load(sub1 + 256)), Vector256.Load(sub2 + 256)), dst + 256);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 272), Vector256.Load(add1 + 272)), Vector256.Load(add2 + 272)), Vector256.Load(sub1 + 272)), Vector256.Load(sub2 + 272)), dst + 272);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 288), Vector256.Load(add1 + 288)), Vector256.Load(add2 + 288)), Vector256.Load(sub1 + 288)), Vector256.Load(sub2 + 288)), dst + 288);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 304), Vector256.Load(add1 + 304)), Vector256.Load(add2 + 304)), Vector256.Load(sub1 + 304)), Vector256.Load(sub2 + 304)), dst + 304);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 320), Vector256.Load(add1 + 320)), Vector256.Load(add2 + 320)), Vector256.Load(sub1 + 320)), Vector256.Load(sub2 + 320)), dst + 320);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 336), Vector256.Load(add1 + 336)), Vector256.Load(add2 + 336)), Vector256.Load(sub1 + 336)), Vector256.Load(sub2 + 336)), dst + 336);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 352), Vector256.Load(add1 + 352)), Vector256.Load(add2 + 352)), Vector256.Load(sub1 + 352)), Vector256.Load(sub2 + 352)), dst + 352);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 368), Vector256.Load(add1 + 368)), Vector256.Load(add2 + 368)), Vector256.Load(sub1 + 368)), Vector256.Load(sub2 + 368)), dst + 368);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 384), Vector256.Load(add1 + 384)), Vector256.Load(add2 + 384)), Vector256.Load(sub1 + 384)), Vector256.Load(sub2 + 384)), dst + 384);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 400), Vector256.Load(add1 + 400)), Vector256.Load(add2 + 400)), Vector256.Load(sub1 + 400)), Vector256.Load(sub2 + 400)), dst + 400);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 416), Vector256.Load(add1 + 416)), Vector256.Load(add2 + 416)), Vector256.Load(sub1 + 416)), Vector256.Load(sub2 + 416)), dst + 416);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 432), Vector256.Load(add1 + 432)), Vector256.Load(add2 + 432)), Vector256.Load(sub1 + 432)), Vector256.Load(sub2 + 432)), dst + 432);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 448), Vector256.Load(add1 + 448)), Vector256.Load(add2 + 448)), Vector256.Load(sub1 + 448)), Vector256.Load(sub2 + 448)), dst + 448);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 464), Vector256.Load(add1 + 464)), Vector256.Load(add2 + 464)), Vector256.Load(sub1 + 464)), Vector256.Load(sub2 + 464)), dst + 464);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 480), Vector256.Load(add1 + 480)), Vector256.Load(add2 + 480)), Vector256.Load(sub1 + 480)), Vector256.Load(sub2 + 480)), dst + 480);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 496), Vector256.Load(add1 + 496)), Vector256.Load(add2 + 496)), Vector256.Load(sub1 + 496)), Vector256.Load(sub2 + 496)), dst + 496);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 512), Vector256.Load(add1 + 512)), Vector256.Load(add2 + 512)), Vector256.Load(sub1 + 512)), Vector256.Load(sub2 + 512)), dst + 512);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 528), Vector256.Load(add1 + 528)), Vector256.Load(add2 + 528)), Vector256.Load(sub1 + 528)), Vector256.Load(sub2 + 528)), dst + 528);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 544), Vector256.Load(add1 + 544)), Vector256.Load(add2 + 544)), Vector256.Load(sub1 + 544)), Vector256.Load(sub2 + 544)), dst + 544);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 560), Vector256.Load(add1 + 560)), Vector256.Load(add2 + 560)), Vector256.Load(sub1 + 560)), Vector256.Load(sub2 + 560)), dst + 560);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 576), Vector256.Load(add1 + 576)), Vector256.Load(add2 + 576)), Vector256.Load(sub1 + 576)), Vector256.Load(sub2 + 576)), dst + 576);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 592), Vector256.Load(add1 + 592)), Vector256.Load(add2 + 592)), Vector256.Load(sub1 + 592)), Vector256.Load(sub2 + 592)), dst + 592);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 608), Vector256.Load(add1 + 608)), Vector256.Load(add2 + 608)), Vector256.Load(sub1 + 608)), Vector256.Load(sub2 + 608)), dst + 608);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 624), Vector256.Load(add1 + 624)), Vector256.Load(add2 + 624)), Vector256.Load(sub1 + 624)), Vector256.Load(sub2 + 624)), dst + 624);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 640), Vector256.Load(add1 + 640)), Vector256.Load(add2 + 640)), Vector256.Load(sub1 + 640)), Vector256.Load(sub2 + 640)), dst + 640);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 656), Vector256.Load(add1 + 656)), Vector256.Load(add2 + 656)), Vector256.Load(sub1 + 656)), Vector256.Load(sub2 + 656)), dst + 656);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 672), Vector256.Load(add1 + 672)), Vector256.Load(add2 + 672)), Vector256.Load(sub1 + 672)), Vector256.Load(sub2 + 672)), dst + 672);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 688), Vector256.Load(add1 + 688)), Vector256.Load(add2 + 688)), Vector256.Load(sub1 + 688)), Vector256.Load(sub2 + 688)), dst + 688);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 704), Vector256.Load(add1 + 704)), Vector256.Load(add2 + 704)), Vector256.Load(sub1 + 704)), Vector256.Load(sub2 + 704)), dst + 704);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 720), Vector256.Load(add1 + 720)), Vector256.Load(add2 + 720)), Vector256.Load(sub1 + 720)), Vector256.Load(sub2 + 720)), dst + 720);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 736), Vector256.Load(add1 + 736)), Vector256.Load(add2 + 736)), Vector256.Load(sub1 + 736)), Vector256.Load(sub2 + 736)), dst + 736);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 752), Vector256.Load(add1 + 752)), Vector256.Load(add2 + 752)), Vector256.Load(sub1 + 752)), Vector256.Load(sub2 + 752)), dst + 752);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 768), Vector256.Load(add1 + 768)), Vector256.Load(add2 + 768)), Vector256.Load(sub1 + 768)), Vector256.Load(sub2 + 768)), dst + 768);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 784), Vector256.Load(add1 + 784)), Vector256.Load(add2 + 784)), Vector256.Load(sub1 + 784)), Vector256.Load(sub2 + 784)), dst + 784);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 800), Vector256.Load(add1 + 800)), Vector256.Load(add2 + 800)), Vector256.Load(sub1 + 800)), Vector256.Load(sub2 + 800)), dst + 800);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 816), Vector256.Load(add1 + 816)), Vector256.Load(add2 + 816)), Vector256.Load(sub1 + 816)), Vector256.Load(sub2 + 816)), dst + 816);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 832), Vector256.Load(add1 + 832)), Vector256.Load(add2 + 832)), Vector256.Load(sub1 + 832)), Vector256.Load(sub2 + 832)), dst + 832);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 848), Vector256.Load(add1 + 848)), Vector256.Load(add2 + 848)), Vector256.Load(sub1 + 848)), Vector256.Load(sub2 + 848)), dst + 848);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 864), Vector256.Load(add1 + 864)), Vector256.Load(add2 + 864)), Vector256.Load(sub1 + 864)), Vector256.Load(sub2 + 864)), dst + 864);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 880), Vector256.Load(add1 + 880)), Vector256.Load(add2 + 880)), Vector256.Load(sub1 + 880)), Vector256.Load(sub2 + 880)), dst + 880);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 896), Vector256.Load(add1 + 896)), Vector256.Load(add2 + 896)), Vector256.Load(sub1 + 896)), Vector256.Load(sub2 + 896)), dst + 896);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 912), Vector256.Load(add1 + 912)), Vector256.Load(add2 + 912)), Vector256.Load(sub1 + 912)), Vector256.Load(sub2 + 912)), dst + 912);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 928), Vector256.Load(add1 + 928)), Vector256.Load(add2 + 928)), Vector256.Load(sub1 + 928)), Vector256.Load(sub2 + 928)), dst + 928);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 944), Vector256.Load(add1 + 944)), Vector256.Load(add2 + 944)), Vector256.Load(sub1 + 944)), Vector256.Load(sub2 + 944)), dst + 944);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 960), Vector256.Load(add1 + 960)), Vector256.Load(add2 + 960)), Vector256.Load(sub1 + 960)), Vector256.Load(sub2 + 960)), dst + 960);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 976), Vector256.Load(add1 + 976)), Vector256.Load(add2 + 976)), Vector256.Load(sub1 + 976)), Vector256.Load(sub2 + 976)), dst + 976);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 992), Vector256.Load(add1 + 992)), Vector256.Load(add2 + 992)), Vector256.Load(sub1 + 992)), Vector256.Load(sub2 + 992)), dst + 992);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1008), Vector256.Load(add1 + 1008)), Vector256.Load(add2 + 1008)), Vector256.Load(sub1 + 1008)), Vector256.Load(sub2 + 1008)), dst + 1008);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 0 * N), VectorT.Load(add1 + 0 * N)), VectorT.Load(add2 + 0 * N)), VectorT.Load(sub1 + 0 * N)), VectorT.Load(sub2 + 0 * N)), dst + 0 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 1 * N), VectorT.Load(add1 + 1 * N)), VectorT.Load(add2 + 1 * N)), VectorT.Load(sub1 + 1 * N)), VectorT.Load(sub2 + 1 * N)), dst + 1 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 2 * N), VectorT.Load(add1 + 2 * N)), VectorT.Load(add2 + 2 * N)), VectorT.Load(sub1 + 2 * N)), VectorT.Load(sub2 + 2 * N)), dst + 2 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 3 * N), VectorT.Load(add1 + 3 * N)), VectorT.Load(add2 + 3 * N)), VectorT.Load(sub1 + 3 * N)), VectorT.Load(sub2 + 3 * N)), dst + 3 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 4 * N), VectorT.Load(add1 + 4 * N)), VectorT.Load(add2 + 4 * N)), VectorT.Load(sub1 + 4 * N)), VectorT.Load(sub2 + 4 * N)), dst + 4 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 5 * N), VectorT.Load(add1 + 5 * N)), VectorT.Load(add2 + 5 * N)), VectorT.Load(sub1 + 5 * N)), VectorT.Load(sub2 + 5 * N)), dst + 5 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 6 * N), VectorT.Load(add1 + 6 * N)), VectorT.Load(add2 + 6 * N)), VectorT.Load(sub1 + 6 * N)), VectorT.Load(sub2 + 6 * N)), dst + 6 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 7 * N), VectorT.Load(add1 + 7 * N)), VectorT.Load(add2 + 7 * N)), VectorT.Load(sub1 + 7 * N)), VectorT.Load(sub2 + 7 * N)), dst + 7 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 8 * N), VectorT.Load(add1 + 8 * N)), VectorT.Load(add2 + 8 * N)), VectorT.Load(sub1 + 8 * N)), VectorT.Load(sub2 + 8 * N)), dst + 8 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 9 * N), VectorT.Load(add1 + 9 * N)), VectorT.Load(add2 + 9 * N)), VectorT.Load(sub1 + 9 * N)), VectorT.Load(sub2 + 9 * N)), dst + 9 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 10 * N), VectorT.Load(add1 + 10 * N)), VectorT.Load(add2 + 10 * N)), VectorT.Load(sub1 + 10 * N)), VectorT.Load(sub2 + 10 * N)), dst + 10 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 11 * N), VectorT.Load(add1 + 11 * N)), VectorT.Load(add2 + 11 * N)), VectorT.Load(sub1 + 11 * N)), VectorT.Load(sub2 + 11 * N)), dst + 11 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 12 * N), VectorT.Load(add1 + 12 * N)), VectorT.Load(add2 + 12 * N)), VectorT.Load(sub1 + 12 * N)), VectorT.Load(sub2 + 12 * N)), dst + 12 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 13 * N), VectorT.Load(add1 + 13 * N)), VectorT.Load(add2 + 13 * N)), VectorT.Load(sub1 + 13 * N)), VectorT.Load(sub2 + 13 * N)), dst + 13 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 14 * N), VectorT.Load(add1 + 14 * N)), VectorT.Load(add2 + 14 * N)), VectorT.Load(sub1 + 14 * N)), VectorT.Load(sub2 + 14 * N)), dst + 14 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 15 * N), VectorT.Load(add1 + 15 * N)), VectorT.Load(add2 + 15 * N)), VectorT.Load(sub1 + 15 * N)), VectorT.Load(sub2 + 15 * N)), dst + 15 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 16 * N), VectorT.Load(add1 + 16 * N)), VectorT.Load(add2 + 16 * N)), VectorT.Load(sub1 + 16 * N)), VectorT.Load(sub2 + 16 * N)), dst + 16 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 17 * N), VectorT.Load(add1 + 17 * N)), VectorT.Load(add2 + 17 * N)), VectorT.Load(sub1 + 17 * N)), VectorT.Load(sub2 + 17 * N)), dst + 17 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 18 * N), VectorT.Load(add1 + 18 * N)), VectorT.Load(add2 + 18 * N)), VectorT.Load(sub1 + 18 * N)), VectorT.Load(sub2 + 18 * N)), dst + 18 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 19 * N), VectorT.Load(add1 + 19 * N)), VectorT.Load(add2 + 19 * N)), VectorT.Load(sub1 + 19 * N)), VectorT.Load(sub2 + 19 * N)), dst + 19 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 20 * N), VectorT.Load(add1 + 20 * N)), VectorT.Load(add2 + 20 * N)), VectorT.Load(sub1 + 20 * N)), VectorT.Load(sub2 + 20 * N)), dst + 20 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 21 * N), VectorT.Load(add1 + 21 * N)), VectorT.Load(add2 + 21 * N)), VectorT.Load(sub1 + 21 * N)), VectorT.Load(sub2 + 21 * N)), dst + 21 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 22 * N), VectorT.Load(add1 + 22 * N)), VectorT.Load(add2 + 22 * N)), VectorT.Load(sub1 + 22 * N)), VectorT.Load(sub2 + 22 * N)), dst + 22 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 23 * N), VectorT.Load(add1 + 23 * N)), VectorT.Load(add2 + 23 * N)), VectorT.Load(sub1 + 23 * N)), VectorT.Load(sub2 + 23 * N)), dst + 23 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 24 * N), VectorT.Load(add1 + 24 * N)), VectorT.Load(add2 + 24 * N)), VectorT.Load(sub1 + 24 * N)), VectorT.Load(sub2 + 24 * N)), dst + 24 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 25 * N), VectorT.Load(add1 + 25 * N)), VectorT.Load(add2 + 25 * N)), VectorT.Load(sub1 + 25 * N)), VectorT.Load(sub2 + 25 * N)), dst + 25 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 26 * N), VectorT.Load(add1 + 26 * N)), VectorT.Load(add2 + 26 * N)), VectorT.Load(sub1 + 26 * N)), VectorT.Load(sub2 + 26 * N)), dst + 26 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 27 * N), VectorT.Load(add1 + 27 * N)), VectorT.Load(add2 + 27 * N)), VectorT.Load(sub1 + 27 * N)), VectorT.Load(sub2 + 27 * N)), dst + 27 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 28 * N), VectorT.Load(add1 + 28 * N)), VectorT.Load(add2 + 28 * N)), VectorT.Load(sub1 + 28 * N)), VectorT.Load(sub2 + 28 * N)), dst + 28 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 29 * N), VectorT.Load(add1 + 29 * N)), VectorT.Load(add2 + 29 * N)), VectorT.Load(sub1 + 29 * N)), VectorT.Load(sub2 + 29 * N)), dst + 29 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 30 * N), VectorT.Load(add1 + 30 * N)), VectorT.Load(add2 + 30 * N)), VectorT.Load(sub1 + 30 * N)), VectorT.Load(sub2 + 30 * N)), dst + 30 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 31 * N), VectorT.Load(add1 + 31 * N)), VectorT.Load(add2 + 31 * N)), VectorT.Load(sub1 + 31 * N)), VectorT.Load(sub2 + 31 * N)), dst + 31 * N);
 
-            if (NNUE.NetArch == NetworkArchitecture.Simple768 && Simple768.HiddenSize <= 1024 ||
-                NNUE.NetArch == NetworkArchitecture.Bucketed768 && Bucketed768.HiddenSize <= 1024)
+            if (StopBefore == AVX512_1024HL)
                 return;
 
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1024), Vector256.Load(add1 + 1024)), Vector256.Load(add2 + 1024)), Vector256.Load(sub1 + 1024)), Vector256.Load(sub2 + 1024)), dst + 1024);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1040), Vector256.Load(add1 + 1040)), Vector256.Load(add2 + 1040)), Vector256.Load(sub1 + 1040)), Vector256.Load(sub2 + 1040)), dst + 1040);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1056), Vector256.Load(add1 + 1056)), Vector256.Load(add2 + 1056)), Vector256.Load(sub1 + 1056)), Vector256.Load(sub2 + 1056)), dst + 1056);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1072), Vector256.Load(add1 + 1072)), Vector256.Load(add2 + 1072)), Vector256.Load(sub1 + 1072)), Vector256.Load(sub2 + 1072)), dst + 1072);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1088), Vector256.Load(add1 + 1088)), Vector256.Load(add2 + 1088)), Vector256.Load(sub1 + 1088)), Vector256.Load(sub2 + 1088)), dst + 1088);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1104), Vector256.Load(add1 + 1104)), Vector256.Load(add2 + 1104)), Vector256.Load(sub1 + 1104)), Vector256.Load(sub2 + 1104)), dst + 1104);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1120), Vector256.Load(add1 + 1120)), Vector256.Load(add2 + 1120)), Vector256.Load(sub1 + 1120)), Vector256.Load(sub2 + 1120)), dst + 1120);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1136), Vector256.Load(add1 + 1136)), Vector256.Load(add2 + 1136)), Vector256.Load(sub1 + 1136)), Vector256.Load(sub2 + 1136)), dst + 1136);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1152), Vector256.Load(add1 + 1152)), Vector256.Load(add2 + 1152)), Vector256.Load(sub1 + 1152)), Vector256.Load(sub2 + 1152)), dst + 1152);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1168), Vector256.Load(add1 + 1168)), Vector256.Load(add2 + 1168)), Vector256.Load(sub1 + 1168)), Vector256.Load(sub2 + 1168)), dst + 1168);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1184), Vector256.Load(add1 + 1184)), Vector256.Load(add2 + 1184)), Vector256.Load(sub1 + 1184)), Vector256.Load(sub2 + 1184)), dst + 1184);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1200), Vector256.Load(add1 + 1200)), Vector256.Load(add2 + 1200)), Vector256.Load(sub1 + 1200)), Vector256.Load(sub2 + 1200)), dst + 1200);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1216), Vector256.Load(add1 + 1216)), Vector256.Load(add2 + 1216)), Vector256.Load(sub1 + 1216)), Vector256.Load(sub2 + 1216)), dst + 1216);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1232), Vector256.Load(add1 + 1232)), Vector256.Load(add2 + 1232)), Vector256.Load(sub1 + 1232)), Vector256.Load(sub2 + 1232)), dst + 1232);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1248), Vector256.Load(add1 + 1248)), Vector256.Load(add2 + 1248)), Vector256.Load(sub1 + 1248)), Vector256.Load(sub2 + 1248)), dst + 1248);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1264), Vector256.Load(add1 + 1264)), Vector256.Load(add2 + 1264)), Vector256.Load(sub1 + 1264)), Vector256.Load(sub2 + 1264)), dst + 1264);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1280), Vector256.Load(add1 + 1280)), Vector256.Load(add2 + 1280)), Vector256.Load(sub1 + 1280)), Vector256.Load(sub2 + 1280)), dst + 1280);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1296), Vector256.Load(add1 + 1296)), Vector256.Load(add2 + 1296)), Vector256.Load(sub1 + 1296)), Vector256.Load(sub2 + 1296)), dst + 1296);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1312), Vector256.Load(add1 + 1312)), Vector256.Load(add2 + 1312)), Vector256.Load(sub1 + 1312)), Vector256.Load(sub2 + 1312)), dst + 1312);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1328), Vector256.Load(add1 + 1328)), Vector256.Load(add2 + 1328)), Vector256.Load(sub1 + 1328)), Vector256.Load(sub2 + 1328)), dst + 1328);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1344), Vector256.Load(add1 + 1344)), Vector256.Load(add2 + 1344)), Vector256.Load(sub1 + 1344)), Vector256.Load(sub2 + 1344)), dst + 1344);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1360), Vector256.Load(add1 + 1360)), Vector256.Load(add2 + 1360)), Vector256.Load(sub1 + 1360)), Vector256.Load(sub2 + 1360)), dst + 1360);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1376), Vector256.Load(add1 + 1376)), Vector256.Load(add2 + 1376)), Vector256.Load(sub1 + 1376)), Vector256.Load(sub2 + 1376)), dst + 1376);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1392), Vector256.Load(add1 + 1392)), Vector256.Load(add2 + 1392)), Vector256.Load(sub1 + 1392)), Vector256.Load(sub2 + 1392)), dst + 1392);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1408), Vector256.Load(add1 + 1408)), Vector256.Load(add2 + 1408)), Vector256.Load(sub1 + 1408)), Vector256.Load(sub2 + 1408)), dst + 1408);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1424), Vector256.Load(add1 + 1424)), Vector256.Load(add2 + 1424)), Vector256.Load(sub1 + 1424)), Vector256.Load(sub2 + 1424)), dst + 1424);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1440), Vector256.Load(add1 + 1440)), Vector256.Load(add2 + 1440)), Vector256.Load(sub1 + 1440)), Vector256.Load(sub2 + 1440)), dst + 1440);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1456), Vector256.Load(add1 + 1456)), Vector256.Load(add2 + 1456)), Vector256.Load(sub1 + 1456)), Vector256.Load(sub2 + 1456)), dst + 1456);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1472), Vector256.Load(add1 + 1472)), Vector256.Load(add2 + 1472)), Vector256.Load(sub1 + 1472)), Vector256.Load(sub2 + 1472)), dst + 1472);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1488), Vector256.Load(add1 + 1488)), Vector256.Load(add2 + 1488)), Vector256.Load(sub1 + 1488)), Vector256.Load(sub2 + 1488)), dst + 1488);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1504), Vector256.Load(add1 + 1504)), Vector256.Load(add2 + 1504)), Vector256.Load(sub1 + 1504)), Vector256.Load(sub2 + 1504)), dst + 1504);
-            Vector256.Store(Vector256.Subtract(Vector256.Subtract(Vector256.Add(Vector256.Add(Vector256.Load(src + 1520), Vector256.Load(add1 + 1520)), Vector256.Load(add2 + 1520)), Vector256.Load(sub1 + 1520)), Vector256.Load(sub2 + 1520)), dst + 1520);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 32 * N), VectorT.Load(add1 + 32 * N)), VectorT.Load(add2 + 32 * N)), VectorT.Load(sub1 + 32 * N)), VectorT.Load(sub2 + 32 * N)), dst + 32 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 33 * N), VectorT.Load(add1 + 33 * N)), VectorT.Load(add2 + 33 * N)), VectorT.Load(sub1 + 33 * N)), VectorT.Load(sub2 + 33 * N)), dst + 33 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 34 * N), VectorT.Load(add1 + 34 * N)), VectorT.Load(add2 + 34 * N)), VectorT.Load(sub1 + 34 * N)), VectorT.Load(sub2 + 34 * N)), dst + 34 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 35 * N), VectorT.Load(add1 + 35 * N)), VectorT.Load(add2 + 35 * N)), VectorT.Load(sub1 + 35 * N)), VectorT.Load(sub2 + 35 * N)), dst + 35 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 36 * N), VectorT.Load(add1 + 36 * N)), VectorT.Load(add2 + 36 * N)), VectorT.Load(sub1 + 36 * N)), VectorT.Load(sub2 + 36 * N)), dst + 36 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 37 * N), VectorT.Load(add1 + 37 * N)), VectorT.Load(add2 + 37 * N)), VectorT.Load(sub1 + 37 * N)), VectorT.Load(sub2 + 37 * N)), dst + 37 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 38 * N), VectorT.Load(add1 + 38 * N)), VectorT.Load(add2 + 38 * N)), VectorT.Load(sub1 + 38 * N)), VectorT.Load(sub2 + 38 * N)), dst + 38 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 39 * N), VectorT.Load(add1 + 39 * N)), VectorT.Load(add2 + 39 * N)), VectorT.Load(sub1 + 39 * N)), VectorT.Load(sub2 + 39 * N)), dst + 39 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 40 * N), VectorT.Load(add1 + 40 * N)), VectorT.Load(add2 + 40 * N)), VectorT.Load(sub1 + 40 * N)), VectorT.Load(sub2 + 40 * N)), dst + 40 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 41 * N), VectorT.Load(add1 + 41 * N)), VectorT.Load(add2 + 41 * N)), VectorT.Load(sub1 + 41 * N)), VectorT.Load(sub2 + 41 * N)), dst + 41 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 42 * N), VectorT.Load(add1 + 42 * N)), VectorT.Load(add2 + 42 * N)), VectorT.Load(sub1 + 42 * N)), VectorT.Load(sub2 + 42 * N)), dst + 42 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 43 * N), VectorT.Load(add1 + 43 * N)), VectorT.Load(add2 + 43 * N)), VectorT.Load(sub1 + 43 * N)), VectorT.Load(sub2 + 43 * N)), dst + 43 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 44 * N), VectorT.Load(add1 + 44 * N)), VectorT.Load(add2 + 44 * N)), VectorT.Load(sub1 + 44 * N)), VectorT.Load(sub2 + 44 * N)), dst + 44 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 45 * N), VectorT.Load(add1 + 45 * N)), VectorT.Load(add2 + 45 * N)), VectorT.Load(sub1 + 45 * N)), VectorT.Load(sub2 + 45 * N)), dst + 45 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 46 * N), VectorT.Load(add1 + 46 * N)), VectorT.Load(add2 + 46 * N)), VectorT.Load(sub1 + 46 * N)), VectorT.Load(sub2 + 46 * N)), dst + 46 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 47 * N), VectorT.Load(add1 + 47 * N)), VectorT.Load(add2 + 47 * N)), VectorT.Load(sub1 + 47 * N)), VectorT.Load(sub2 + 47 * N)), dst + 47 * N);
+
+            if (StopBefore == AVX512_1536HL)
+                return;
+
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 48 * N), VectorT.Load(add1 + 48 * N)), VectorT.Load(add2 + 48 * N)), VectorT.Load(sub1 + 48 * N)), VectorT.Load(sub2 + 48 * N)), dst + 48 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 49 * N), VectorT.Load(add1 + 49 * N)), VectorT.Load(add2 + 49 * N)), VectorT.Load(sub1 + 49 * N)), VectorT.Load(sub2 + 49 * N)), dst + 49 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 50 * N), VectorT.Load(add1 + 50 * N)), VectorT.Load(add2 + 50 * N)), VectorT.Load(sub1 + 50 * N)), VectorT.Load(sub2 + 50 * N)), dst + 50 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 51 * N), VectorT.Load(add1 + 51 * N)), VectorT.Load(add2 + 51 * N)), VectorT.Load(sub1 + 51 * N)), VectorT.Load(sub2 + 51 * N)), dst + 51 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 52 * N), VectorT.Load(add1 + 52 * N)), VectorT.Load(add2 + 52 * N)), VectorT.Load(sub1 + 52 * N)), VectorT.Load(sub2 + 52 * N)), dst + 52 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 53 * N), VectorT.Load(add1 + 53 * N)), VectorT.Load(add2 + 53 * N)), VectorT.Load(sub1 + 53 * N)), VectorT.Load(sub2 + 53 * N)), dst + 53 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 54 * N), VectorT.Load(add1 + 54 * N)), VectorT.Load(add2 + 54 * N)), VectorT.Load(sub1 + 54 * N)), VectorT.Load(sub2 + 54 * N)), dst + 54 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 55 * N), VectorT.Load(add1 + 55 * N)), VectorT.Load(add2 + 55 * N)), VectorT.Load(sub1 + 55 * N)), VectorT.Load(sub2 + 55 * N)), dst + 55 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 56 * N), VectorT.Load(add1 + 56 * N)), VectorT.Load(add2 + 56 * N)), VectorT.Load(sub1 + 56 * N)), VectorT.Load(sub2 + 56 * N)), dst + 56 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 57 * N), VectorT.Load(add1 + 57 * N)), VectorT.Load(add2 + 57 * N)), VectorT.Load(sub1 + 57 * N)), VectorT.Load(sub2 + 57 * N)), dst + 57 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 58 * N), VectorT.Load(add1 + 58 * N)), VectorT.Load(add2 + 58 * N)), VectorT.Load(sub1 + 58 * N)), VectorT.Load(sub2 + 58 * N)), dst + 58 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 59 * N), VectorT.Load(add1 + 59 * N)), VectorT.Load(add2 + 59 * N)), VectorT.Load(sub1 + 59 * N)), VectorT.Load(sub2 + 59 * N)), dst + 59 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 60 * N), VectorT.Load(add1 + 60 * N)), VectorT.Load(add2 + 60 * N)), VectorT.Load(sub1 + 60 * N)), VectorT.Load(sub2 + 60 * N)), dst + 60 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 61 * N), VectorT.Load(add1 + 61 * N)), VectorT.Load(add2 + 61 * N)), VectorT.Load(sub1 + 61 * N)), VectorT.Load(sub2 + 61 * N)), dst + 61 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 62 * N), VectorT.Load(add1 + 62 * N)), VectorT.Load(add2 + 62 * N)), VectorT.Load(sub1 + 62 * N)), VectorT.Load(sub2 + 62 * N)), dst + 62 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 63 * N), VectorT.Load(add1 + 63 * N)), VectorT.Load(add2 + 63 * N)), VectorT.Load(sub1 + 63 * N)), VectorT.Load(sub2 + 63 * N)), dst + 63 * N);
+
+            if (StopBefore == AVX256_1024HL)
+                return;
+
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 64 * N), VectorT.Load(add1 + 64 * N)), VectorT.Load(add2 + 64 * N)), VectorT.Load(sub1 + 64 * N)), VectorT.Load(sub2 + 64 * N)), dst + 64 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 65 * N), VectorT.Load(add1 + 65 * N)), VectorT.Load(add2 + 65 * N)), VectorT.Load(sub1 + 65 * N)), VectorT.Load(sub2 + 65 * N)), dst + 65 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 66 * N), VectorT.Load(add1 + 66 * N)), VectorT.Load(add2 + 66 * N)), VectorT.Load(sub1 + 66 * N)), VectorT.Load(sub2 + 66 * N)), dst + 66 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 67 * N), VectorT.Load(add1 + 67 * N)), VectorT.Load(add2 + 67 * N)), VectorT.Load(sub1 + 67 * N)), VectorT.Load(sub2 + 67 * N)), dst + 67 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 68 * N), VectorT.Load(add1 + 68 * N)), VectorT.Load(add2 + 68 * N)), VectorT.Load(sub1 + 68 * N)), VectorT.Load(sub2 + 68 * N)), dst + 68 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 69 * N), VectorT.Load(add1 + 69 * N)), VectorT.Load(add2 + 69 * N)), VectorT.Load(sub1 + 69 * N)), VectorT.Load(sub2 + 69 * N)), dst + 69 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 70 * N), VectorT.Load(add1 + 70 * N)), VectorT.Load(add2 + 70 * N)), VectorT.Load(sub1 + 70 * N)), VectorT.Load(sub2 + 70 * N)), dst + 70 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 71 * N), VectorT.Load(add1 + 71 * N)), VectorT.Load(add2 + 71 * N)), VectorT.Load(sub1 + 71 * N)), VectorT.Load(sub2 + 71 * N)), dst + 71 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 72 * N), VectorT.Load(add1 + 72 * N)), VectorT.Load(add2 + 72 * N)), VectorT.Load(sub1 + 72 * N)), VectorT.Load(sub2 + 72 * N)), dst + 72 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 73 * N), VectorT.Load(add1 + 73 * N)), VectorT.Load(add2 + 73 * N)), VectorT.Load(sub1 + 73 * N)), VectorT.Load(sub2 + 73 * N)), dst + 73 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 74 * N), VectorT.Load(add1 + 74 * N)), VectorT.Load(add2 + 74 * N)), VectorT.Load(sub1 + 74 * N)), VectorT.Load(sub2 + 74 * N)), dst + 74 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 75 * N), VectorT.Load(add1 + 75 * N)), VectorT.Load(add2 + 75 * N)), VectorT.Load(sub1 + 75 * N)), VectorT.Load(sub2 + 75 * N)), dst + 75 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 76 * N), VectorT.Load(add1 + 76 * N)), VectorT.Load(add2 + 76 * N)), VectorT.Load(sub1 + 76 * N)), VectorT.Load(sub2 + 76 * N)), dst + 76 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 77 * N), VectorT.Load(add1 + 77 * N)), VectorT.Load(add2 + 77 * N)), VectorT.Load(sub1 + 77 * N)), VectorT.Load(sub2 + 77 * N)), dst + 77 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 78 * N), VectorT.Load(add1 + 78 * N)), VectorT.Load(add2 + 78 * N)), VectorT.Load(sub1 + 78 * N)), VectorT.Load(sub2 + 78 * N)), dst + 78 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 79 * N), VectorT.Load(add1 + 79 * N)), VectorT.Load(add2 + 79 * N)), VectorT.Load(sub1 + 79 * N)), VectorT.Load(sub2 + 79 * N)), dst + 79 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 80 * N), VectorT.Load(add1 + 80 * N)), VectorT.Load(add2 + 80 * N)), VectorT.Load(sub1 + 80 * N)), VectorT.Load(sub2 + 80 * N)), dst + 80 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 81 * N), VectorT.Load(add1 + 81 * N)), VectorT.Load(add2 + 81 * N)), VectorT.Load(sub1 + 81 * N)), VectorT.Load(sub2 + 81 * N)), dst + 81 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 82 * N), VectorT.Load(add1 + 82 * N)), VectorT.Load(add2 + 82 * N)), VectorT.Load(sub1 + 82 * N)), VectorT.Load(sub2 + 82 * N)), dst + 82 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 83 * N), VectorT.Load(add1 + 83 * N)), VectorT.Load(add2 + 83 * N)), VectorT.Load(sub1 + 83 * N)), VectorT.Load(sub2 + 83 * N)), dst + 83 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 84 * N), VectorT.Load(add1 + 84 * N)), VectorT.Load(add2 + 84 * N)), VectorT.Load(sub1 + 84 * N)), VectorT.Load(sub2 + 84 * N)), dst + 84 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 85 * N), VectorT.Load(add1 + 85 * N)), VectorT.Load(add2 + 85 * N)), VectorT.Load(sub1 + 85 * N)), VectorT.Load(sub2 + 85 * N)), dst + 85 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 86 * N), VectorT.Load(add1 + 86 * N)), VectorT.Load(add2 + 86 * N)), VectorT.Load(sub1 + 86 * N)), VectorT.Load(sub2 + 86 * N)), dst + 86 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 87 * N), VectorT.Load(add1 + 87 * N)), VectorT.Load(add2 + 87 * N)), VectorT.Load(sub1 + 87 * N)), VectorT.Load(sub2 + 87 * N)), dst + 87 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 88 * N), VectorT.Load(add1 + 88 * N)), VectorT.Load(add2 + 88 * N)), VectorT.Load(sub1 + 88 * N)), VectorT.Load(sub2 + 88 * N)), dst + 88 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 89 * N), VectorT.Load(add1 + 89 * N)), VectorT.Load(add2 + 89 * N)), VectorT.Load(sub1 + 89 * N)), VectorT.Load(sub2 + 89 * N)), dst + 89 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 90 * N), VectorT.Load(add1 + 90 * N)), VectorT.Load(add2 + 90 * N)), VectorT.Load(sub1 + 90 * N)), VectorT.Load(sub2 + 90 * N)), dst + 90 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 91 * N), VectorT.Load(add1 + 91 * N)), VectorT.Load(add2 + 91 * N)), VectorT.Load(sub1 + 91 * N)), VectorT.Load(sub2 + 91 * N)), dst + 91 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 92 * N), VectorT.Load(add1 + 92 * N)), VectorT.Load(add2 + 92 * N)), VectorT.Load(sub1 + 92 * N)), VectorT.Load(sub2 + 92 * N)), dst + 92 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 93 * N), VectorT.Load(add1 + 93 * N)), VectorT.Load(add2 + 93 * N)), VectorT.Load(sub1 + 93 * N)), VectorT.Load(sub2 + 93 * N)), dst + 93 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 94 * N), VectorT.Load(add1 + 94 * N)), VectorT.Load(add2 + 94 * N)), VectorT.Load(sub1 + 94 * N)), VectorT.Load(sub2 + 94 * N)), dst + 94 * N);
+            VectorT.Store(VectorT.Subtract(VectorT.Subtract(VectorT.Add(VectorT.Add(VectorT.Load(src + 95 * N), VectorT.Load(add1 + 95 * N)), VectorT.Load(add2 + 95 * N)), VectorT.Load(sub1 + 95 * N)), VectorT.Load(sub2 + 95 * N)), dst + 95 * N);
+
         }
     }
 }

--- a/Logic/NN/Simple768.cs
+++ b/Logic/NN/Simple768.cs
@@ -22,38 +22,16 @@ namespace Lizard.Logic.NN
         public const int OutputScale = 400;
         private const bool SelectOutputBucket = (OutputBuckets != 1);
 
-        public static readonly int SIMD_CHUNKS = HiddenSize / Vector256<short>.Count;
+        private static readonly int SIMD_CHUNKS_512 = HiddenSize / Vector512<short>.Count;
+        private static readonly int SIMD_CHUNKS_256 = HiddenSize / Vector256<short>.Count;
 
         public const string NetworkName = "iguana-wiggle-epoch11.bin";
 
-        /// <summary>
-        /// The values applied according to the active features and current bucket.
-        /// <para></para>
-        /// This is the 768 -> 1536 part of the architecture.
-        /// </summary>
-        public static readonly Vector256<short>* FeatureWeights;
 
-        /// <summary>
-        /// The initial values that are placed into the accumulators.
-        /// <para></para>
-        /// When doing a full refresh, both accumulators are filled with these.
-        /// </summary>
-        public static readonly Vector256<short>* FeatureBiases;
-
-        /// <summary>
-        /// The values that are multiplied with the SCRelu-activated output from the feature transformer 
-        /// to produce the final sum.
-        /// <para></para>
-        /// This is the (1536)x2 -> 1 part.
-        /// </summary>
-        public static readonly Vector256<short>* LayerWeights;
-
-        /// <summary>
-        /// The value(s) applied to the final output.
-        /// <para></para>
-        /// There is exactly 1 bias for each output bucket, so this currently contains only 1 number (followed by 15 zeroes).
-        /// </summary>
-        public static readonly Vector256<short>* LayerBiases;
+        public static readonly short* FeatureWeights;
+        public static readonly short* FeatureBiases;
+        public static readonly short* LayerWeights;
+        public static readonly short* LayerBiases;
 
         private const int FeatureWeightElements = InputSize * HiddenSize;
         private const int FeatureBiasElements = HiddenSize;
@@ -65,11 +43,11 @@ namespace Lizard.Logic.NN
 
         static Simple768()
         {
-            FeatureWeights = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * FeatureWeightElements);
-            FeatureBiases = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * FeatureBiasElements);
+            FeatureWeights = (short*)AlignedAllocZeroed(sizeof(short) * FeatureWeightElements);
+            FeatureBiases = (short*)AlignedAllocZeroed(sizeof(short) * FeatureBiasElements);
 
-            LayerWeights = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * LayerWeightElements);
-            LayerBiases = (Vector256<short>*)AlignedAllocZeroed(sizeof(short) * (nuint)Math.Max(LayerBiasElements, VSize.Short));
+            LayerWeights = (short*)AlignedAllocZeroed(sizeof(short) * LayerWeightElements);
+            LayerBiases = (short*)AlignedAllocZeroed(sizeof(short) * (nuint)Math.Max(LayerBiasElements, VSize.Short));
 
             string networkToLoad = NetworkName;
 
@@ -106,19 +84,24 @@ namespace Lizard.Logic.NN
                 }
             }
 
-            for (int i = 0; i < FeatureWeightElements / VSize.Short; i++)
+            for (int i = 0; i < FeatureWeightElements; i++)
             {
-                FeatureWeights[i] = Vector256.Create(br.ReadInt64(), br.ReadInt64(), br.ReadInt64(), br.ReadInt64()).AsInt16();
+                FeatureWeights[i] = br.ReadInt16();
             }
 
-            for (int i = 0; i < FeatureBiasElements / VSize.Short; i++)
+            for (int i = 0; i < FeatureBiasElements; i++)
             {
-                FeatureBiases[i] = Vector256.Create(br.ReadInt64(), br.ReadInt64(), br.ReadInt64(), br.ReadInt64()).AsInt16();
+                FeatureBiases[i] = br.ReadInt16();
             }
 
-            for (int i = 0; i < LayerWeightElements / VSize.Short; i++)
+            for (int i = 0; i < LayerWeightElements; i++)
             {
-                LayerWeights[i] = Vector256.Create(br.ReadInt64(), br.ReadInt64(), br.ReadInt64(), br.ReadInt64()).AsInt16();
+                LayerWeights[i] = br.ReadInt16();
+            }
+
+            for (int i = 0; i < LayerBiasElements; i++)
+            {
+                LayerBiases[i] = br.ReadInt16();
             }
 
             if (OutputBuckets > 1)
@@ -126,24 +109,7 @@ namespace Lizard.Logic.NN
                 //  These weights are stored in column major order, but they are easier to use in row major order.
                 //  The first 8 weights in the binary file are actually the first weight for each of the 8 output buckets,
                 //  so we will transpose them so that the all of the weights for each output bucket are contiguous.
-                TransposeLayerWeights((short*)LayerWeights, HiddenSize * 2, OutputBuckets);
-            }
-
-            //  Round LayerBiasElements to the next highest multiple of VSize.Short
-            //  i.e. if LayerBiasElements is <= 15, totalBiases = 16.
-            int totalBiases = ((LayerBiasElements + VSize.Short - 1) / VSize.Short) * VSize.Short;
-
-            short[] _Biases = new short[totalBiases];
-            Array.Fill(_Biases, (short)0);
-
-            for (int i = 0; i < LayerBiasElements; i++)
-            {
-                _Biases[i] = br.ReadInt16();
-            }
-
-            for (int i = 0; i < totalBiases / VSize.Short; i++)
-            {
-                LayerBiases[i] = Vector256.Create(_Biases, (i * VSize.Short));
+                TransposeLayerWeights(LayerWeights, HiddenSize * 2, OutputBuckets);
             }
 
 #if DEBUG
@@ -162,6 +128,9 @@ namespace Lizard.Logic.NN
             ref Accumulator accumulator = ref *pos.State->Accumulator;
             ref Bitboard bb = ref pos.bb;
 
+            var w = (Vector512<short>*)accumulator.White;
+            var b = (Vector512<short>*)accumulator.Black;
+
             Unsafe.CopyBlock(accumulator.White, FeatureBiases, sizeof(short) * HiddenSize);
             Unsafe.CopyBlock(accumulator.Black, FeatureBiases, sizeof(short) * HiddenSize);
 
@@ -175,74 +144,55 @@ namespace Lizard.Logic.NN
 
                 (int wIdx, int bIdx) = FeatureIndex(pc, pt, pieceIdx);
 
-                for (int i = 0; i < SIMD_CHUNKS; i++)
+                var whiteWeights = (Vector512<short>*)(FeatureWeights + wIdx);
+                var blackWeights = (Vector512<short>*)(FeatureWeights + bIdx);
+
+                for (int i = 0; i < SIMD_CHUNKS_512; i++)
                 {
-                    accumulator.White[i] = Vector256.Add(accumulator.White[i], FeatureWeights[wIdx + i]);
-                    accumulator.Black[i] = Vector256.Add(accumulator.Black[i], FeatureWeights[bIdx + i]);
+                    w[i] = Vector512.Add(w[i], whiteWeights[i]);
+                    b[i] = Vector512.Add(b[i], blackWeights[i]);
                 }
             }
         }
 
-        public static int GetEvaluation(Position pos)
+        public static int GetEvaluationFallback(Position pos)
         {
             ref Accumulator accumulator = ref *pos.State->Accumulator;
-            Vector256<short> ClampMax = Vector256.Create((short)QA);
-            Vector256<int> normalSum = Vector256<int>.Zero;
+            Vector256<short> maxVec = Vector256.Create((short)QA);
+            Vector256<short> zeroVec = Vector256<short>.Zero;
+            Vector256<int> sum = Vector256<int>.Zero;
 
             int outputBucket = SelectOutputBucket ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
             var ourData =   (accumulator[pos.ToMove]);
             var theirData = (accumulator[Not(pos.ToMove)]);
-            var ourWeights =   (LayerWeights + (outputBucket * (SIMD_CHUNKS * 2)));
-            var theirWeights = (LayerWeights + (outputBucket * (SIMD_CHUNKS * 2)) + SIMD_CHUNKS);
+            var ourWeights =   (Vector256<short>*)(LayerWeights + (outputBucket * (HiddenSize * 2)));
+            var theirWeights = (Vector256<short>*)(LayerWeights + (outputBucket * (HiddenSize * 2)) + HiddenSize);
 
-            for (int i = 0; i < SIMD_CHUNKS; i++)
+            for (int i = 0; i < SIMD_CHUNKS_256; i++)
             {
-                //  Clamp each feature between [0, QA]
-                Vector256<short> clamp = Vector256.Min(ClampMax, Vector256.Max(Vector256<short>.Zero, ourData[i]));
-
-                //  Multiply the clamped feature by its corresponding weight.
-                //  We can do this with short values since the weights are always between [-127, 127]
-                //  (and the product will always be < short.MaxValue) so this will never overflow.
+                Vector256<short> clamp = Vector256.Min(maxVec, Vector256.Max(zeroVec, ourData[i]));
                 Vector256<short> mult = clamp * ourWeights[i];
 
-                if (UseAvx)
-                {
-                    //  We can use VPMADDWD to do the multiplication of mult and clamp, and add it to the sum.
-                    //  MADD multiplies and sums adjacent pairs of 16-bit integers into 32-bit integers, so this doesn't overflow either.
-                    normalSum = Vector256.Add(normalSum, Avx2.MultiplyAddAdjacent(mult, clamp));
-                }
-                else
-                {
-                    //  Otherwise, we can widen the values in both vectors into integers and multiply them.
-                    //  This results in an additional multiply, add, and a couple of vextracti128/vpmovsxwd for the widening
-                    (var loMult, var hiMult) = Vector256.Widen(mult);
-                    (var loClamp, var hiClamp) = Vector256.Widen(clamp);
+                (var loMult, var hiMult) = Vector256.Widen(mult);
+                (var loClamp, var hiClamp) = Vector256.Widen(clamp);
 
-                    normalSum = Vector256.Add(normalSum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
-                }
+                sum = Vector256.Add(sum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
             }
 
-            for (int i = 0; i < SIMD_CHUNKS; i++)
+            for (int i = 0; i < SIMD_CHUNKS_256; i++)
             {
-                Vector256<short> clamp = Vector256.Min(ClampMax, Vector256.Max(Vector256<short>.Zero, theirData[i]));
+                Vector256<short> clamp = Vector256.Min(maxVec, Vector256.Max(zeroVec, theirData[i]));
                 Vector256<short> mult = clamp * theirWeights[i];
 
-                if (UseAvx)
-                {
-                    normalSum = Vector256.Add(normalSum, Avx2.MultiplyAddAdjacent(mult, clamp));
-                }
-                else
-                {
-                    (var loMult, var hiMult) = Vector256.Widen(mult);
-                    (var loClamp, var hiClamp) = Vector256.Widen(clamp);
+                (var loMult, var hiMult) = Vector256.Widen(mult);
+                (var loClamp, var hiClamp) = Vector256.Widen(clamp);
 
-                    normalSum = Vector256.Add(normalSum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
-                }
+                sum = Vector256.Add(sum, Vector256.Add(loMult * loClamp, hiMult * hiClamp));
             }
 
-            int output = UseAvx ? SumVector256NoHadd(normalSum) : Vector256.Sum(normalSum);
+            int output = Vector256.Sum(sum);
 
-            return (output / QA + LayerBiases[0][outputBucket]) * OutputScale / QAB;
+            return (output / QA + LayerBiases[outputBucket]) * OutputScale / QAB;
         }
 
 
@@ -251,7 +201,7 @@ namespace Lizard.Logic.NN
             const int ColorStride = 64 * 6;
             const int PieceStride = 64;
 
-            return ((pc ^ perspective) * ColorStride + pt * PieceStride + (sq ^ perspective * 56)) * SIMD_CHUNKS;
+            return ((pc ^ perspective) * ColorStride + pt * PieceStride + (sq ^ perspective * 56)) * HiddenSize;
         }
 
 
@@ -264,7 +214,7 @@ namespace Lizard.Logic.NN
             int whiteIndex = pc * ColorStride + pt * PieceStride + sq;
             int blackIndex = Not(pc) * ColorStride + pt * PieceStride + (sq ^ 56);
 
-            return (whiteIndex * SIMD_CHUNKS, blackIndex * SIMD_CHUNKS);
+            return (whiteIndex * HiddenSize, blackIndex * HiddenSize);
         }
 
 
@@ -304,30 +254,30 @@ namespace Lizard.Logic.NN
                 (int wRookTo, int bRookTo) = FeatureIndex(us, Rook, rookTo);
 
                 SubSubAddAdd((short*)srcWhite, (short*)dstWhite,
-                    (short*)(FeatureWeights + wFrom),
-                    (short*)(FeatureWeights + wRookFrom),
-                    (short*)(FeatureWeights + wTo),
-                    (short*)(FeatureWeights + wRookTo));
+                             (FeatureWeights + wFrom),
+                             (FeatureWeights + wRookFrom),
+                             (FeatureWeights + wTo),
+                             (FeatureWeights + wRookTo));
 
                 SubSubAddAdd((short*)srcBlack, (short*)dstBlack,
-                    (short*)(FeatureWeights + bFrom),
-                    (short*)(FeatureWeights + bRookFrom),
-                    (short*)(FeatureWeights + bTo),
-                    (short*)(FeatureWeights + bRookTo));
+                             (FeatureWeights + bFrom),
+                             (FeatureWeights + bRookFrom),
+                             (FeatureWeights + bTo),
+                             (FeatureWeights + bRookTo));
             }
             else if (theirPiece != None)
             {
                 (int wCap, int bCap) = FeatureIndex(them, theirPiece, moveTo);
 
                 SubSubAdd((short*)srcWhite, (short*)dstWhite,
-                    (short*)(FeatureWeights + wFrom),
-                    (short*)(FeatureWeights + wCap),
-                    (short*)(FeatureWeights + wTo));
+                          (FeatureWeights + wFrom),
+                          (FeatureWeights + wCap),
+                          (FeatureWeights + wTo));
 
                 SubSubAdd((short*)srcBlack, (short*)dstBlack,
-                    (short*)(FeatureWeights + bFrom),
-                    (short*)(FeatureWeights + bCap),
-                    (short*)(FeatureWeights + bTo));
+                          (FeatureWeights + bFrom),
+                          (FeatureWeights + bCap),
+                          (FeatureWeights + bTo));
             }
             else if (m.EnPassant)
             {
@@ -336,86 +286,25 @@ namespace Lizard.Logic.NN
                 (int wCap, int bCap) = FeatureIndex(them, Pawn, idxPawn);
 
                 SubSubAdd((short*)srcWhite, (short*)dstWhite,
-                    (short*)(FeatureWeights + wFrom),
-                    (short*)(FeatureWeights + wCap),
-                    (short*)(FeatureWeights + wTo));
+                          (FeatureWeights + wFrom),
+                          (FeatureWeights + wCap),
+                          (FeatureWeights + wTo));
 
                 SubSubAdd((short*)srcBlack, (short*)dstBlack,
-                    (short*)(FeatureWeights + bFrom),
-                    (short*)(FeatureWeights + bCap),
-                    (short*)(FeatureWeights + bTo));
+                          (FeatureWeights + bFrom),
+                          (FeatureWeights + bCap),
+                          (FeatureWeights + bTo));
             }
             else
             {
                 SubAdd((short*)srcWhite, (short*)dstWhite,
-                    (short*)(FeatureWeights + wFrom),
-                    (short*)(FeatureWeights + wTo));
+                       (FeatureWeights + wFrom),
+                       (FeatureWeights + wTo));
 
                 SubAdd((short*)srcBlack, (short*)dstBlack,
-                    (short*)(FeatureWeights + bFrom),
-                    (short*)(FeatureWeights + bTo));
+                       (FeatureWeights + bFrom),
+                       (FeatureWeights + bTo));
             }
         }
-
-
-        private static int SumVector256NoHadd(Vector256<int> vect)
-        {
-            Vector128<int> lo = vect.GetLower();
-            Vector128<int> hi = Avx.ExtractVector128(vect, 1);
-            Vector128<int> sum128 = Sse2.Add(lo, hi);
-
-            sum128 = Sse2.Add(sum128, Sse2.Shuffle(sum128, 0b_10_11_00_01));
-            sum128 = Sse2.Add(sum128, Sse2.Shuffle(sum128, 0b_01_00_11_10));
-
-            //  Something along the lines of Add(sum128, UnpackHigh(sum128, sum128))
-            //  would also work here but it is occasionally off by +- 1.
-            //  The JIT also seems to replace the unpack with a shuffle anyways depending on the instruction order,
-            //  and who am I to not trust the JIT? :)
-
-            return Sse2.ConvertToInt32(sum128);
-        }
-
-        /// <summary>
-        /// Transposes the weights stored in <paramref name="block"/>
-        /// </summary>
-        private static void TransposeLayerWeights(short* block, int columnLength, int rowLength)
-        {
-            short* temp = stackalloc short[columnLength * rowLength];
-            Unsafe.CopyBlock(temp, block, (uint)(sizeof(short) * columnLength * rowLength));
-
-            for (int bucket = 0; bucket < rowLength; bucket++)
-            {
-                short* thisBucket = block + (bucket * columnLength);
-
-                for (int i = 0; i < columnLength; i++)
-                {
-                    thisBucket[i] = temp[(rowLength * i) + bucket];
-                }
-            }
-        }
-
-
-        private static void NetStats(string layerName, void* layer, int n)
-        {
-            long avg = 0;
-            int max = int.MinValue;
-            int min = int.MaxValue;
-            short* ptr = (short*)layer;
-            for (int i = 0; i < n; i++)
-            {
-                if (ptr[i] > max)
-                {
-                    max = ptr[i];
-                }
-                if (ptr[i] < min)
-                {
-                    min = ptr[i];
-                }
-                avg += ptr[i];
-            }
-
-            Log(layerName + "\tmin: " + min + ", max: " + max + ", avg: " + (double)avg / n);
-        }
-
     }
 }

--- a/Logic/NN/Simple768Unroll.cs
+++ b/Logic/NN/Simple768Unroll.cs
@@ -1,451 +1,495 @@
-﻿using System.Runtime.Intrinsics;
-using System.Runtime.Intrinsics.X86;
+﻿
+#if AVX512
+using SIMDClass = System.Runtime.Intrinsics.X86.Avx512BW;
+using VectorT = System.Runtime.Intrinsics.Vector512;
+using VShort = System.Runtime.Intrinsics.Vector512<short>;
+using VInt = System.Runtime.Intrinsics.Vector512<int>;
+#else
+using SIMDClass = System.Runtime.Intrinsics.X86.Avx2;
+using VectorT = System.Runtime.Intrinsics.Vector256;
+using VInt = System.Runtime.Intrinsics.Vector256<int>;
+using VShort = System.Runtime.Intrinsics.Vector256<short>;
+#endif
+
 
 namespace Lizard.Logic.NN
 {
     public static unsafe partial class Simple768
     {
 
-        public static int GetEvaluationUnrolled(Position pos)
+#if AVX512
+        private const int N = 32;
+#else
+        private const int N = 16;
+#endif
+
+        private const int StopBefore = HiddenSize / N;
+
+        private const int AVX512_1024HL = 1024 / 32;
+        private const int AVX512_1536HL = 1536 / 32;
+
+        private const int AVX256_1024HL = 1024 / 16;
+        private const int AVX256_1536HL = 1536 / 16;
+
+        public static int GetEvaluationUnrolled512(Position pos)
         {
             ref Accumulator accumulator = ref *pos.State->Accumulator;
-            Vector256<short> ClampMax = Vector256.Create((short)QA);
-            Vector256<int> normalSum = Vector256<int>.Zero;
+            var maxVec = VectorT.Create((short)QA);
+            var zeroVec = VShort.Zero;
+            var sumVec = VInt.Zero;
 
-            int outputBucket = SelectOutputBucket ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
+            int outputBucket = (SelectOutputBucket) ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
 
-            var ourData = (short*)(accumulator[pos.ToMove]);
-            var ourWeights = (short*)(LayerWeights + (outputBucket * (SIMD_CHUNKS * 2)));
+            var ourData =   (short*)(accumulator[pos.ToMove]);
             var theirData = (short*)(accumulator[Not(pos.ToMove)]);
-            var theirWeights = (short*)(LayerWeights + (outputBucket * (SIMD_CHUNKS * 2)) + SIMD_CHUNKS);
+            var ourWeights =   (LayerWeights + (outputBucket * (HiddenSize * 2)));
+            var theirWeights = (LayerWeights + (outputBucket * (HiddenSize * 2)) + HiddenSize);
 
-            #region STM
+            #region R_STM
 
-            Vector256<short> clamp_us_0 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 0)));
-            Vector256<short> clamp_us_16 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 16)));
-            Vector256<short> clamp_us_32 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 32)));
-            Vector256<short> clamp_us_48 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 48)));
-            Vector256<short> clamp_us_64 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 64)));
-            Vector256<short> clamp_us_80 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 80)));
-            Vector256<short> clamp_us_96 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 96)));
-            Vector256<short> clamp_us_112 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 112)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_0, Avx2.MultiplyLow(clamp_us_0, Avx2.LoadAlignedVector256(ourWeights + 0))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_16, Avx2.MultiplyLow(clamp_us_16, Avx2.LoadAlignedVector256(ourWeights + 16))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_32, Avx2.MultiplyLow(clamp_us_32, Avx2.LoadAlignedVector256(ourWeights + 32))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_48, Avx2.MultiplyLow(clamp_us_48, Avx2.LoadAlignedVector256(ourWeights + 48))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_64, Avx2.MultiplyLow(clamp_us_64, Avx2.LoadAlignedVector256(ourWeights + 64))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_80, Avx2.MultiplyLow(clamp_us_80, Avx2.LoadAlignedVector256(ourWeights + 80))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_96, Avx2.MultiplyLow(clamp_us_96, Avx2.LoadAlignedVector256(ourWeights + 96))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_112, Avx2.MultiplyLow(clamp_us_112, Avx2.LoadAlignedVector256(ourWeights + 112))));
+            var c_us_0 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 0 * N)));
+            var c_us_1 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 1 * N)));
+            var c_us_2 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 2 * N)));
+            var c_us_3 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 3 * N)));
+            var c_us_4 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 4 * N)));
+            var c_us_5 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 5 * N)));
+            var c_us_6 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 6 * N)));
+            var c_us_7 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 7 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_0, SIMDClass.MultiplyLow(c_us_0, VectorT.LoadAligned(ourWeights + 0 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_1, SIMDClass.MultiplyLow(c_us_1, VectorT.LoadAligned(ourWeights + 1 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_2, SIMDClass.MultiplyLow(c_us_2, VectorT.LoadAligned(ourWeights + 2 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_3, SIMDClass.MultiplyLow(c_us_3, VectorT.LoadAligned(ourWeights + 3 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_4, SIMDClass.MultiplyLow(c_us_4, VectorT.LoadAligned(ourWeights + 4 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_5, SIMDClass.MultiplyLow(c_us_5, VectorT.LoadAligned(ourWeights + 5 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_6, SIMDClass.MultiplyLow(c_us_6, VectorT.LoadAligned(ourWeights + 6 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_7, SIMDClass.MultiplyLow(c_us_7, VectorT.LoadAligned(ourWeights + 7 * N))));
 
-            Vector256<short> clamp_us_128 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 128)));
-            Vector256<short> clamp_us_144 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 144)));
-            Vector256<short> clamp_us_160 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 160)));
-            Vector256<short> clamp_us_176 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 176)));
-            Vector256<short> clamp_us_192 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 192)));
-            Vector256<short> clamp_us_208 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 208)));
-            Vector256<short> clamp_us_224 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 224)));
-            Vector256<short> clamp_us_240 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 240)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_128, Avx2.MultiplyLow(clamp_us_128, Avx2.LoadAlignedVector256(ourWeights + 128))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_144, Avx2.MultiplyLow(clamp_us_144, Avx2.LoadAlignedVector256(ourWeights + 144))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_160, Avx2.MultiplyLow(clamp_us_160, Avx2.LoadAlignedVector256(ourWeights + 160))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_176, Avx2.MultiplyLow(clamp_us_176, Avx2.LoadAlignedVector256(ourWeights + 176))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_192, Avx2.MultiplyLow(clamp_us_192, Avx2.LoadAlignedVector256(ourWeights + 192))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_208, Avx2.MultiplyLow(clamp_us_208, Avx2.LoadAlignedVector256(ourWeights + 208))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_224, Avx2.MultiplyLow(clamp_us_224, Avx2.LoadAlignedVector256(ourWeights + 224))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_240, Avx2.MultiplyLow(clamp_us_240, Avx2.LoadAlignedVector256(ourWeights + 240))));
+            var c_us_8 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 8 * N)));
+            var c_us_9 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 9 * N)));
+            var c_us_10 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 10 * N)));
+            var c_us_11 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 11 * N)));
+            var c_us_12 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 12 * N)));
+            var c_us_13 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 13 * N)));
+            var c_us_14 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 14 * N)));
+            var c_us_15 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 15 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_8, SIMDClass.MultiplyLow(c_us_8, VectorT.LoadAligned(ourWeights + 8 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_9, SIMDClass.MultiplyLow(c_us_9, VectorT.LoadAligned(ourWeights + 9 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_10, SIMDClass.MultiplyLow(c_us_10, VectorT.LoadAligned(ourWeights + 10 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_11, SIMDClass.MultiplyLow(c_us_11, VectorT.LoadAligned(ourWeights + 11 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_12, SIMDClass.MultiplyLow(c_us_12, VectorT.LoadAligned(ourWeights + 12 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_13, SIMDClass.MultiplyLow(c_us_13, VectorT.LoadAligned(ourWeights + 13 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_14, SIMDClass.MultiplyLow(c_us_14, VectorT.LoadAligned(ourWeights + 14 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_15, SIMDClass.MultiplyLow(c_us_15, VectorT.LoadAligned(ourWeights + 15 * N))));
 
-            Vector256<short> clamp_us_256 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 256)));
-            Vector256<short> clamp_us_272 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 272)));
-            Vector256<short> clamp_us_288 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 288)));
-            Vector256<short> clamp_us_304 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 304)));
-            Vector256<short> clamp_us_320 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 320)));
-            Vector256<short> clamp_us_336 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 336)));
-            Vector256<short> clamp_us_352 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 352)));
-            Vector256<short> clamp_us_368 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 368)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_256, Avx2.MultiplyLow(clamp_us_256, Avx2.LoadAlignedVector256(ourWeights + 256))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_272, Avx2.MultiplyLow(clamp_us_272, Avx2.LoadAlignedVector256(ourWeights + 272))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_288, Avx2.MultiplyLow(clamp_us_288, Avx2.LoadAlignedVector256(ourWeights + 288))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_304, Avx2.MultiplyLow(clamp_us_304, Avx2.LoadAlignedVector256(ourWeights + 304))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_320, Avx2.MultiplyLow(clamp_us_320, Avx2.LoadAlignedVector256(ourWeights + 320))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_336, Avx2.MultiplyLow(clamp_us_336, Avx2.LoadAlignedVector256(ourWeights + 336))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_352, Avx2.MultiplyLow(clamp_us_352, Avx2.LoadAlignedVector256(ourWeights + 352))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_368, Avx2.MultiplyLow(clamp_us_368, Avx2.LoadAlignedVector256(ourWeights + 368))));
+            var c_us_16 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 16 * N)));
+            var c_us_17 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 17 * N)));
+            var c_us_18 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 18 * N)));
+            var c_us_19 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 19 * N)));
+            var c_us_20 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 20 * N)));
+            var c_us_21 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 21 * N)));
+            var c_us_22 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 22 * N)));
+            var c_us_23 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 23 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_16, SIMDClass.MultiplyLow(c_us_16, VectorT.LoadAligned(ourWeights + 16 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_17, SIMDClass.MultiplyLow(c_us_17, VectorT.LoadAligned(ourWeights + 17 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_18, SIMDClass.MultiplyLow(c_us_18, VectorT.LoadAligned(ourWeights + 18 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_19, SIMDClass.MultiplyLow(c_us_19, VectorT.LoadAligned(ourWeights + 19 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_20, SIMDClass.MultiplyLow(c_us_20, VectorT.LoadAligned(ourWeights + 20 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_21, SIMDClass.MultiplyLow(c_us_21, VectorT.LoadAligned(ourWeights + 21 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_22, SIMDClass.MultiplyLow(c_us_22, VectorT.LoadAligned(ourWeights + 22 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_23, SIMDClass.MultiplyLow(c_us_23, VectorT.LoadAligned(ourWeights + 23 * N))));
 
-            Vector256<short> clamp_us_384 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 384)));
-            Vector256<short> clamp_us_400 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 400)));
-            Vector256<short> clamp_us_416 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 416)));
-            Vector256<short> clamp_us_432 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 432)));
-            Vector256<short> clamp_us_448 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 448)));
-            Vector256<short> clamp_us_464 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 464)));
-            Vector256<short> clamp_us_480 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 480)));
-            Vector256<short> clamp_us_496 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 496)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_384, Avx2.MultiplyLow(clamp_us_384, Avx2.LoadAlignedVector256(ourWeights + 384))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_400, Avx2.MultiplyLow(clamp_us_400, Avx2.LoadAlignedVector256(ourWeights + 400))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_416, Avx2.MultiplyLow(clamp_us_416, Avx2.LoadAlignedVector256(ourWeights + 416))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_432, Avx2.MultiplyLow(clamp_us_432, Avx2.LoadAlignedVector256(ourWeights + 432))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_448, Avx2.MultiplyLow(clamp_us_448, Avx2.LoadAlignedVector256(ourWeights + 448))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_464, Avx2.MultiplyLow(clamp_us_464, Avx2.LoadAlignedVector256(ourWeights + 464))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_480, Avx2.MultiplyLow(clamp_us_480, Avx2.LoadAlignedVector256(ourWeights + 480))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_496, Avx2.MultiplyLow(clamp_us_496, Avx2.LoadAlignedVector256(ourWeights + 496))));
+            var c_us_24 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 24 * N)));
+            var c_us_25 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 25 * N)));
+            var c_us_26 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 26 * N)));
+            var c_us_27 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 27 * N)));
+            var c_us_28 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 28 * N)));
+            var c_us_29 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 29 * N)));
+            var c_us_30 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 30 * N)));
+            var c_us_31 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 31 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_24, SIMDClass.MultiplyLow(c_us_24, VectorT.LoadAligned(ourWeights + 24 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_25, SIMDClass.MultiplyLow(c_us_25, VectorT.LoadAligned(ourWeights + 25 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_26, SIMDClass.MultiplyLow(c_us_26, VectorT.LoadAligned(ourWeights + 26 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_27, SIMDClass.MultiplyLow(c_us_27, VectorT.LoadAligned(ourWeights + 27 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_28, SIMDClass.MultiplyLow(c_us_28, VectorT.LoadAligned(ourWeights + 28 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_29, SIMDClass.MultiplyLow(c_us_29, VectorT.LoadAligned(ourWeights + 29 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_30, SIMDClass.MultiplyLow(c_us_30, VectorT.LoadAligned(ourWeights + 30 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_31, SIMDClass.MultiplyLow(c_us_31, VectorT.LoadAligned(ourWeights + 31 * N))));
 
-            Vector256<short> clamp_us_512 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 512)));
-            Vector256<short> clamp_us_528 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 528)));
-            Vector256<short> clamp_us_544 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 544)));
-            Vector256<short> clamp_us_560 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 560)));
-            Vector256<short> clamp_us_576 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 576)));
-            Vector256<short> clamp_us_592 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 592)));
-            Vector256<short> clamp_us_608 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 608)));
-            Vector256<short> clamp_us_624 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 624)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_512, Avx2.MultiplyLow(clamp_us_512, Avx2.LoadAlignedVector256(ourWeights + 512))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_528, Avx2.MultiplyLow(clamp_us_528, Avx2.LoadAlignedVector256(ourWeights + 528))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_544, Avx2.MultiplyLow(clamp_us_544, Avx2.LoadAlignedVector256(ourWeights + 544))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_560, Avx2.MultiplyLow(clamp_us_560, Avx2.LoadAlignedVector256(ourWeights + 560))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_576, Avx2.MultiplyLow(clamp_us_576, Avx2.LoadAlignedVector256(ourWeights + 576))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_592, Avx2.MultiplyLow(clamp_us_592, Avx2.LoadAlignedVector256(ourWeights + 592))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_608, Avx2.MultiplyLow(clamp_us_608, Avx2.LoadAlignedVector256(ourWeights + 608))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_624, Avx2.MultiplyLow(clamp_us_624, Avx2.LoadAlignedVector256(ourWeights + 624))));
+            if (StopBefore == AVX512_1024HL)
+                goto NSTM;
 
-            Vector256<short> clamp_us_640 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 640)));
-            Vector256<short> clamp_us_656 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 656)));
-            Vector256<short> clamp_us_672 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 672)));
-            Vector256<short> clamp_us_688 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 688)));
-            Vector256<short> clamp_us_704 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 704)));
-            Vector256<short> clamp_us_720 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 720)));
-            Vector256<short> clamp_us_736 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 736)));
-            Vector256<short> clamp_us_752 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 752)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_640, Avx2.MultiplyLow(clamp_us_640, Avx2.LoadAlignedVector256(ourWeights + 640))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_656, Avx2.MultiplyLow(clamp_us_656, Avx2.LoadAlignedVector256(ourWeights + 656))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_672, Avx2.MultiplyLow(clamp_us_672, Avx2.LoadAlignedVector256(ourWeights + 672))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_688, Avx2.MultiplyLow(clamp_us_688, Avx2.LoadAlignedVector256(ourWeights + 688))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_704, Avx2.MultiplyLow(clamp_us_704, Avx2.LoadAlignedVector256(ourWeights + 704))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_720, Avx2.MultiplyLow(clamp_us_720, Avx2.LoadAlignedVector256(ourWeights + 720))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_736, Avx2.MultiplyLow(clamp_us_736, Avx2.LoadAlignedVector256(ourWeights + 736))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_752, Avx2.MultiplyLow(clamp_us_752, Avx2.LoadAlignedVector256(ourWeights + 752))));
+            var c_us_32 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 32 * N)));
+            var c_us_33 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 33 * N)));
+            var c_us_34 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 34 * N)));
+            var c_us_35 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 35 * N)));
+            var c_us_36 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 36 * N)));
+            var c_us_37 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 37 * N)));
+            var c_us_38 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 38 * N)));
+            var c_us_39 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 39 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_32, SIMDClass.MultiplyLow(c_us_32, VectorT.LoadAligned(ourWeights + 32 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_33, SIMDClass.MultiplyLow(c_us_33, VectorT.LoadAligned(ourWeights + 33 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_34, SIMDClass.MultiplyLow(c_us_34, VectorT.LoadAligned(ourWeights + 34 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_35, SIMDClass.MultiplyLow(c_us_35, VectorT.LoadAligned(ourWeights + 35 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_36, SIMDClass.MultiplyLow(c_us_36, VectorT.LoadAligned(ourWeights + 36 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_37, SIMDClass.MultiplyLow(c_us_37, VectorT.LoadAligned(ourWeights + 37 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_38, SIMDClass.MultiplyLow(c_us_38, VectorT.LoadAligned(ourWeights + 38 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_39, SIMDClass.MultiplyLow(c_us_39, VectorT.LoadAligned(ourWeights + 39 * N))));
 
-            Vector256<short> clamp_us_768 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 768)));
-            Vector256<short> clamp_us_784 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 784)));
-            Vector256<short> clamp_us_800 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 800)));
-            Vector256<short> clamp_us_816 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 816)));
-            Vector256<short> clamp_us_832 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 832)));
-            Vector256<short> clamp_us_848 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 848)));
-            Vector256<short> clamp_us_864 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 864)));
-            Vector256<short> clamp_us_880 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 880)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_768, Avx2.MultiplyLow(clamp_us_768, Avx2.LoadAlignedVector256(ourWeights + 768))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_784, Avx2.MultiplyLow(clamp_us_784, Avx2.LoadAlignedVector256(ourWeights + 784))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_800, Avx2.MultiplyLow(clamp_us_800, Avx2.LoadAlignedVector256(ourWeights + 800))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_816, Avx2.MultiplyLow(clamp_us_816, Avx2.LoadAlignedVector256(ourWeights + 816))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_832, Avx2.MultiplyLow(clamp_us_832, Avx2.LoadAlignedVector256(ourWeights + 832))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_848, Avx2.MultiplyLow(clamp_us_848, Avx2.LoadAlignedVector256(ourWeights + 848))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_864, Avx2.MultiplyLow(clamp_us_864, Avx2.LoadAlignedVector256(ourWeights + 864))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_880, Avx2.MultiplyLow(clamp_us_880, Avx2.LoadAlignedVector256(ourWeights + 880))));
+            var c_us_40 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 40 * N)));
+            var c_us_41 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 41 * N)));
+            var c_us_42 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 42 * N)));
+            var c_us_43 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 43 * N)));
+            var c_us_44 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 44 * N)));
+            var c_us_45 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 45 * N)));
+            var c_us_46 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 46 * N)));
+            var c_us_47 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 47 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_40, SIMDClass.MultiplyLow(c_us_40, VectorT.LoadAligned(ourWeights + 40 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_41, SIMDClass.MultiplyLow(c_us_41, VectorT.LoadAligned(ourWeights + 41 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_42, SIMDClass.MultiplyLow(c_us_42, VectorT.LoadAligned(ourWeights + 42 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_43, SIMDClass.MultiplyLow(c_us_43, VectorT.LoadAligned(ourWeights + 43 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_44, SIMDClass.MultiplyLow(c_us_44, VectorT.LoadAligned(ourWeights + 44 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_45, SIMDClass.MultiplyLow(c_us_45, VectorT.LoadAligned(ourWeights + 45 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_46, SIMDClass.MultiplyLow(c_us_46, VectorT.LoadAligned(ourWeights + 46 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_47, SIMDClass.MultiplyLow(c_us_47, VectorT.LoadAligned(ourWeights + 47 * N))));
 
-            Vector256<short> clamp_us_896 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 896)));
-            Vector256<short> clamp_us_912 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 912)));
-            Vector256<short> clamp_us_928 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 928)));
-            Vector256<short> clamp_us_944 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 944)));
-            Vector256<short> clamp_us_960 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 960)));
-            Vector256<short> clamp_us_976 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 976)));
-            Vector256<short> clamp_us_992 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 992)));
-            Vector256<short> clamp_us_1008 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1008)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_896, Avx2.MultiplyLow(clamp_us_896, Avx2.LoadAlignedVector256(ourWeights + 896))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_912, Avx2.MultiplyLow(clamp_us_912, Avx2.LoadAlignedVector256(ourWeights + 912))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_928, Avx2.MultiplyLow(clamp_us_928, Avx2.LoadAlignedVector256(ourWeights + 928))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_944, Avx2.MultiplyLow(clamp_us_944, Avx2.LoadAlignedVector256(ourWeights + 944))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_960, Avx2.MultiplyLow(clamp_us_960, Avx2.LoadAlignedVector256(ourWeights + 960))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_976, Avx2.MultiplyLow(clamp_us_976, Avx2.LoadAlignedVector256(ourWeights + 976))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_992, Avx2.MultiplyLow(clamp_us_992, Avx2.LoadAlignedVector256(ourWeights + 992))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1008, Avx2.MultiplyLow(clamp_us_1008, Avx2.LoadAlignedVector256(ourWeights + 1008))));
+            if (StopBefore == AVX512_1536HL)
+                goto NSTM;
 
-            if (Simple768.HiddenSize > 1024)
-            {
-                Vector256<short> clamp_us_1024 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1024)));
-                Vector256<short> clamp_us_1040 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1040)));
-                Vector256<short> clamp_us_1056 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1056)));
-                Vector256<short> clamp_us_1072 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1072)));
-                Vector256<short> clamp_us_1088 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1088)));
-                Vector256<short> clamp_us_1104 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1104)));
-                Vector256<short> clamp_us_1120 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1120)));
-                Vector256<short> clamp_us_1136 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1136)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1024, Avx2.MultiplyLow(clamp_us_1024, Avx2.LoadAlignedVector256(ourWeights + 1024))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1040, Avx2.MultiplyLow(clamp_us_1040, Avx2.LoadAlignedVector256(ourWeights + 1040))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1056, Avx2.MultiplyLow(clamp_us_1056, Avx2.LoadAlignedVector256(ourWeights + 1056))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1072, Avx2.MultiplyLow(clamp_us_1072, Avx2.LoadAlignedVector256(ourWeights + 1072))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1088, Avx2.MultiplyLow(clamp_us_1088, Avx2.LoadAlignedVector256(ourWeights + 1088))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1104, Avx2.MultiplyLow(clamp_us_1104, Avx2.LoadAlignedVector256(ourWeights + 1104))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1120, Avx2.MultiplyLow(clamp_us_1120, Avx2.LoadAlignedVector256(ourWeights + 1120))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1136, Avx2.MultiplyLow(clamp_us_1136, Avx2.LoadAlignedVector256(ourWeights + 1136))));
+            var c_us_48 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 48 * N)));
+            var c_us_49 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 49 * N)));
+            var c_us_50 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 50 * N)));
+            var c_us_51 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 51 * N)));
+            var c_us_52 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 52 * N)));
+            var c_us_53 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 53 * N)));
+            var c_us_54 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 54 * N)));
+            var c_us_55 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 55 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_48, SIMDClass.MultiplyLow(c_us_48, VectorT.LoadAligned(ourWeights + 48 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_49, SIMDClass.MultiplyLow(c_us_49, VectorT.LoadAligned(ourWeights + 49 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_50, SIMDClass.MultiplyLow(c_us_50, VectorT.LoadAligned(ourWeights + 50 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_51, SIMDClass.MultiplyLow(c_us_51, VectorT.LoadAligned(ourWeights + 51 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_52, SIMDClass.MultiplyLow(c_us_52, VectorT.LoadAligned(ourWeights + 52 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_53, SIMDClass.MultiplyLow(c_us_53, VectorT.LoadAligned(ourWeights + 53 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_54, SIMDClass.MultiplyLow(c_us_54, VectorT.LoadAligned(ourWeights + 54 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_55, SIMDClass.MultiplyLow(c_us_55, VectorT.LoadAligned(ourWeights + 55 * N))));
 
-                Vector256<short> clamp_us_1152 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1152)));
-                Vector256<short> clamp_us_1168 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1168)));
-                Vector256<short> clamp_us_1184 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1184)));
-                Vector256<short> clamp_us_1200 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1200)));
-                Vector256<short> clamp_us_1216 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1216)));
-                Vector256<short> clamp_us_1232 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1232)));
-                Vector256<short> clamp_us_1248 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1248)));
-                Vector256<short> clamp_us_1264 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1264)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1152, Avx2.MultiplyLow(clamp_us_1152, Avx2.LoadAlignedVector256(ourWeights + 1152))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1168, Avx2.MultiplyLow(clamp_us_1168, Avx2.LoadAlignedVector256(ourWeights + 1168))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1184, Avx2.MultiplyLow(clamp_us_1184, Avx2.LoadAlignedVector256(ourWeights + 1184))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1200, Avx2.MultiplyLow(clamp_us_1200, Avx2.LoadAlignedVector256(ourWeights + 1200))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1216, Avx2.MultiplyLow(clamp_us_1216, Avx2.LoadAlignedVector256(ourWeights + 1216))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1232, Avx2.MultiplyLow(clamp_us_1232, Avx2.LoadAlignedVector256(ourWeights + 1232))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1248, Avx2.MultiplyLow(clamp_us_1248, Avx2.LoadAlignedVector256(ourWeights + 1248))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1264, Avx2.MultiplyLow(clamp_us_1264, Avx2.LoadAlignedVector256(ourWeights + 1264))));
+            var c_us_56 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 56 * N)));
+            var c_us_57 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 57 * N)));
+            var c_us_58 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 58 * N)));
+            var c_us_59 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 59 * N)));
+            var c_us_60 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 60 * N)));
+            var c_us_61 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 61 * N)));
+            var c_us_62 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 62 * N)));
+            var c_us_63 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 63 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_56, SIMDClass.MultiplyLow(c_us_56, VectorT.LoadAligned(ourWeights + 56 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_57, SIMDClass.MultiplyLow(c_us_57, VectorT.LoadAligned(ourWeights + 57 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_58, SIMDClass.MultiplyLow(c_us_58, VectorT.LoadAligned(ourWeights + 58 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_59, SIMDClass.MultiplyLow(c_us_59, VectorT.LoadAligned(ourWeights + 59 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_60, SIMDClass.MultiplyLow(c_us_60, VectorT.LoadAligned(ourWeights + 60 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_61, SIMDClass.MultiplyLow(c_us_61, VectorT.LoadAligned(ourWeights + 61 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_62, SIMDClass.MultiplyLow(c_us_62, VectorT.LoadAligned(ourWeights + 62 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_63, SIMDClass.MultiplyLow(c_us_63, VectorT.LoadAligned(ourWeights + 63 * N))));
 
-                Vector256<short> clamp_us_1280 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1280)));
-                Vector256<short> clamp_us_1296 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1296)));
-                Vector256<short> clamp_us_1312 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1312)));
-                Vector256<short> clamp_us_1328 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1328)));
-                Vector256<short> clamp_us_1344 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1344)));
-                Vector256<short> clamp_us_1360 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1360)));
-                Vector256<short> clamp_us_1376 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1376)));
-                Vector256<short> clamp_us_1392 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1392)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1280, Avx2.MultiplyLow(clamp_us_1280, Avx2.LoadAlignedVector256(ourWeights + 1280))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1296, Avx2.MultiplyLow(clamp_us_1296, Avx2.LoadAlignedVector256(ourWeights + 1296))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1312, Avx2.MultiplyLow(clamp_us_1312, Avx2.LoadAlignedVector256(ourWeights + 1312))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1328, Avx2.MultiplyLow(clamp_us_1328, Avx2.LoadAlignedVector256(ourWeights + 1328))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1344, Avx2.MultiplyLow(clamp_us_1344, Avx2.LoadAlignedVector256(ourWeights + 1344))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1360, Avx2.MultiplyLow(clamp_us_1360, Avx2.LoadAlignedVector256(ourWeights + 1360))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1376, Avx2.MultiplyLow(clamp_us_1376, Avx2.LoadAlignedVector256(ourWeights + 1376))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1392, Avx2.MultiplyLow(clamp_us_1392, Avx2.LoadAlignedVector256(ourWeights + 1392))));
+            if (StopBefore == AVX256_1024HL)
+                goto NSTM;
 
-                Vector256<short> clamp_us_1408 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1408)));
-                Vector256<short> clamp_us_1424 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1424)));
-                Vector256<short> clamp_us_1440 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1440)));
-                Vector256<short> clamp_us_1456 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1456)));
-                Vector256<short> clamp_us_1472 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1472)));
-                Vector256<short> clamp_us_1488 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1488)));
-                Vector256<short> clamp_us_1504 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1504)));
-                Vector256<short> clamp_us_1520 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(ourData + 1520)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1408, Avx2.MultiplyLow(clamp_us_1408, Avx2.LoadAlignedVector256(ourWeights + 1408))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1424, Avx2.MultiplyLow(clamp_us_1424, Avx2.LoadAlignedVector256(ourWeights + 1424))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1440, Avx2.MultiplyLow(clamp_us_1440, Avx2.LoadAlignedVector256(ourWeights + 1440))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1456, Avx2.MultiplyLow(clamp_us_1456, Avx2.LoadAlignedVector256(ourWeights + 1456))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1472, Avx2.MultiplyLow(clamp_us_1472, Avx2.LoadAlignedVector256(ourWeights + 1472))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1488, Avx2.MultiplyLow(clamp_us_1488, Avx2.LoadAlignedVector256(ourWeights + 1488))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1504, Avx2.MultiplyLow(clamp_us_1504, Avx2.LoadAlignedVector256(ourWeights + 1504))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_us_1520, Avx2.MultiplyLow(clamp_us_1520, Avx2.LoadAlignedVector256(ourWeights + 1520))));
-            }
+            var c_us_64 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 64 * N)));
+            var c_us_65 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 65 * N)));
+            var c_us_66 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 66 * N)));
+            var c_us_67 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 67 * N)));
+            var c_us_68 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 68 * N)));
+            var c_us_69 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 69 * N)));
+            var c_us_70 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 70 * N)));
+            var c_us_71 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 71 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_64, SIMDClass.MultiplyLow(c_us_64, VectorT.LoadAligned(ourWeights + 64 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_65, SIMDClass.MultiplyLow(c_us_65, VectorT.LoadAligned(ourWeights + 65 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_66, SIMDClass.MultiplyLow(c_us_66, VectorT.LoadAligned(ourWeights + 66 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_67, SIMDClass.MultiplyLow(c_us_67, VectorT.LoadAligned(ourWeights + 67 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_68, SIMDClass.MultiplyLow(c_us_68, VectorT.LoadAligned(ourWeights + 68 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_69, SIMDClass.MultiplyLow(c_us_69, VectorT.LoadAligned(ourWeights + 69 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_70, SIMDClass.MultiplyLow(c_us_70, VectorT.LoadAligned(ourWeights + 70 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_71, SIMDClass.MultiplyLow(c_us_71, VectorT.LoadAligned(ourWeights + 71 * N))));
+
+            var c_us_72 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 72 * N)));
+            var c_us_73 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 73 * N)));
+            var c_us_74 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 74 * N)));
+            var c_us_75 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 75 * N)));
+            var c_us_76 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 76 * N)));
+            var c_us_77 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 77 * N)));
+            var c_us_78 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 78 * N)));
+            var c_us_79 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 79 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_72, SIMDClass.MultiplyLow(c_us_72, VectorT.LoadAligned(ourWeights + 72 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_73, SIMDClass.MultiplyLow(c_us_73, VectorT.LoadAligned(ourWeights + 73 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_74, SIMDClass.MultiplyLow(c_us_74, VectorT.LoadAligned(ourWeights + 74 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_75, SIMDClass.MultiplyLow(c_us_75, VectorT.LoadAligned(ourWeights + 75 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_76, SIMDClass.MultiplyLow(c_us_76, VectorT.LoadAligned(ourWeights + 76 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_77, SIMDClass.MultiplyLow(c_us_77, VectorT.LoadAligned(ourWeights + 77 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_78, SIMDClass.MultiplyLow(c_us_78, VectorT.LoadAligned(ourWeights + 78 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_79, SIMDClass.MultiplyLow(c_us_79, VectorT.LoadAligned(ourWeights + 79 * N))));
+
+            var c_us_80 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 80 * N)));
+            var c_us_81 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 81 * N)));
+            var c_us_82 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 82 * N)));
+            var c_us_83 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 83 * N)));
+            var c_us_84 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 84 * N)));
+            var c_us_85 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 85 * N)));
+            var c_us_86 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 86 * N)));
+            var c_us_87 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 87 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_80, SIMDClass.MultiplyLow(c_us_80, VectorT.LoadAligned(ourWeights + 80 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_81, SIMDClass.MultiplyLow(c_us_81, VectorT.LoadAligned(ourWeights + 81 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_82, SIMDClass.MultiplyLow(c_us_82, VectorT.LoadAligned(ourWeights + 82 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_83, SIMDClass.MultiplyLow(c_us_83, VectorT.LoadAligned(ourWeights + 83 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_84, SIMDClass.MultiplyLow(c_us_84, VectorT.LoadAligned(ourWeights + 84 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_85, SIMDClass.MultiplyLow(c_us_85, VectorT.LoadAligned(ourWeights + 85 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_86, SIMDClass.MultiplyLow(c_us_86, VectorT.LoadAligned(ourWeights + 86 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_87, SIMDClass.MultiplyLow(c_us_87, VectorT.LoadAligned(ourWeights + 87 * N))));
+
+            var c_us_88 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 88 * N)));
+            var c_us_89 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 89 * N)));
+            var c_us_90 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 90 * N)));
+            var c_us_91 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 91 * N)));
+            var c_us_92 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 92 * N)));
+            var c_us_93 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 93 * N)));
+            var c_us_94 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 94 * N)));
+            var c_us_95 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(ourData + 95 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_88, SIMDClass.MultiplyLow(c_us_88, VectorT.LoadAligned(ourWeights + 88 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_89, SIMDClass.MultiplyLow(c_us_89, VectorT.LoadAligned(ourWeights + 89 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_90, SIMDClass.MultiplyLow(c_us_90, VectorT.LoadAligned(ourWeights + 90 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_91, SIMDClass.MultiplyLow(c_us_91, VectorT.LoadAligned(ourWeights + 91 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_92, SIMDClass.MultiplyLow(c_us_92, VectorT.LoadAligned(ourWeights + 92 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_93, SIMDClass.MultiplyLow(c_us_93, VectorT.LoadAligned(ourWeights + 93 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_94, SIMDClass.MultiplyLow(c_us_94, VectorT.LoadAligned(ourWeights + 94 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_us_95, SIMDClass.MultiplyLow(c_us_95, VectorT.LoadAligned(ourWeights + 95 * N))));
+
+            #endregion
+
+
+
+            NSTM:
+
+            #region R_NSTM
+
+            var c_them_0 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 0 * N)));
+            var c_them_1 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 1 * N)));
+            var c_them_2 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 2 * N)));
+            var c_them_3 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 3 * N)));
+            var c_them_4 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 4 * N)));
+            var c_them_5 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 5 * N)));
+            var c_them_6 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 6 * N)));
+            var c_them_7 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 7 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_0, SIMDClass.MultiplyLow(c_them_0, VectorT.LoadAligned(theirWeights + 0 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_1, SIMDClass.MultiplyLow(c_them_1, VectorT.LoadAligned(theirWeights + 1 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_2, SIMDClass.MultiplyLow(c_them_2, VectorT.LoadAligned(theirWeights + 2 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_3, SIMDClass.MultiplyLow(c_them_3, VectorT.LoadAligned(theirWeights + 3 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_4, SIMDClass.MultiplyLow(c_them_4, VectorT.LoadAligned(theirWeights + 4 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_5, SIMDClass.MultiplyLow(c_them_5, VectorT.LoadAligned(theirWeights + 5 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_6, SIMDClass.MultiplyLow(c_them_6, VectorT.LoadAligned(theirWeights + 6 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_7, SIMDClass.MultiplyLow(c_them_7, VectorT.LoadAligned(theirWeights + 7 * N))));
+
+            var c_them_8 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 8 * N)));
+            var c_them_9 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 9 * N)));
+            var c_them_10 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 10 * N)));
+            var c_them_11 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 11 * N)));
+            var c_them_12 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 12 * N)));
+            var c_them_13 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 13 * N)));
+            var c_them_14 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 14 * N)));
+            var c_them_15 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 15 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_8, SIMDClass.MultiplyLow(c_them_8, VectorT.LoadAligned(theirWeights + 8 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_9, SIMDClass.MultiplyLow(c_them_9, VectorT.LoadAligned(theirWeights + 9 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_10, SIMDClass.MultiplyLow(c_them_10, VectorT.LoadAligned(theirWeights + 10 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_11, SIMDClass.MultiplyLow(c_them_11, VectorT.LoadAligned(theirWeights + 11 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_12, SIMDClass.MultiplyLow(c_them_12, VectorT.LoadAligned(theirWeights + 12 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_13, SIMDClass.MultiplyLow(c_them_13, VectorT.LoadAligned(theirWeights + 13 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_14, SIMDClass.MultiplyLow(c_them_14, VectorT.LoadAligned(theirWeights + 14 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_15, SIMDClass.MultiplyLow(c_them_15, VectorT.LoadAligned(theirWeights + 15 * N))));
+
+            var c_them_16 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 16 * N)));
+            var c_them_17 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 17 * N)));
+            var c_them_18 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 18 * N)));
+            var c_them_19 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 19 * N)));
+            var c_them_20 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 20 * N)));
+            var c_them_21 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 21 * N)));
+            var c_them_22 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 22 * N)));
+            var c_them_23 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 23 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_16, SIMDClass.MultiplyLow(c_them_16, VectorT.LoadAligned(theirWeights + 16 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_17, SIMDClass.MultiplyLow(c_them_17, VectorT.LoadAligned(theirWeights + 17 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_18, SIMDClass.MultiplyLow(c_them_18, VectorT.LoadAligned(theirWeights + 18 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_19, SIMDClass.MultiplyLow(c_them_19, VectorT.LoadAligned(theirWeights + 19 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_20, SIMDClass.MultiplyLow(c_them_20, VectorT.LoadAligned(theirWeights + 20 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_21, SIMDClass.MultiplyLow(c_them_21, VectorT.LoadAligned(theirWeights + 21 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_22, SIMDClass.MultiplyLow(c_them_22, VectorT.LoadAligned(theirWeights + 22 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_23, SIMDClass.MultiplyLow(c_them_23, VectorT.LoadAligned(theirWeights + 23 * N))));
+
+            var c_them_24 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 24 * N)));
+            var c_them_25 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 25 * N)));
+            var c_them_26 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 26 * N)));
+            var c_them_27 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 27 * N)));
+            var c_them_28 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 28 * N)));
+            var c_them_29 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 29 * N)));
+            var c_them_30 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 30 * N)));
+            var c_them_31 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 31 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_24, SIMDClass.MultiplyLow(c_them_24, VectorT.LoadAligned(theirWeights + 24 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_25, SIMDClass.MultiplyLow(c_them_25, VectorT.LoadAligned(theirWeights + 25 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_26, SIMDClass.MultiplyLow(c_them_26, VectorT.LoadAligned(theirWeights + 26 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_27, SIMDClass.MultiplyLow(c_them_27, VectorT.LoadAligned(theirWeights + 27 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_28, SIMDClass.MultiplyLow(c_them_28, VectorT.LoadAligned(theirWeights + 28 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_29, SIMDClass.MultiplyLow(c_them_29, VectorT.LoadAligned(theirWeights + 29 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_30, SIMDClass.MultiplyLow(c_them_30, VectorT.LoadAligned(theirWeights + 30 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_31, SIMDClass.MultiplyLow(c_them_31, VectorT.LoadAligned(theirWeights + 31 * N))));
+
+            if (StopBefore == AVX512_1024HL)
+                goto END;
+
+            var c_them_32 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 32 * N)));
+            var c_them_33 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 33 * N)));
+            var c_them_34 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 34 * N)));
+            var c_them_35 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 35 * N)));
+            var c_them_36 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 36 * N)));
+            var c_them_37 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 37 * N)));
+            var c_them_38 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 38 * N)));
+            var c_them_39 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 39 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_32, SIMDClass.MultiplyLow(c_them_32, VectorT.LoadAligned(theirWeights + 32 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_33, SIMDClass.MultiplyLow(c_them_33, VectorT.LoadAligned(theirWeights + 33 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_34, SIMDClass.MultiplyLow(c_them_34, VectorT.LoadAligned(theirWeights + 34 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_35, SIMDClass.MultiplyLow(c_them_35, VectorT.LoadAligned(theirWeights + 35 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_36, SIMDClass.MultiplyLow(c_them_36, VectorT.LoadAligned(theirWeights + 36 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_37, SIMDClass.MultiplyLow(c_them_37, VectorT.LoadAligned(theirWeights + 37 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_38, SIMDClass.MultiplyLow(c_them_38, VectorT.LoadAligned(theirWeights + 38 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_39, SIMDClass.MultiplyLow(c_them_39, VectorT.LoadAligned(theirWeights + 39 * N))));
+
+            var c_them_40 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 40 * N)));
+            var c_them_41 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 41 * N)));
+            var c_them_42 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 42 * N)));
+            var c_them_43 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 43 * N)));
+            var c_them_44 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 44 * N)));
+            var c_them_45 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 45 * N)));
+            var c_them_46 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 46 * N)));
+            var c_them_47 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 47 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_40, SIMDClass.MultiplyLow(c_them_40, VectorT.LoadAligned(theirWeights + 40 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_41, SIMDClass.MultiplyLow(c_them_41, VectorT.LoadAligned(theirWeights + 41 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_42, SIMDClass.MultiplyLow(c_them_42, VectorT.LoadAligned(theirWeights + 42 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_43, SIMDClass.MultiplyLow(c_them_43, VectorT.LoadAligned(theirWeights + 43 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_44, SIMDClass.MultiplyLow(c_them_44, VectorT.LoadAligned(theirWeights + 44 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_45, SIMDClass.MultiplyLow(c_them_45, VectorT.LoadAligned(theirWeights + 45 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_46, SIMDClass.MultiplyLow(c_them_46, VectorT.LoadAligned(theirWeights + 46 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_47, SIMDClass.MultiplyLow(c_them_47, VectorT.LoadAligned(theirWeights + 47 * N))));
+
+            if (StopBefore == AVX512_1536HL)
+                goto END;
+
+            var c_them_48 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 48 * N)));
+            var c_them_49 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 49 * N)));
+            var c_them_50 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 50 * N)));
+            var c_them_51 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 51 * N)));
+            var c_them_52 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 52 * N)));
+            var c_them_53 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 53 * N)));
+            var c_them_54 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 54 * N)));
+            var c_them_55 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 55 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_48, SIMDClass.MultiplyLow(c_them_48, VectorT.LoadAligned(theirWeights + 48 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_49, SIMDClass.MultiplyLow(c_them_49, VectorT.LoadAligned(theirWeights + 49 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_50, SIMDClass.MultiplyLow(c_them_50, VectorT.LoadAligned(theirWeights + 50 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_51, SIMDClass.MultiplyLow(c_them_51, VectorT.LoadAligned(theirWeights + 51 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_52, SIMDClass.MultiplyLow(c_them_52, VectorT.LoadAligned(theirWeights + 52 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_53, SIMDClass.MultiplyLow(c_them_53, VectorT.LoadAligned(theirWeights + 53 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_54, SIMDClass.MultiplyLow(c_them_54, VectorT.LoadAligned(theirWeights + 54 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_55, SIMDClass.MultiplyLow(c_them_55, VectorT.LoadAligned(theirWeights + 55 * N))));
+
+            var c_them_56 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 56 * N)));
+            var c_them_57 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 57 * N)));
+            var c_them_58 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 58 * N)));
+            var c_them_59 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 59 * N)));
+            var c_them_60 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 60 * N)));
+            var c_them_61 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 61 * N)));
+            var c_them_62 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 62 * N)));
+            var c_them_63 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 63 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_56, SIMDClass.MultiplyLow(c_them_56, VectorT.LoadAligned(theirWeights + 56 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_57, SIMDClass.MultiplyLow(c_them_57, VectorT.LoadAligned(theirWeights + 57 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_58, SIMDClass.MultiplyLow(c_them_58, VectorT.LoadAligned(theirWeights + 58 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_59, SIMDClass.MultiplyLow(c_them_59, VectorT.LoadAligned(theirWeights + 59 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_60, SIMDClass.MultiplyLow(c_them_60, VectorT.LoadAligned(theirWeights + 60 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_61, SIMDClass.MultiplyLow(c_them_61, VectorT.LoadAligned(theirWeights + 61 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_62, SIMDClass.MultiplyLow(c_them_62, VectorT.LoadAligned(theirWeights + 62 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_63, SIMDClass.MultiplyLow(c_them_63, VectorT.LoadAligned(theirWeights + 63 * N))));
+
+            if (StopBefore == AVX256_1024HL)
+                goto END;
+
+            var c_them_64 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 64 * N)));
+            var c_them_65 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 65 * N)));
+            var c_them_66 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 66 * N)));
+            var c_them_67 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 67 * N)));
+            var c_them_68 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 68 * N)));
+            var c_them_69 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 69 * N)));
+            var c_them_70 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 70 * N)));
+            var c_them_71 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 71 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_64, SIMDClass.MultiplyLow(c_them_64, VectorT.LoadAligned(theirWeights + 64 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_65, SIMDClass.MultiplyLow(c_them_65, VectorT.LoadAligned(theirWeights + 65 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_66, SIMDClass.MultiplyLow(c_them_66, VectorT.LoadAligned(theirWeights + 66 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_67, SIMDClass.MultiplyLow(c_them_67, VectorT.LoadAligned(theirWeights + 67 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_68, SIMDClass.MultiplyLow(c_them_68, VectorT.LoadAligned(theirWeights + 68 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_69, SIMDClass.MultiplyLow(c_them_69, VectorT.LoadAligned(theirWeights + 69 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_70, SIMDClass.MultiplyLow(c_them_70, VectorT.LoadAligned(theirWeights + 70 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_71, SIMDClass.MultiplyLow(c_them_71, VectorT.LoadAligned(theirWeights + 71 * N))));
+
+            var c_them_72 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 72 * N)));
+            var c_them_73 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 73 * N)));
+            var c_them_74 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 74 * N)));
+            var c_them_75 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 75 * N)));
+            var c_them_76 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 76 * N)));
+            var c_them_77 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 77 * N)));
+            var c_them_78 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 78 * N)));
+            var c_them_79 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 79 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_72, SIMDClass.MultiplyLow(c_them_72, VectorT.LoadAligned(theirWeights + 72 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_73, SIMDClass.MultiplyLow(c_them_73, VectorT.LoadAligned(theirWeights + 73 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_74, SIMDClass.MultiplyLow(c_them_74, VectorT.LoadAligned(theirWeights + 74 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_75, SIMDClass.MultiplyLow(c_them_75, VectorT.LoadAligned(theirWeights + 75 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_76, SIMDClass.MultiplyLow(c_them_76, VectorT.LoadAligned(theirWeights + 76 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_77, SIMDClass.MultiplyLow(c_them_77, VectorT.LoadAligned(theirWeights + 77 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_78, SIMDClass.MultiplyLow(c_them_78, VectorT.LoadAligned(theirWeights + 78 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_79, SIMDClass.MultiplyLow(c_them_79, VectorT.LoadAligned(theirWeights + 79 * N))));
+
+            var c_them_80 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 80 * N)));
+            var c_them_81 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 81 * N)));
+            var c_them_82 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 82 * N)));
+            var c_them_83 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 83 * N)));
+            var c_them_84 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 84 * N)));
+            var c_them_85 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 85 * N)));
+            var c_them_86 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 86 * N)));
+            var c_them_87 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 87 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_80, SIMDClass.MultiplyLow(c_them_80, VectorT.LoadAligned(theirWeights + 80 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_81, SIMDClass.MultiplyLow(c_them_81, VectorT.LoadAligned(theirWeights + 81 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_82, SIMDClass.MultiplyLow(c_them_82, VectorT.LoadAligned(theirWeights + 82 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_83, SIMDClass.MultiplyLow(c_them_83, VectorT.LoadAligned(theirWeights + 83 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_84, SIMDClass.MultiplyLow(c_them_84, VectorT.LoadAligned(theirWeights + 84 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_85, SIMDClass.MultiplyLow(c_them_85, VectorT.LoadAligned(theirWeights + 85 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_86, SIMDClass.MultiplyLow(c_them_86, VectorT.LoadAligned(theirWeights + 86 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_87, SIMDClass.MultiplyLow(c_them_87, VectorT.LoadAligned(theirWeights + 87 * N))));
+
+            var c_them_88 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 88 * N)));
+            var c_them_89 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 89 * N)));
+            var c_them_90 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 90 * N)));
+            var c_them_91 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 91 * N)));
+            var c_them_92 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 92 * N)));
+            var c_them_93 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 93 * N)));
+            var c_them_94 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 94 * N)));
+            var c_them_95 = VectorT.Min(maxVec, VectorT.Max(zeroVec, VectorT.LoadAligned(theirData + 95 * N)));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_88, SIMDClass.MultiplyLow(c_them_88, VectorT.LoadAligned(theirWeights + 88 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_89, SIMDClass.MultiplyLow(c_them_89, VectorT.LoadAligned(theirWeights + 89 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_90, SIMDClass.MultiplyLow(c_them_90, VectorT.LoadAligned(theirWeights + 90 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_91, SIMDClass.MultiplyLow(c_them_91, VectorT.LoadAligned(theirWeights + 91 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_92, SIMDClass.MultiplyLow(c_them_92, VectorT.LoadAligned(theirWeights + 92 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_93, SIMDClass.MultiplyLow(c_them_93, VectorT.LoadAligned(theirWeights + 93 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_94, SIMDClass.MultiplyLow(c_them_94, VectorT.LoadAligned(theirWeights + 94 * N))));
+            sumVec = VectorT.Add(sumVec, SIMDClass.MultiplyAddAdjacent(c_them_95, SIMDClass.MultiplyLow(c_them_95, VectorT.LoadAligned(theirWeights + 95 * N))));
 
             #endregion
 
 
 
-            #region NSTM
+            END:
 
-            Vector256<short> clamp_them_0 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 0)));
-            Vector256<short> clamp_them_16 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 16)));
-            Vector256<short> clamp_them_32 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 32)));
-            Vector256<short> clamp_them_48 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 48)));
-            Vector256<short> clamp_them_64 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 64)));
-            Vector256<short> clamp_them_80 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 80)));
-            Vector256<short> clamp_them_96 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 96)));
-            Vector256<short> clamp_them_112 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 112)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_0, Avx2.MultiplyLow(clamp_them_0, Avx2.LoadAlignedVector256(theirWeights + 0))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_16, Avx2.MultiplyLow(clamp_them_16, Avx2.LoadAlignedVector256(theirWeights + 16))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_32, Avx2.MultiplyLow(clamp_them_32, Avx2.LoadAlignedVector256(theirWeights + 32))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_48, Avx2.MultiplyLow(clamp_them_48, Avx2.LoadAlignedVector256(theirWeights + 48))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_64, Avx2.MultiplyLow(clamp_them_64, Avx2.LoadAlignedVector256(theirWeights + 64))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_80, Avx2.MultiplyLow(clamp_them_80, Avx2.LoadAlignedVector256(theirWeights + 80))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_96, Avx2.MultiplyLow(clamp_them_96, Avx2.LoadAlignedVector256(theirWeights + 96))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_112, Avx2.MultiplyLow(clamp_them_112, Avx2.LoadAlignedVector256(theirWeights + 112))));
+            int output = NNUE.SumVectorNoHadd(sumVec);
 
-            Vector256<short> clamp_them_128 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 128)));
-            Vector256<short> clamp_them_144 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 144)));
-            Vector256<short> clamp_them_160 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 160)));
-            Vector256<short> clamp_them_176 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 176)));
-            Vector256<short> clamp_them_192 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 192)));
-            Vector256<short> clamp_them_208 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 208)));
-            Vector256<short> clamp_them_224 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 224)));
-            Vector256<short> clamp_them_240 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 240)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_128, Avx2.MultiplyLow(clamp_them_128, Avx2.LoadAlignedVector256(theirWeights + 128))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_144, Avx2.MultiplyLow(clamp_them_144, Avx2.LoadAlignedVector256(theirWeights + 144))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_160, Avx2.MultiplyLow(clamp_them_160, Avx2.LoadAlignedVector256(theirWeights + 160))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_176, Avx2.MultiplyLow(clamp_them_176, Avx2.LoadAlignedVector256(theirWeights + 176))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_192, Avx2.MultiplyLow(clamp_them_192, Avx2.LoadAlignedVector256(theirWeights + 192))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_208, Avx2.MultiplyLow(clamp_them_208, Avx2.LoadAlignedVector256(theirWeights + 208))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_224, Avx2.MultiplyLow(clamp_them_224, Avx2.LoadAlignedVector256(theirWeights + 224))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_240, Avx2.MultiplyLow(clamp_them_240, Avx2.LoadAlignedVector256(theirWeights + 240))));
-
-            Vector256<short> clamp_them_256 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 256)));
-            Vector256<short> clamp_them_272 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 272)));
-            Vector256<short> clamp_them_288 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 288)));
-            Vector256<short> clamp_them_304 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 304)));
-            Vector256<short> clamp_them_320 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 320)));
-            Vector256<short> clamp_them_336 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 336)));
-            Vector256<short> clamp_them_352 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 352)));
-            Vector256<short> clamp_them_368 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 368)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_256, Avx2.MultiplyLow(clamp_them_256, Avx2.LoadAlignedVector256(theirWeights + 256))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_272, Avx2.MultiplyLow(clamp_them_272, Avx2.LoadAlignedVector256(theirWeights + 272))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_288, Avx2.MultiplyLow(clamp_them_288, Avx2.LoadAlignedVector256(theirWeights + 288))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_304, Avx2.MultiplyLow(clamp_them_304, Avx2.LoadAlignedVector256(theirWeights + 304))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_320, Avx2.MultiplyLow(clamp_them_320, Avx2.LoadAlignedVector256(theirWeights + 320))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_336, Avx2.MultiplyLow(clamp_them_336, Avx2.LoadAlignedVector256(theirWeights + 336))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_352, Avx2.MultiplyLow(clamp_them_352, Avx2.LoadAlignedVector256(theirWeights + 352))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_368, Avx2.MultiplyLow(clamp_them_368, Avx2.LoadAlignedVector256(theirWeights + 368))));
-
-            Vector256<short> clamp_them_384 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 384)));
-            Vector256<short> clamp_them_400 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 400)));
-            Vector256<short> clamp_them_416 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 416)));
-            Vector256<short> clamp_them_432 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 432)));
-            Vector256<short> clamp_them_448 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 448)));
-            Vector256<short> clamp_them_464 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 464)));
-            Vector256<short> clamp_them_480 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 480)));
-            Vector256<short> clamp_them_496 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 496)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_384, Avx2.MultiplyLow(clamp_them_384, Avx2.LoadAlignedVector256(theirWeights + 384))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_400, Avx2.MultiplyLow(clamp_them_400, Avx2.LoadAlignedVector256(theirWeights + 400))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_416, Avx2.MultiplyLow(clamp_them_416, Avx2.LoadAlignedVector256(theirWeights + 416))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_432, Avx2.MultiplyLow(clamp_them_432, Avx2.LoadAlignedVector256(theirWeights + 432))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_448, Avx2.MultiplyLow(clamp_them_448, Avx2.LoadAlignedVector256(theirWeights + 448))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_464, Avx2.MultiplyLow(clamp_them_464, Avx2.LoadAlignedVector256(theirWeights + 464))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_480, Avx2.MultiplyLow(clamp_them_480, Avx2.LoadAlignedVector256(theirWeights + 480))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_496, Avx2.MultiplyLow(clamp_them_496, Avx2.LoadAlignedVector256(theirWeights + 496))));
-
-            Vector256<short> clamp_them_512 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 512)));
-            Vector256<short> clamp_them_528 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 528)));
-            Vector256<short> clamp_them_544 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 544)));
-            Vector256<short> clamp_them_560 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 560)));
-            Vector256<short> clamp_them_576 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 576)));
-            Vector256<short> clamp_them_592 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 592)));
-            Vector256<short> clamp_them_608 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 608)));
-            Vector256<short> clamp_them_624 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 624)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_512, Avx2.MultiplyLow(clamp_them_512, Avx2.LoadAlignedVector256(theirWeights + 512))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_528, Avx2.MultiplyLow(clamp_them_528, Avx2.LoadAlignedVector256(theirWeights + 528))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_544, Avx2.MultiplyLow(clamp_them_544, Avx2.LoadAlignedVector256(theirWeights + 544))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_560, Avx2.MultiplyLow(clamp_them_560, Avx2.LoadAlignedVector256(theirWeights + 560))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_576, Avx2.MultiplyLow(clamp_them_576, Avx2.LoadAlignedVector256(theirWeights + 576))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_592, Avx2.MultiplyLow(clamp_them_592, Avx2.LoadAlignedVector256(theirWeights + 592))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_608, Avx2.MultiplyLow(clamp_them_608, Avx2.LoadAlignedVector256(theirWeights + 608))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_624, Avx2.MultiplyLow(clamp_them_624, Avx2.LoadAlignedVector256(theirWeights + 624))));
-
-            Vector256<short> clamp_them_640 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 640)));
-            Vector256<short> clamp_them_656 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 656)));
-            Vector256<short> clamp_them_672 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 672)));
-            Vector256<short> clamp_them_688 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 688)));
-            Vector256<short> clamp_them_704 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 704)));
-            Vector256<short> clamp_them_720 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 720)));
-            Vector256<short> clamp_them_736 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 736)));
-            Vector256<short> clamp_them_752 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 752)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_640, Avx2.MultiplyLow(clamp_them_640, Avx2.LoadAlignedVector256(theirWeights + 640))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_656, Avx2.MultiplyLow(clamp_them_656, Avx2.LoadAlignedVector256(theirWeights + 656))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_672, Avx2.MultiplyLow(clamp_them_672, Avx2.LoadAlignedVector256(theirWeights + 672))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_688, Avx2.MultiplyLow(clamp_them_688, Avx2.LoadAlignedVector256(theirWeights + 688))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_704, Avx2.MultiplyLow(clamp_them_704, Avx2.LoadAlignedVector256(theirWeights + 704))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_720, Avx2.MultiplyLow(clamp_them_720, Avx2.LoadAlignedVector256(theirWeights + 720))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_736, Avx2.MultiplyLow(clamp_them_736, Avx2.LoadAlignedVector256(theirWeights + 736))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_752, Avx2.MultiplyLow(clamp_them_752, Avx2.LoadAlignedVector256(theirWeights + 752))));
-
-            Vector256<short> clamp_them_768 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 768)));
-            Vector256<short> clamp_them_784 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 784)));
-            Vector256<short> clamp_them_800 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 800)));
-            Vector256<short> clamp_them_816 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 816)));
-            Vector256<short> clamp_them_832 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 832)));
-            Vector256<short> clamp_them_848 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 848)));
-            Vector256<short> clamp_them_864 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 864)));
-            Vector256<short> clamp_them_880 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 880)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_768, Avx2.MultiplyLow(clamp_them_768, Avx2.LoadAlignedVector256(theirWeights + 768))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_784, Avx2.MultiplyLow(clamp_them_784, Avx2.LoadAlignedVector256(theirWeights + 784))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_800, Avx2.MultiplyLow(clamp_them_800, Avx2.LoadAlignedVector256(theirWeights + 800))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_816, Avx2.MultiplyLow(clamp_them_816, Avx2.LoadAlignedVector256(theirWeights + 816))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_832, Avx2.MultiplyLow(clamp_them_832, Avx2.LoadAlignedVector256(theirWeights + 832))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_848, Avx2.MultiplyLow(clamp_them_848, Avx2.LoadAlignedVector256(theirWeights + 848))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_864, Avx2.MultiplyLow(clamp_them_864, Avx2.LoadAlignedVector256(theirWeights + 864))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_880, Avx2.MultiplyLow(clamp_them_880, Avx2.LoadAlignedVector256(theirWeights + 880))));
-
-            Vector256<short> clamp_them_896 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 896)));
-            Vector256<short> clamp_them_912 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 912)));
-            Vector256<short> clamp_them_928 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 928)));
-            Vector256<short> clamp_them_944 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 944)));
-            Vector256<short> clamp_them_960 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 960)));
-            Vector256<short> clamp_them_976 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 976)));
-            Vector256<short> clamp_them_992 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 992)));
-            Vector256<short> clamp_them_1008 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1008)));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_896, Avx2.MultiplyLow(clamp_them_896, Avx2.LoadAlignedVector256(theirWeights + 896))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_912, Avx2.MultiplyLow(clamp_them_912, Avx2.LoadAlignedVector256(theirWeights + 912))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_928, Avx2.MultiplyLow(clamp_them_928, Avx2.LoadAlignedVector256(theirWeights + 928))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_944, Avx2.MultiplyLow(clamp_them_944, Avx2.LoadAlignedVector256(theirWeights + 944))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_960, Avx2.MultiplyLow(clamp_them_960, Avx2.LoadAlignedVector256(theirWeights + 960))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_976, Avx2.MultiplyLow(clamp_them_976, Avx2.LoadAlignedVector256(theirWeights + 976))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_992, Avx2.MultiplyLow(clamp_them_992, Avx2.LoadAlignedVector256(theirWeights + 992))));
-            normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1008, Avx2.MultiplyLow(clamp_them_1008, Avx2.LoadAlignedVector256(theirWeights + 1008))));
-
-            if (Simple768.HiddenSize > 1024)
-            {
-                Vector256<short> clamp_them_1024 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1024)));
-                Vector256<short> clamp_them_1040 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1040)));
-                Vector256<short> clamp_them_1056 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1056)));
-                Vector256<short> clamp_them_1072 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1072)));
-                Vector256<short> clamp_them_1088 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1088)));
-                Vector256<short> clamp_them_1104 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1104)));
-                Vector256<short> clamp_them_1120 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1120)));
-                Vector256<short> clamp_them_1136 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1136)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1024, Avx2.MultiplyLow(clamp_them_1024, Avx2.LoadAlignedVector256(theirWeights + 1024))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1040, Avx2.MultiplyLow(clamp_them_1040, Avx2.LoadAlignedVector256(theirWeights + 1040))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1056, Avx2.MultiplyLow(clamp_them_1056, Avx2.LoadAlignedVector256(theirWeights + 1056))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1072, Avx2.MultiplyLow(clamp_them_1072, Avx2.LoadAlignedVector256(theirWeights + 1072))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1088, Avx2.MultiplyLow(clamp_them_1088, Avx2.LoadAlignedVector256(theirWeights + 1088))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1104, Avx2.MultiplyLow(clamp_them_1104, Avx2.LoadAlignedVector256(theirWeights + 1104))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1120, Avx2.MultiplyLow(clamp_them_1120, Avx2.LoadAlignedVector256(theirWeights + 1120))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1136, Avx2.MultiplyLow(clamp_them_1136, Avx2.LoadAlignedVector256(theirWeights + 1136))));
-
-                Vector256<short> clamp_them_1152 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1152)));
-                Vector256<short> clamp_them_1168 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1168)));
-                Vector256<short> clamp_them_1184 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1184)));
-                Vector256<short> clamp_them_1200 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1200)));
-                Vector256<short> clamp_them_1216 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1216)));
-                Vector256<short> clamp_them_1232 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1232)));
-                Vector256<short> clamp_them_1248 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1248)));
-                Vector256<short> clamp_them_1264 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1264)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1152, Avx2.MultiplyLow(clamp_them_1152, Avx2.LoadAlignedVector256(theirWeights + 1152))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1168, Avx2.MultiplyLow(clamp_them_1168, Avx2.LoadAlignedVector256(theirWeights + 1168))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1184, Avx2.MultiplyLow(clamp_them_1184, Avx2.LoadAlignedVector256(theirWeights + 1184))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1200, Avx2.MultiplyLow(clamp_them_1200, Avx2.LoadAlignedVector256(theirWeights + 1200))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1216, Avx2.MultiplyLow(clamp_them_1216, Avx2.LoadAlignedVector256(theirWeights + 1216))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1232, Avx2.MultiplyLow(clamp_them_1232, Avx2.LoadAlignedVector256(theirWeights + 1232))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1248, Avx2.MultiplyLow(clamp_them_1248, Avx2.LoadAlignedVector256(theirWeights + 1248))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1264, Avx2.MultiplyLow(clamp_them_1264, Avx2.LoadAlignedVector256(theirWeights + 1264))));
-
-                Vector256<short> clamp_them_1280 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1280)));
-                Vector256<short> clamp_them_1296 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1296)));
-                Vector256<short> clamp_them_1312 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1312)));
-                Vector256<short> clamp_them_1328 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1328)));
-                Vector256<short> clamp_them_1344 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1344)));
-                Vector256<short> clamp_them_1360 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1360)));
-                Vector256<short> clamp_them_1376 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1376)));
-                Vector256<short> clamp_them_1392 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1392)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1280, Avx2.MultiplyLow(clamp_them_1280, Avx2.LoadAlignedVector256(theirWeights + 1280))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1296, Avx2.MultiplyLow(clamp_them_1296, Avx2.LoadAlignedVector256(theirWeights + 1296))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1312, Avx2.MultiplyLow(clamp_them_1312, Avx2.LoadAlignedVector256(theirWeights + 1312))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1328, Avx2.MultiplyLow(clamp_them_1328, Avx2.LoadAlignedVector256(theirWeights + 1328))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1344, Avx2.MultiplyLow(clamp_them_1344, Avx2.LoadAlignedVector256(theirWeights + 1344))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1360, Avx2.MultiplyLow(clamp_them_1360, Avx2.LoadAlignedVector256(theirWeights + 1360))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1376, Avx2.MultiplyLow(clamp_them_1376, Avx2.LoadAlignedVector256(theirWeights + 1376))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1392, Avx2.MultiplyLow(clamp_them_1392, Avx2.LoadAlignedVector256(theirWeights + 1392))));
-
-                Vector256<short> clamp_them_1408 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1408)));
-                Vector256<short> clamp_them_1424 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1424)));
-                Vector256<short> clamp_them_1440 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1440)));
-                Vector256<short> clamp_them_1456 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1456)));
-                Vector256<short> clamp_them_1472 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1472)));
-                Vector256<short> clamp_them_1488 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1488)));
-                Vector256<short> clamp_them_1504 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1504)));
-                Vector256<short> clamp_them_1520 = Avx2.Min(ClampMax, Avx2.Max(Vector256<short>.Zero, Avx2.LoadAlignedVector256(theirData + 1520)));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1408, Avx2.MultiplyLow(clamp_them_1408, Avx2.LoadAlignedVector256(theirWeights + 1408))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1424, Avx2.MultiplyLow(clamp_them_1424, Avx2.LoadAlignedVector256(theirWeights + 1424))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1440, Avx2.MultiplyLow(clamp_them_1440, Avx2.LoadAlignedVector256(theirWeights + 1440))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1456, Avx2.MultiplyLow(clamp_them_1456, Avx2.LoadAlignedVector256(theirWeights + 1456))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1472, Avx2.MultiplyLow(clamp_them_1472, Avx2.LoadAlignedVector256(theirWeights + 1472))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1488, Avx2.MultiplyLow(clamp_them_1488, Avx2.LoadAlignedVector256(theirWeights + 1488))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1504, Avx2.MultiplyLow(clamp_them_1504, Avx2.LoadAlignedVector256(theirWeights + 1504))));
-                normalSum = Avx2.Add(normalSum, Avx2.MultiplyAddAdjacent(clamp_them_1520, Avx2.MultiplyLow(clamp_them_1520, Avx2.LoadAlignedVector256(theirWeights + 1520))));
-            }
-
-            #endregion
-
-            int output = SumVector256NoHadd(normalSum);
-
-            return (output / QA + LayerBiases[0][outputBucket]) * OutputScale / QAB;
+            return (output / QA + LayerBiases[outputBucket]) * 400 / (QA * QB);
         }
 
     }

--- a/Logic/Util/IsAOTHandler.cs
+++ b/Logic/Util/IsAOTHandler.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lizard.Logic.Util
+{
+
+    //  https://stackoverflow.com/questions/49522751/how-to-read-get-a-propertygroup-value-from-a-csproj-file-using-c-sharp-in-a-ne
+
+    [System.AttributeUsage(System.AttributeTargets.Assembly, Inherited = false, AllowMultiple = false)]
+    sealed class IsAOTAttribute : System.Attribute
+    {
+        public bool _IsAOT { get; }
+        public IsAOTAttribute(string str)
+        {
+            this._IsAOT = (str.EqualsIgnoreCase("true"));
+        }
+
+        public static bool IsAOT()
+        {
+            bool retVal = false;
+            try
+            {
+                retVal = Assembly.GetEntryAssembly().GetCustomAttribute<IsAOTAttribute>()._IsAOT;
+            }
+            catch { }
+
+            return retVal;
+        }
+    }
+}

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -242,9 +242,9 @@ namespace Lizard.Logic.Util
             sb.Append(Avx2.IsSupported ? "Avx2 " : string.Empty);
 
 #if AVX512
-            sb.Append(Avx512BW.IsSupported ? "Avx512 " : string.Empty);
+            sb.Append(Avx512BW.IsSupported ? "Avx512=(supported, used) " : "Avx512=(unsupported, used!) ");
 #else
-            sb.Append(Avx512BW.IsSupported ? "Avx512 (<- unused!) " : string.Empty);
+            sb.Append(Avx512BW.IsSupported ? "Avx512=(supported, unused!) " : "Avx512=(unsupported, unused) ");
 #endif
 
             sb.Append(Bmi2.IsSupported ? "Bmi2 " : string.Empty);

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
@@ -194,10 +196,6 @@ namespace Lizard.Logic.Util
             //  This is because the AOT compiler can't guarantee what types are in the assembly until it is compiled,
             //  so it doesn't let you get a list of them (via GetExecutingAssembly().GetTypes()) or run their constructors.
 
-#if PUBLISH_AOT
-            return;
-#endif
-
             foreach (Type type in System.Reflection.Assembly.GetExecutingAssembly().GetTypes())
             {
                 //  Don't run the constructors of NN classes.
@@ -233,9 +231,8 @@ namespace Lizard.Logic.Util
             sb.Append("Debug ");
 #endif
 
-#if PUBLISH_AOT
-            sb.Append("AOT ");
-#endif
+
+            sb.Append(IsAOTAttribute.IsAOT() ? "AOT " : string.Empty);
 
             if (HasSkipInit)
             {

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -243,6 +243,13 @@ namespace Lizard.Logic.Util
             }
 
             sb.Append(Avx2.IsSupported ? "Avx2 " : string.Empty);
+
+#if AVX512
+            sb.Append(Avx512BW.IsSupported ? "Avx512 " : string.Empty);
+#else
+            sb.Append(Avx512BW.IsSupported ? "Avx512 (<- unused!) " : string.Empty);
+#endif
+
             sb.Append(Bmi2.IsSupported ? "Bmi2 " : string.Empty);
             sb.Append(Sse3.IsSupported ? "Sse3 " : string.Empty);
             sb.Append(Sse42.IsSupported ? "Sse42 " : string.Empty);

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifndef CC
 	CC = dotnet
 endif
 
+
 #	self-contained              .NET Core won't need to be installed to run the binary
 #	-v quiet                    Silences CS#### warnings during building (e.g. "CS0162: Unreachable code detected")
 #	--property WarningLevel=0   Silences CS#### warnings during building
@@ -15,22 +16,53 @@ endif
 #	-c Release                  Builds using the Release configuration in Lizard.csproj
 #	-p:AssemblyName=$(EXE)      Renames the binary to whatever $(EXE) is.
 #	-p:DebugType=embedded       Places the PDB file inside the binary
-BUILD_OPTS = --self-contained -v quiet --property WarningLevel=0 -o ./ -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded
+#	-p:EVALFILE=$(EVALFILE)		Path to a network to be loaded. Note the file is NOT embedded, so it can't be moved or the binary will fail to load it.
+#								This should probably be an absolute path.
+BUILD_OPTS := --self-contained -v quiet --property WarningLevel=0 -o ./ -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
+
+
+#	-p:PublishAOT=true				Actually enables AOT
+#	-p:PublishSingleFile=false		AOT is incompatible with single file publishing
+#	-p:IS_AOT=true					Sets a variable during runtime signalling AOT is enabled, same to how EVALFILE works.
+AOT_OPTS = -p:PublishAOT=true -p:PublishSingleFile=false -p:IS_AOT=true
+
+
+OPT_512 = -p:DefineConstants="$(DefineConstants)AVX_512"
+
+AVX_OR_NOT = 
+
+GET_COMP_INFO = $(shell echo | $(EXE) compiler)
+
+
+define CHK
+	ifneq ($(findstring Avx512, $(GET_COMP_INFO)),)
+		$(eval AVX_OR_NOT=true)
+	endif
+endef
+
+
+default_build:
+	dotnet publish . $(BUILD_OPTS)
+	-rmdir /s /q .\bin\Release
+	$(MAKE) check512
+
+
+check512:
+	$(eval $(call CHK))
+	$(MAKE) release
 
 
 #	Try building the non-AOT version first, and then try to build the AOT version if possible.
-#   This recipe should always work, but AOT requires some additional setup so the aot recipe may fail.
+#   This recipe should always work, but AOT requires some additional setup so that recipe may fail.
 release:
-	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="$(DefineConstants)" -p:EVALFILE=$(EVALFILE)
+	dotnet publish . $(BUILD_OPTS) $(AVX_OR_NOT)
 	-rmdir /s /q .\bin\Release
 	$(MAKE) aot
 
 
-#	Replaces PublishSingleFile with PublishAOT
-#	-p:DebugType=embedded apparently just... doesn't embed it? So this will delete the pdb as well.	
-#	https://github.com/dotnet/sdk/issues/35798
+#	This will/might only succeed if you have the right toolchain
 aot:
-	-dotnet publish . $(BUILD_OPTS) -p:PublishAOT=true -p:PublishSingleFile=false -p:DefineConstants="$(DefineConstants)PUBLISH_AOT" -p:EVALFILE=$(EVALFILE)
+	-dotnet publish . $(BUILD_OPTS) $(AOT_OPTS) $(AVX_OR_NOT)
 	-rmdir /s /q .\bin\Release\native
 	-rmdir /s /q .\bin\Release
 	-del .\Lizard.pdb

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ RM_BLD_FOLDER = -cd bin && $(RM_FOLDER_CMD) Release && cd ..
 #	-p:DebugType=embedded       Places the PDB file inside the binary
 #	-p:EVALFILE=$(EVALFILE)		Path to a network to be loaded. Note the file is NOT embedded, so it can't be moved or the binary will fail to load it.
 #								This should probably be an absolute path.
-BUILD_OPTS := --self-contained -v d --property WarningLevel=0 -o $(OUT_PATH) -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
+BUILD_OPTS := --self-contained -v d --property WarningLevel=0 -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
 
 
 #	-p:PublishAOT=true				Actually enables AOT

--- a/Makefile
+++ b/Makefile
@@ -52,24 +52,23 @@ AOT_OPTS = -p:PublishAOT=true -p:PublishSingleFile=false -p:IS_AOT=true
 #   This recipe should always work, but AOT requires some additional setup so that recipe may fail.
 release:
 	dotnet publish . $(BUILD_OPTS)
-	$(RM_BLD_FOLDER)
 	$(MAKE) aot
 
 
 #	This will/might only succeed if you have the right toolchain
 aot:
 	-dotnet publish . $(BUILD_OPTS) $(AOT_OPTS)
-	$(RM_BLD_FOLDER)
-	$(RM_PDB)
 
 
 512:
 	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="AVX_512"
-	$(RM_BLD_FOLDER)
 	$(MAKE) aot_512
 
 
 aot_512:
 	-dotnet publish . $(BUILD_OPTS) $(AOT_OPTS) -p:DefineConstants="AVX_512"
+
+
+clean:
 	$(RM_BLD_FOLDER)
 	$(RM_PDB)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ RM_BLD_FOLDER = -cd bin && $(RM_FOLDER_CMD) Release && cd ..
 #	-p:DebugType=embedded       Places the PDB file inside the binary
 #	-p:EVALFILE=$(EVALFILE)		Path to a network to be loaded. Note the file is NOT embedded, so it can't be moved or the binary will fail to load it.
 #								This should probably be an absolute path.
-BUILD_OPTS := --self-contained -v quiet --property WarningLevel=0 -o $(OUT_PATH) -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
+BUILD_OPTS := --self-contained -v diag --property WarningLevel=0 -o $(OUT_PATH) -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
 
 
 #	-p:PublishAOT=true				Actually enables AOT

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ RM_BLD_FOLDER = -cd bin && $(RM_FOLDER_CMD) Release && cd ..
 #	-p:DebugType=embedded       Places the PDB file inside the binary
 #	-p:EVALFILE=$(EVALFILE)		Path to a network to be loaded. Note the file is NOT embedded, so it can't be moved or the binary will fail to load it.
 #								This should probably be an absolute path.
-BUILD_OPTS := --self-contained -v d --property WarningLevel=0 -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
+BUILD_OPTS := --self-contained -v quiet --property WarningLevel=0 -o ./ -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
 
 
 #	-p:PublishAOT=true				Actually enables AOT
@@ -61,12 +61,12 @@ aot:
 
 
 512:
-	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="AVX_512"
+	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="AVX512"
 	$(MAKE) aot_512
 
 
 aot_512:
-	-dotnet publish . $(BUILD_OPTS) $(AOT_OPTS) -p:DefineConstants="AVX_512"
+	-dotnet publish . $(BUILD_OPTS) $(AOT_OPTS) -p:DefineConstants="AVX512"
 
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ RM_BLD_FOLDER = -cd bin && $(RM_FOLDER_CMD) Release && cd ..
 #	-p:DebugType=embedded       Places the PDB file inside the binary
 #	-p:EVALFILE=$(EVALFILE)		Path to a network to be loaded. Note the file is NOT embedded, so it can't be moved or the binary will fail to load it.
 #								This should probably be an absolute path.
-BUILD_OPTS := --self-contained -v diag --property WarningLevel=0 -o $(OUT_PATH) -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
+BUILD_OPTS := --self-contained -v d --property WarningLevel=0 -o $(OUT_PATH) -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
 
 
 #	-p:PublishAOT=true				Actually enables AOT

--- a/Program.cs
+++ b/Program.cs
@@ -73,7 +73,6 @@ namespace Lizard
             Thread.CurrentThread.Name = "MainThread";
 
             Utilities.CheckConcurrency();
-            Utilities.InitializeStaticConstructors();
 
             //  The GC seems to drag its feet collecting some of the now unneeded memory (random strings and RunClassConstructor junk).
             //  This doesn't HAVE to be done now, and generally it isn't productive to force GC collections,

--- a/Program.cs
+++ b/Program.cs
@@ -20,10 +20,18 @@ namespace Lizard
 
         public static void Main(string[] args)
         {
-            if (args.Length == 1 && args[0] == "bench")
+            if (args.Length == 1)
             {
-                SearchBench.Go(12, openBench: true);
-                Environment.Exit(0);
+                if (args[0] == "bench")
+                {
+                    SearchBench.Go(12, openBench: true);
+                    Environment.Exit(0);
+                }
+                else if (args[0] == "compiler")
+                {
+                    Console.WriteLine(GetCompilerInfo());
+                    Environment.Exit(0);
+                }
             }
 
             InitializeAll();

--- a/Properties/PublishProfiles/Release-win64-aot.pubxml
+++ b/Properties/PublishProfiles/Release-win64-aot.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <DefineConstants>PUBLISH_AOT;PEXT</DefineConstants>
+    <DefineConstants>PUBLISH_AOT</DefineConstants>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishAot>True</PublishAot>
     <AssemblyName>Lizard-$(RuntimeIdentifier)-aot</AssemblyName>

--- a/Properties/PublishProfiles/Release-win64-dev.pubxml
+++ b/Properties/PublishProfiles/Release-win64-dev.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <DefineConstants>PUBLISH_AOT;PEXT;DEV</DefineConstants>
+    <DefineConstants>DEV</DefineConstants>
     <AssemblyName>Lizard-$(RuntimeIdentifier)-dev</AssemblyName>
   </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/Release-win64-pext.pubxml
+++ b/Properties/PublishProfiles/Release-win64-pext.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <DefineConstants>PUBLISH_AOT;PEXT</DefineConstants>
+    <DefineConstants>PEXT</DefineConstants>
     <AssemblyName>Lizard-$(RuntimeIdentifier)-pext</AssemblyName>
   </PropertyGroup>
 </Project>

--- a/Properties/PublishProfiles/Release-win64.pubxml
+++ b/Properties/PublishProfiles/Release-win64.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <DefineConstants>PUBLISH_AOT</DefineConstants>
+    <DefineConstants></DefineConstants>
     <AssemblyName>Lizard-$(RuntimeIdentifier)</AssemblyName>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ who has a website for the true "LTChess" [here](https://ltchess.weebly.com/). So
 
 | Version | Released | [CCRL 40/15](https://www.computerchess.org.uk/ccrl/4040/) | [CCRL Blitz](https://www.computerchess.org.uk/ccrl/404/) | Notes |
 | ---- | ------------ | ---- | ---- | --- |
-| 10.0 | Jan. 4 2024  | 3365 | 3406 | First non-Stockfish NNUE |
-| 10.1 | Jan. 13 2024 | 3427 | -    | Various improvements to search |
-| 10.2 | Feb. 9 2024 | 3500 | 3585    | Larger network, more tunes |
-| 10.3 | Mar. 8 2024 | TBD | TBD    | Significant speedups, FRC support |
+| 10.0 | Jan. 4 2024  | 3367 | 3402 | First non-Stockfish NNUE |
+| 10.1 | Jan. 13 2024 | 3429 | -    | Various improvements to search |
+| 10.2 | Feb. 9 2024 | 3499 | 3580    | Larger network, more tunes |
+| 10.3 | Mar. 8 2024 | 3510 | TBD    | Significant speedups, FRC support |
 
 </div>
 


### PR DESCRIPTION
- Avx-512 will only be used if "AVX512" is one of the DefineConstants. 
- PUBLISH_AOT is no longer required to be defined for AOT to not break.
- Standardizes much of the code between the bucketed and unbucketed arches so there is less repetition.