### PR TITLE
Use average score in aspiration windows

### DIFF
--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -385,7 +385,7 @@ namespace Lizard.Logic.Threads
                     int alpha = AlphaStart;
                     int beta = BetaStart;
                     int window = ScoreInfinite;
-                    int score = RootMoves[PVIndex].PreviousScore;
+                    int score = RootMoves[PVIndex].AverageScore;
                     SelDepth = 0;
 
                     if (RootDepth >= 5)


### PR DESCRIPTION
```
Elo   | 2.34 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 41586 W: 10215 L: 9935 D: 21436
Penta | [239, 4855, 10355, 5075, 269]
http://somelizard.pythonanywhere.com/test/892/
```