### PR TITLE
Save evaluation in non-hit TT entries

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -182,6 +182,8 @@ namespace Lizard.Logic.Search
             {
                 //  Get the static evaluation and store it in the empty TT slot.
                 eval = ss->StaticEval = NNUE.GetEvaluation(pos);
+                
+                tte->Update(pos.Hash, ScoreNone, BoundNone, DepthNone, Move.Null, eval, ss->TTPV);
             }
 
             if (ss->Ply >= 2)
@@ -776,6 +778,9 @@ namespace Lizard.Logic.Search
 
                 if (eval >= beta)
                 {
+                    if (!ss->TTHit)
+                        tte->Update(pos.Hash, MakeTTScore(eval, ss->Ply), TTNodeType.Alpha, DepthNone, Move.Null, eval, false);
+
                     return eval;
                 }
 


### PR DESCRIPTION
```
Elo   | 14.67 +- 7.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4762 W: 1333 L: 1132 D: 2297
Penta | [29, 495, 1155, 650, 52]
http://somelizard.pythonanywhere.com/test/652/
```

```
Elo   | 11.47 +- 8.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.55 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2940 W: 779 L: 682 D: 1479
Penta | [5, 304, 758, 395, 8]
http://somelizard.pythonanywhere.com/test/650/
```