### PR TITLE
More negative extensions in SE

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -44,7 +44,7 @@
         /// <summary>
         /// The depth must be greater than or equal to this for singular extensions to be considered.
         /// </summary>
-        public static int SingularExtensionsMinDepth = 7;
+        public static int SingularExtensionsMinDepth = 6;
 
         /// <summary>
         /// This number is multiplied by the depth to determine the singular beta value.

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -451,10 +451,17 @@ namespace Lizard.Logic.Search
                     {
                         return singleBeta;
                     }
-                    else if (ttScore >= beta || ttScore <= alpha)
+                    else if (ttScore >= beta)
                     {
-                        //  This move is basically the opposite of singular, so reduce it instead.
-                        extend = isPV ? -1 : -extend;
+                        extend = -2 + (isPV ? 1 : 0);
+                    }
+                    else if (cutNode)
+                    {
+                        extend = -2;
+                    }
+                    else if (ttScore <= alpha)
+                    {
+                        extend = -1;
                     }
                 }
 


### PR DESCRIPTION
This is speculative...
```
Elo   | 7.05 +- 5.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6358 W: 1598 L: 1469 D: 3291
Penta | [19, 679, 1658, 800, 23]
http://somelizard.pythonanywhere.com/test/645/
```