### PR TITLE
Added move stability

### DIFF
--- a/Logic/Search/TimeManager.cs
+++ b/Logic/Search/TimeManager.cs
@@ -121,17 +121,9 @@
                 newSearchTime = PlayerTime;
             }
 
-            /*
-            At 15+0.15
-            Score of SoftNodeTM vs Baseline: 156 - 99 - 254  [0.556] 509
-            ...      SoftNodeTM playing White: 133 - 9 - 113  [0.743] 255
-            ...      SoftNodeTM playing Black: 23 - 90 - 141  [0.368] 254
-            ...      White vs Black: 223 - 32 - 254  [0.688] 509
-            Elo difference: 39.1 +/- 21.4, LOS: 100.0 %, DrawRatio: 49.9 %
-            SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
-            */
-            //  Values from Clarity
-            SoftTimeLimit = 0.6 * ((PlayerTime / MovesToGo) + (PlayerIncrement * 3 / 4));
+
+            //  Values from Clarity, then slightly adjusted
+            SoftTimeLimit = 0.65 * ((PlayerTime / MovesToGo) + (PlayerIncrement * 3 / 4));
 
             MaxSearchTime = newSearchTime;
             Log("Setting search time to " + SoftTimeLimit + ", hard limit at " + newSearchTime);


### PR DESCRIPTION
Spends less time if we get the same best move from consecutive depths, and more time if the best move switches.

```
Elo   | 16.15 +- 5.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4240 W: 1161 L: 964 D: 2115
Penta | [23, 423, 1045, 592, 37]
http://somelizard.pythonanywhere.com/test/727/
```

Performs similarly at LTC:
```
Elo   | 17.92 +- 5.64 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 3338 W: 860 L: 688 D: 1790
Penta | [4, 286, 917, 458, 4]
http://somelizard.pythonanywhere.com/test/728/
```