### PR TITLE
5 input buckets, 8 material scaling outputs

### DIFF
--- a/Logic/NN/Bucketed768Unroll.cs
+++ b/Logic/NN/Bucketed768Unroll.cs
@@ -48,7 +48,9 @@ namespace Lizard.Logic.NN
                 RefreshAccumulatorPerspective(pos, Black);
             }
 
-            int outputBucket = (SelectOutputBucket) ? (int)((popcount(pos.bb.Occupancy) - 2) / 4) : 0;
+            //  Formula from BlackMarlin
+            int occ = (int)popcount(pos.bb.Occupancy);
+            int outputBucket = Math.Min((63 - occ) * (32 - occ) / 225, 7);
 
             var ourData =   (short*)(accumulator[pos.ToMove]);
             var theirData = (short*)(accumulator[Not(pos.ToMove)]);

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -63,9 +63,9 @@ namespace Lizard.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
-        public static byte[] L1536x4x8_g75_s20_580 {
+        public static byte[] L1536x5x8_g75_s20_550 {
             get {
-                object obj = ResourceManager.GetObject("L1536x4x8_g75_s20-580", resourceCulture);
+                object obj = ResourceManager.GetObject("L1536x5x8_g75_s20-550", resourceCulture);
                 return ((byte[])(obj));
             }
         }

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="L1536x4x8_g75_s20-580" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\L1536x4x8_g75_s20-580.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="L1536x5x8_g75_s20-550" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\L1536x5x8_g75_s20-550.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION

```
Elo   | 7.78 +- 3.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9956 W: 2779 L: 2556 D: 4621
Penta | [97, 1127, 2352, 1260, 142]
http://somelizard.pythonanywhere.com/test/703/
```