### PR TITLE
Raise Probcut verification depth by 1

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -308,7 +308,7 @@ namespace Lizard.Logic.Search
                     if (score >= probBeta)
                     {
                         //  Verify at a low depth
-                        score = -Negamax<NonPVNode>(pos, ss + 1, -probBeta, -probBeta + 1, depth - 4, !cutNode);
+                        score = -Negamax<NonPVNode>(pos, ss + 1, -probBeta, -probBeta + 1, depth - 3, !cutNode);
                     }
 
                     pos.UnmakeMove(m);


### PR DESCRIPTION
```
Elo   | 5.07 +- 2.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14814 W: 3740 L: 3524 D: 7550
Penta | [77, 1676, 3694, 1874, 86]
http://somelizard.pythonanywhere.com/test/905/
```

depth - 2 appeared to gain, but not as much as depth - 3: http://somelizard.pythonanywhere.com/test/909/
depth - 5 which looked negative: http://somelizard.pythonanywhere.com/test/906/