### PR TITLE
Enabled huge pages for the transposition table

### DIFF
--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -59,7 +59,9 @@ namespace Lizard.Logic.Transposition
             }
 
             ClusterCount = (ulong)mb * 0x100000UL / (ulong)sizeof(TTCluster);
-            Clusters = (TTCluster*)AlignedAllocZeroed(((nuint)sizeof(TTCluster) * (nuint)ClusterCount), AllocAlignment);
+            Clusters = (TTCluster*)AlignedAllocZeroed(((nuint)sizeof(TTCluster) * (nuint)ClusterCount), (1024 * 1024));
+            AdviseHugePage(Clusters, ((nuint)sizeof(TTCluster) * (nuint)ClusterCount));
+
             for (ulong i = 0; i < ClusterCount; i++)
             {
                 Clusters[i] = new TTCluster();

--- a/Logic/Util/Interop.cs
+++ b/Logic/Util/Interop.cs
@@ -169,5 +169,29 @@ namespace Lizard.Logic.Util
             return block;
         }
 
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int madvise(IntPtr addr, UIntPtr length, int advice);
+        private const int MADV_HUGEPAGE = 14;
+        public static unsafe void AdviseHugePage(void* addr, nuint length)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return;
+            }
+
+            try
+            {
+                int result = madvise(new IntPtr(addr), length, MADV_HUGEPAGE);
+                if (result != 0)
+                {
+                    Console.WriteLine($"info string madvise failed with result {result} and error {Marshal.GetLastSystemError()}");
+                }
+            }
+            catch (Exception exc)
+            {
+                Console.WriteLine($"info string madvise threw {exc.GetType()}");
+            }
+        }
     }
 }


### PR DESCRIPTION
Only used for Linux systems, and might give a slight speedup.
Vs main:
```
Elo   | 2.96 +- 2.11 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 28550 W: 7501 L: 7258 D: 13791
Penta | [241, 2837, 7858, 3116, 223]
http://somelizard.pythonanywhere.com/test/873/
```

And this is apparently not solely due to the alignment being a larger power of 2 (2^20 instead of 2^6).
Align 2^20, madvise vs. no madvise:
```
Elo   | 5.97 +- 3.27 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12172 W: 3240 L: 3031 D: 5901
Penta | [102, 1192, 3298, 1383, 111]
http://somelizard.pythonanywhere.com/test/971/
```