### PR TITLE
Weight previous conthist more in LMR

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -512,9 +512,9 @@ namespace Lizard.Logic.Search
                         R--;
 
                     var histScore = 2 * history.MainHistory[us, m] + 
-                           (*(ss - 1)->ContinuationHistory)[histIdx] + 
-                           (*(ss - 2)->ContinuationHistory)[histIdx] + 
-                           (*(ss - 4)->ContinuationHistory)[histIdx];
+                                    2 * (*(ss - 1)->ContinuationHistory)[histIdx] + 
+                                        (*(ss - 2)->ContinuationHistory)[histIdx] + 
+                                        (*(ss - 4)->ContinuationHistory)[histIdx];
 
                     R -= (histScore / (4096 * HistoryReductionMultiplier));
 


### PR DESCRIPTION
```
Elo   | 5.30 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14412 W: 3701 L: 3481 D: 7230
Penta | [112, 1584, 3592, 1808, 110]
http://somelizard.pythonanywhere.com/test/746/
```