### PR TITLE
Added Cuckoo repetition detection

### DIFF
--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -1059,6 +1059,7 @@ namespace Lizard.Logic.Core
                 State->PliesFromNull = 0;
 
                 //  TODO: set GamePly to 0 here?
+                GamePly = 0;
 
                 for (int i = 0; i < splits.Length; i++)
                 {

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -247,6 +247,7 @@ namespace Lizard.Logic.Core
             State++;
 
             State->HalfmoveClock++;
+            State->PliesFromNull++;
             GamePly++;
 
             if (ToMove == Black)
@@ -511,6 +512,7 @@ namespace Lizard.Logic.Core
             State->Hash.ZobristChangeToMove();
             ToMove = Not(ToMove);
             State->HalfmoveClock++;
+            State->PliesFromNull = 0;
 
             SetCheckInfo();
 
@@ -1054,6 +1056,7 @@ namespace Lizard.Logic.Core
                 NativeMemory.Clear(State, StateInfo.StateCopySize);
                 State->CastleStatus = CastlingStatus.None;
                 State->HalfmoveClock = 0;
+                State->PliesFromNull = 0;
 
                 //  TODO: set GamePly to 0 here?
 

--- a/Logic/Core/StateInfo.cs
+++ b/Logic/Core/StateInfo.cs
@@ -57,6 +57,12 @@ namespace Lizard.Logic.Core
         public int CapturedPiece = None;
 
         [FieldOffset(120)]
+        public int PliesFromNull = 0;
+
+        [FieldOffset(124)]
+        private int _align = 0;
+
+        [FieldOffset(128)]
         public Accumulator* Accumulator;
 
         public StateInfo()

--- a/Logic/Data/Move.cs
+++ b/Logic/Data/Move.cs
@@ -104,6 +104,7 @@ namespace Lizard.Logic.Data
         }
 
 
+        public Move(int from, int to) => _data = (ushort)(to | (from << 6));
         public void SetNew(int from, int to) => _data = (ushort)(to | (from << 6));
 
         public void SetNew(int from, int to, int promotionTo) => _data = (ushort)(to | (from << 6) | ((promotionTo - 1) << 12) | FlagPromotion);

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -397,7 +397,7 @@ namespace Lizard.Logic.Threads
 
                     while (true)
                     {
-                        score = Logic.Search.Searches.Negamax<RootNode>(ref info, ss, alpha, beta, Math.Max(1, RootDepth), false);
+                        score = Logic.Search.Searches.Negamax<RootNode>(info.Position, ss, alpha, beta, Math.Max(1, RootDepth), false);
 
                         StableSort(ref RootMoves, PVIndex);
 

--- a/Logic/Transposition/Cuckoo.cs
+++ b/Logic/Transposition/Cuckoo.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lizard.Logic.Transposition
+{
+    public static unsafe class Cuckoo
+    {
+        private static Move* Moves;
+        private static ulong* Keys;
+
+        private const int TableSize = 8192;
+
+        private static int Hash1(ulong key) => (int)(key & 0x1FFF);
+        private static int Hash2(ulong key) => (int)((key >> 16) & 0x1FFF);
+
+        static Cuckoo()
+        {
+            Moves = (Move*)AlignedAllocZeroed((nuint)sizeof(Move) * TableSize, AllocAlignment);
+            Keys = (ulong*)AlignedAllocZeroed((nuint)sizeof(ulong) * TableSize, AllocAlignment);
+            new Span<Move>(Moves, TableSize).Fill(Move.Null);
+
+            for (int pc = White; pc <= Black; pc++)
+            {
+                for (int pt = Knight; pt <= King; pt++)
+                {
+                    for (int s1 = A1; s1 <= H8; s1++)
+                    {
+                        for (int s2 = s1 + 1; s2 <= H8; s2++)
+                        {
+                            if ((AttackMask(s1, pc, pt) & SquareBB[s2]) != 0)
+                            {
+                                Move m = new Move(s1, s2);
+                                ulong key = Zobrist.HashForPiece(pc, pt, s1) ^ Zobrist.HashForPiece(pc, pt, s2) ^ Zobrist.ColorHash;
+
+                                int iter = Hash1(key);
+                                while (true)
+                                {
+                                    (Keys[iter], key) = (key, Keys[iter]);
+                                    (Moves[iter], m) = (m, Moves[iter]);
+
+                                    if (m == Move.Null)
+                                        break;
+
+                                    iter = iter == Hash1(key) ? Hash2(key) : Hash1(key);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            ulong AttackMask(int idx, int pc, int pt)
+            {
+                return pt switch
+                {
+                    Knight => KnightMasks[idx],
+                    Bishop => GetBishopMoves(0, idx),
+                    Rook => GetRookMoves(0, idx),
+                    Queen => GetBishopMoves(0, idx) | GetRookMoves(0, idx),
+                    _ => NeighborsMask[idx],
+                };
+            }
+        }
+
+        public static bool HasCycle(Position pos, int ply)
+        {
+            StateInfo* st = pos.State;
+            int dist = Math.Min(st->HalfmoveClock, st->PliesFromNull);
+
+            if (dist < 3)
+                return false;
+
+            ref Bitboard bb = ref pos.bb;
+            ulong ogHash = st->Hash;
+
+            ulong HashFromStack(int i) => pos.StartingState[pos.GamePly - i].Hash;
+
+            //ulong other = ~(st[0].Hash ^ st[-1].Hash);
+            ulong other = ~(HashFromStack(0) ^ HashFromStack(1));
+            for (int d = 3; d <= dist; d += 2)
+            {
+                //other ^= ~(st[-d-1].Hash ^ st[-d].Hash);
+                ulong now = HashFromStack(d);
+                other ^= ~(now ^ HashFromStack(d - 1));
+
+                var diff = ogHash ^ now;
+                int slot = Hash1(diff);
+
+                if (diff != Keys[slot])
+                    slot = Hash2(diff);
+
+                if (diff != Keys[slot])
+                    continue;
+
+                Move m = Moves[slot];
+                int moveFrom = m.From;
+                int moveTo = m.To;
+
+                if ((bb.Occupancy & LineBB[moveFrom][moveTo]) == 0)
+                {
+                    if (ply > d)
+                        return true;
+
+                    int pc = (bb.GetPieceAtIndex(moveFrom) != None) ? bb.GetColorAtIndex(moveFrom) : bb.GetColorAtIndex(moveTo);
+                    return pc == pos.ToMove;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Logic/Transposition/Zobrist.cs
+++ b/Logic/Transposition/Zobrist.cs
@@ -12,6 +12,9 @@ namespace Lizard.Logic.Transposition
         private static ulong BlackHash;
         private static Random rand = new Random(DefaultSeed);
 
+        public static ulong HashForPiece(int pc, int pt, int sq) => ColorPieceSquareHashes[pc][pt][sq];
+        public static ulong ColorHash => BlackHash;
+
         [ModuleInitializer]
         public static void Initialize()
         {


### PR DESCRIPTION
This added a `PliesFromNull` field to position states, and may have also fixed a subtle issue with GamePly and IsThreefoldRepetition. 
Negamax/QSearch are now directly passed the position as a parameter instead of having it be passed indirectly via a `SearchInformation` object.
```
Elo   | 12.27 +- 4.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5664 W: 1452 L: 1252 D: 2960
Penta | [32, 602, 1375, 780, 43]
http://somelizard.pythonanywhere.com/test/890/
```