### PR TITLE
Adjust return value of QSearch beta cuts

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -799,6 +799,7 @@ namespace Lizard.Logic.Search
                     if (!ss->TTHit)
                         tte->Update(pos.Hash, MakeTTScore(eval, ss->Ply), TTNodeType.Alpha, DepthNone, Move.Null, eval, false);
 
+                    if (Math.Abs(eval) < ScoreTTWin) eval = (short) ((4 * eval + beta) / 5);
                     return eval;
                 }
 
@@ -919,6 +920,8 @@ namespace Lizard.Logic.Search
 
                         if (score >= beta)
                         {
+                            if (Math.Abs(bestScore) < ScoreTTWin) bestScore = ((4 * bestScore + beta) / 5);
+
                             //  Beta cut
                             break;
                         }


### PR DESCRIPTION
```
Elo   | 5.90 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12420 W: 3137 L: 2926 D: 6357
Penta | [71, 1362, 3150, 1539, 88]
http://somelizard.pythonanywhere.com/test/900/
```