### PR TITLE
Reworked TTEntry depth/structure

### DIFF
--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -27,7 +27,7 @@ namespace Lizard.Logic.Transposition
         /// <summary>
         /// The age of the TT, which is increased for every call to <see cref="Threads.SearchThread.MainThreadSearch"/>.
         /// </summary>
-        public static ushort Age = 0;
+        public static byte Age = 0;
 
         private static bool Initialized = false;
 
@@ -113,8 +113,6 @@ namespace Lizard.Logic.Transposition
                 //  If the entry's key matches, or the entry is empty, then pick this one.
                 if (tte[i].Key == key || tte[i].IsEmpty)
                 {
-                    tte[i].AgePVType = (sbyte)(Age | (tte[i].AgePVType & (TT_AGE_INC - 1)));
-
                     tte = &tte[i];
 
                     //  We return true if the entry isn't empty, which means that tte is valid.
@@ -130,8 +128,8 @@ namespace Lizard.Logic.Transposition
             TTEntry* replace = tte;
             for (int i = 1; i < EntriesPerCluster; i++)
             {
-                if (((replace->_depth - (TT_AGE_CYCLE + Age - replace->AgePVType)) & TT_AGE_MASK) >
-                    ((tte[i]._depth - (TT_AGE_CYCLE + Age - tte[i].AgePVType)) & TT_AGE_MASK))
+                if ((replace->_depth - replace->RelAge(TranspositionTable.Age)) >
+                    (  tte[i]._depth -   tte[i].RelAge(TranspositionTable.Age)))
                 {
                     replace = &tte[i];
                 }

--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -128,8 +128,8 @@ namespace Lizard.Logic.Transposition
             TTEntry* replace = tte;
             for (int i = 1; i < EntriesPerCluster; i++)
             {
-                if ((replace->_depth - replace->RelAge(TranspositionTable.Age)) >
-                    (  tte[i]._depth -   tte[i].RelAge(TranspositionTable.Age)))
+                if ((replace->RawDepth - replace->RelAge(TranspositionTable.Age)) >
+                    (  tte[i].RawDepth -   tte[i].RelAge(TranspositionTable.Age)))
                 {
                     replace = &tte[i];
                 }
@@ -173,7 +173,7 @@ namespace Lizard.Logic.Transposition
 
                 for (int j = 0; j < EntriesPerCluster; j++)
                 {
-                    if (!cluster[j].IsEmpty && (cluster[j].AgePVType & TT_AGE_MASK) == (Age & TT_AGE_MASK))
+                    if (!cluster[j].IsEmpty && (cluster[j].Age) == (Age & TT_AGE_MASK))
                     {
                         entries++;
                     }


### PR DESCRIPTION
```
Elo   | 3.33 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 26286 W: 6935 L: 6683 D: 12668
Penta | [216, 3006, 6470, 3212, 239]
http://somelizard.pythonanywhere.com/test/649/
```