### PR TITLE
Apply LMR to non-PV captures

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -490,7 +490,7 @@ namespace Lizard.Logic.Search
 
                 if (depth >= 2
                     && legalMoves >= 2
-                    && !isCapture)
+                    && !(isPV && isCapture))
                 {
 
                     int R = LogarithmicReductionTable[depth][legalMoves];


### PR DESCRIPTION
```
Elo   | 4.25 +- 3.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19530 W: 5146 L: 4907 D: 9477
Penta | [172, 2241, 4725, 2430, 197]
http://somelizard.pythonanywhere.com/test/660/
```

Essentially untested at LTC:
```
Elo   | -0.60 +- 19.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | -0.04 (-2.94, 2.94) [0.00, 3.00]
Games | N: 576 W: 137 L: 138 D: 301
Penta | [0, 69, 152, 66, 1]
http://somelizard.pythonanywhere.com/test/665/
```