### PR TITLE
Reduce more in NMP based on eval

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -88,6 +88,9 @@
         /// </summary>
         public static int NMPReductionDivisor = 5;
 
+        public static int NMPEvalDivisor = 173;
+        public static int NMPEvalMin = 3;
+
 
 
         /// <summary>

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -236,7 +236,7 @@ namespace Lizard.Logic.Search
                 && (ss - 1)->CurrentMove != Move.Null
                 && pos.MaterialCountNonPawn[pos.ToMove] > 0)
             {
-                int reduction = NMPReductionBase + (depth / NMPReductionDivisor);
+                int reduction = 5 + (depth / 5) + Math.Min((eval - beta) / 173, 3);
                 ss->CurrentMove = Move.Null;
                 ss->ContinuationHistory = history.Continuations[0][0][0];
 

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -236,7 +236,7 @@ namespace Lizard.Logic.Search
                 && (ss - 1)->CurrentMove != Move.Null
                 && pos.MaterialCountNonPawn[pos.ToMove] > 0)
             {
-                int reduction = 5 + (depth / 5) + Math.Min((eval - beta) / 173, 3);
+                int reduction = NMPReductionBase + (depth / NMPReductionDivisor) + Math.Min((eval - beta) / NMPEvalDivisor, NMPEvalMin);
                 ss->CurrentMove = Move.Null;
                 ss->ContinuationHistory = history.Continuations[0][0][0];
 

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -621,6 +621,8 @@ namespace Lizard.Logic.UCI
             Options[nameof(NMPMinDepth)].SetMinMax(1, 9);
             Options[nameof(NMPReductionBase)].SetMinMax(1, 9);
             Options[nameof(NMPReductionDivisor)].SetMinMax(1, 9);
+            Options[nameof(NMPEvalDivisor)].AutoMinMax();
+            Options[nameof(NMPEvalMin)].SetMinMax(0, 6); 
 
             Options[nameof(ReverseFutilityPruningMaxDepth)].SetMinMax(4, 12);
             Options[nameof(ReverseFutilityPruningPerDepth)].AutoMinMax();


### PR DESCRIPTION
```
Elo   | 6.19 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 11964 W: 3054 L: 2841 D: 6069
Penta | [72, 1347, 2939, 1544, 80]
http://somelizard.pythonanywhere.com/test/816/
```
Doesn't seem to scale well:
```
Elo   | 2.68 +- 2.70 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.51 (-2.94, 2.94) [0.00, 3.00]
Games | N: 15294 W: 3650 L: 3532 D: 8112
Penta | [24, 1685, 4114, 1797, 27]
http://somelizard.pythonanywhere.com/test/822/
```