### PR TITLE
Save a minimum depth of -1 in QSearch

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -752,7 +752,6 @@ namespace Lizard.Logic.Search
             }
 
             if (!isPV
-                && tte->Depth >= ttDepth
                 && ttScore != ScoreNone
                 && (tte->Bound & (ttScore >= beta ? BoundLower : BoundUpper)) != 0)
             {

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -924,7 +924,7 @@ namespace Lizard.Logic.Search
                       ((bestScore > startingAlpha) ? TTNodeType.Exact : 
                                                      TTNodeType.Beta);
 
-            tte->Update(pos.Hash, MakeTTScore((short)bestScore, ss->Ply), bound, depth, bestMove, ss->StaticEval, ss->TTPV);
+            tte->Update(pos.Hash, MakeTTScore((short)bestScore, ss->Ply), bound, ttDepth, bestMove, ss->StaticEval, ss->TTPV);
 
             return bestScore;
         }


### PR DESCRIPTION
QSearch used to save the current depth into TT entries, but because the depth decreases for each recursive QSearch call this caused entries with sufficiently large negative depths to wrap around to 255 and be treated as having a very high depth instead of a low one. 
Thanks to @yl25946 for mentioning a similar issue and giving me the idea to look into this further.
```
Elo   | 3.83 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21210 W: 5419 L: 5185 D: 10606
Penta | [132, 2422, 5293, 2596, 162]
http://somelizard.pythonanywhere.com/test/758/
```
Even more apparent under higher hash pressure:
```
Elo   | 5.84 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=1MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12664 W: 3215 L: 3002 D: 6447
Penta | [74, 1412, 3164, 1591, 91]
http://somelizard.pythonanywhere.com/test/759/
```