### PR TITLE
Removed capture history heuristic divisor

### DIFF
--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -89,7 +89,7 @@ namespace Lizard.Logic.Search.Ordering
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
                     sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
-                               (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece] / OrderingHistoryDivisor);
+                               (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece]);
                 }
                 else
                 {

--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -41,7 +41,7 @@ namespace Lizard.Logic.Search.Ordering
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
                     sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
-                               (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece] / OrderingHistoryDivisor);
+                               (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece]);
                 }
                 else
                 {

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -211,11 +211,6 @@
         /// </summary>
         public static int OrderingVictimValueMultiplier = 14;
 
-        /// <summary>
-        /// The multiplier for the CaptureHistory heuristic to add to that move's score.
-        /// </summary>
-        public static int OrderingHistoryDivisor = 11;
-
 
 
         /// <summary>

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -643,7 +643,6 @@ namespace Lizard.Logic.UCI
 
             Options[nameof(OrderingGivesCheckBonus)].AutoMinMax();
             Options[nameof(OrderingVictimValueMultiplier)].AutoMinMax();
-            Options[nameof(OrderingHistoryDivisor)].AutoMinMax();
 
             Options[nameof(StatBonusMult)].AutoMinMax();
             Options[nameof(StatBonusSub)].AutoMinMax();


### PR DESCRIPTION
This was a surprisingly large error... oops
```
Elo   | 10.18 +- 4.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6758 W: 1785 L: 1587 D: 3386
Penta | [27, 740, 1665, 902, 45]
http://somelizard.pythonanywhere.com/test/815/
```