### PR TITLE
10k iteration STC tune 

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -44,23 +44,23 @@
         /// <summary>
         /// The depth must be greater than or equal to this for singular extensions to be considered.
         /// </summary>
-        public static int SingularExtensionsMinDepth = 6;
+        public static int SingularExtensionsMinDepth = 5;
 
         /// <summary>
         /// This number is multiplied by the depth to determine the singular beta value.
         /// </summary>
-        public static int SingularExtensionsNumerator = 9;
+        public static int SingularExtensionsNumerator = 10;
 
         /// <summary>
         /// If the score from a singular search is below the singular beta value by this amount,
         /// the depth will be extended by 2 instead of by 1.
         /// </summary>
-        public static int SingularExtensionsBeta = 22;
+        public static int SingularExtensionsBeta = 25;
 
         /// <summary>
         /// This amount will be added to the current depth when determining the depth for a singular extension search.
         /// </summary>
-        public static int SingularExtensionsDepthAugment = -1;
+        public static int SingularExtensionsDepthAugment = 0;
 
 
 
@@ -68,7 +68,7 @@
         /// Whether or not to prune sequences of moves that don't improve the position evaluation enough 
         /// even when if we give our opponent a free move.
         /// </summary>
-        public const bool UseNullMovePruning = true;
+        public const bool UseNMP = true;
 
         /// <summary>
         /// Nodes need to be at this depth of higher to be considered for pruning.
@@ -81,15 +81,15 @@
         /// <summary>
         /// The base reduction is always set to this amount.
         /// </summary>
-        public static int NMPReductionBase = 5;
+        public static int NMPReductionBase = 4;
 
         /// <summary>
         /// The reduction is increased by the current depth divided by this amount.
         /// </summary>
-        public static int NMPReductionDivisor = 5;
+        public static int NMPReductionDivisor = 4;
 
-        public static int NMPEvalDivisor = 173;
-        public static int NMPEvalMin = 3;
+        public static int NMPEvalDivisor = 197;
+        public static int NMPEvalMin = 2;
 
 
 
@@ -106,17 +106,17 @@
         /// This is counteracted by the fact that RFP searches are still significantly faster than otherwise, 
         /// so speed-wise this isn't a huge issue.
         /// </summary>
-        public const bool UseReverseFutilityPruning = true;
+        public const bool UseRFP = true;
 
         /// <summary>
         /// The depth must be less than or equal to this for reverse futility pruning to be considered.
         /// </summary>
-        public static int ReverseFutilityPruningMaxDepth = 7;
+        public static int RFPMaxDepth = 6;
 
         /// <summary>
         /// This amount is added to reverse futility pruning's margin per depth.
         /// </summary>
-        public static int ReverseFutilityPruningPerDepth = 47;
+        public static int RFPMargin = 47;
 
 
 
@@ -131,12 +131,12 @@
         /// <summary>
         /// This margin is added to the current beta to determine the modified window if the side to move is NOT improving.
         /// </summary>
-        public static int ProbCutBeta = 191;
+        public static int ProbCutBeta = 245;
 
         /// <summary>
         /// This margin is added to the current beta to determine the modified window if the side to move is improving.
         /// </summary>
-        public static int ProbCutBetaImproving = 100;
+        public static int ProbCutBetaImproving = 105;
 
         /// <summary>
         /// The depth must be greater than or equal to this for ProbCut to be considered.
@@ -149,14 +149,14 @@
         /// If an LMR search returns a score that is above the current best score by this amount, 
         /// the following verification search will be extended by 1.
         /// </summary>
-        public static int LMRExtensionThreshold = 131;
+        public static int LMRExtensionThreshold = 123;
 
         /// <summary>
         /// In Negamax, non-evasion moves that lose (this amount * depth) will be skipped.
         /// <para></para>
         /// This generally prunes moves that hang a piece.
         /// </summary>
-        public static int LMRExchangeBase = 216;
+        public static int LMRExchangeBase = 212;
 
 
 
@@ -173,18 +173,18 @@
         /// This is used to determine the minimum score a move must have to NOT be considered futile,
         /// as low scoring moves are generally a waste of time to search.
         /// </summary>
-        public static int FutilityExchangeBase = 181;
+        public static int FutilityExchangeBase = 186;
 
 
 
         /// <summary>
         /// Cut nodes without transposition table entries will have a reduction applied to them if the search depth is at or above this.
         /// </summary>
-        public static int ExtraCutNodeReductionMinDepth = 5;
+        public static int ExtraCutNodeReductionMinDepth = 4;
 
 
-        public static int SkipQuietsMinDepth = 8;
-        public static int QSSeeThreshold = 90;
+        public static int SkipQuietsMaxDepth = 9;
+        public static int QSSeeThreshold = 78;
 
 
         /// <summary>
@@ -194,21 +194,21 @@
         /// Smaller margins will eliminate more nodes from the search (saves time), but if the margin is too small
         /// we will be forced to redo the search which can waste more time than it saves at high depths.
         /// </summary>
-        public static int AspirationWindowMargin = 11;
+        public static int AspirationWindowMargin = 12;
 
 
 
         /// <summary>
         /// The best move will get a slightly larger bonus if it's score is this much above beta.
         /// </summary>
-        public static int HistoryCaptureBonusMargin = 158;
+        public static int HistoryCaptureBonusMargin = 166;
 
 
 
         /// <summary>
         /// Quiet moves that give check will be given this additional bonus.
         /// </summary>
-        public static int OrderingGivesCheckBonus = 10345;
+        public static int OrderingGivesCheckBonus = 9611;
 
         /// <summary>
         /// The multiplier for the value of a piece being captured to add to a capturing move's score.
@@ -222,47 +222,47 @@
         /// <summary>
         /// The value multiplied by the depth
         /// </summary>
-        public static int StatBonusMult = 170;
+        public static int StatBonusMult = 178;
 
         /// <summary>
         /// The value to subtract from (StatBonusMult * depth)
         /// </summary>
-        public static int StatBonusSub = 95;
+        public static int StatBonusSub = 81;
 
         /// <summary>
         /// The maximum value that a bonus can be.
         /// </summary>
-        public static int StatBonusMax = 1822;
+        public static int StatBonusMax = 1592;
 
 
 
         /// <summary>
         /// The value to multiply by the depth
         /// </summary>
-        public static int StatMalusMult = 466;
+        public static int StatMalusMult = 574;
 
         /// <summary>
         /// The value to subtract from (StatMalusMult * depth)
         /// </summary>
-        public static int StatMalusSub = 97;
+        public static int StatMalusSub = 109;
 
         /// <summary>
         /// The maximum value that a malus can be.
         /// </summary>
-        public static int StatMalusMax = 1787;
+        public static int StatMalusMax = 1569;
 
 
 
-        public static int SEEValue_Pawn = 112;
-        public static int SEEValue_Knight = 794;
-        public static int SEEValue_Bishop = 868;
-        public static int SEEValue_Rook = 1324;
-        public static int SEEValue_Queen = 2107;
+        public static int SEEValue_Pawn = 103;
+        public static int SEEValue_Knight = 863;
+        public static int SEEValue_Bishop = 1009;
+        public static int SEEValue_Rook = 1396;
+        public static int SEEValue_Queen = 2222;
 
-        public static int ValuePawn = 199;
-        public static int ValueKnight = 920;
-        public static int ValueBishop = 1058;
-        public static int ValueRook = 1553;
-        public static int ValueQueen = 3127;
+        public static int ValuePawn = 170;
+        public static int ValueKnight = 797;
+        public static int ValueBishop = 975;
+        public static int ValueRook = 1604;
+        public static int ValueQueen = 3149;
     }
 }

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -183,6 +183,9 @@
         public static int ExtraCutNodeReductionMinDepth = 5;
 
 
+        public static int SkipQuietsMinDepth = 8;
+        public static int QSSeeThreshold = 90;
+
 
         /// <summary>
         /// If the evaluation at the next depth is within this margin from the previous evaluation,

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -398,7 +398,7 @@ namespace Lizard.Logic.Search
 
                     bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB[moveTo]) != 0);
 
-                    if (skipQuiets && depth <= 8 && !(givesCheck || isCapture))
+                    if (skipQuiets && depth <= SkipQuietsMinDepth && !(givesCheck || isCapture))
                     {
                         continue;
                     }
@@ -880,7 +880,7 @@ namespace Lizard.Logic.Search
                         break;
                     }
 
-                    if (!ss->InCheck && !SEE_GE(pos, m, -90))
+                    if (!ss->InCheck && !SEE_GE(pos, m, -QSSeeThreshold))
                     {
                         //  This move loses a significant amount of material
                         continue;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -205,20 +205,20 @@ namespace Lizard.Logic.Search
             //  We accept Reverse Futility Pruning for:
             //  non-PV nodes
             //  that aren't a response to a previous singular extension search
-            //  at a depth at or below the max (currently 7)
+            //  at a depth at or below the max (currently 6)
             //  which don't have a TT move,
             //  so long as:
             //  The static evaluation (eval) is below a TT win or a mate score,
             //  the eval would cause a beta cutoff,
             //  and the eval is significantly above beta.
-            if (UseReverseFutilityPruning
+            if (UseRFP
                 && !ss->TTPV
                 && !doSkip
-                && depth <= ReverseFutilityPruningMaxDepth
+                && depth <= RFPMaxDepth
                 && ttMove.Equals(Move.Null)
                 && (eval < ScoreAssuredWin)
                 && (eval >= beta)
-                && (eval - GetReverseFutilityMargin(depth, improving)) >= beta)
+                && (eval - GetRFPMargin(depth, improving)) >= beta)
             {
                 return (eval + beta) / 2;
             }
@@ -233,7 +233,7 @@ namespace Lizard.Logic.Search
             //  The previous node didn't start a singular extension search,
             //  the previous node didn't start a null move search,
             //  and we have non-pawn material (important for Zugzwang).
-            if (UseNullMovePruning
+            if (UseNMP
                 && !isPV
                 && depth >= NMPMinDepth
                 && eval >= beta
@@ -326,7 +326,7 @@ namespace Lizard.Logic.Search
                 && depth >= ExtraCutNodeReductionMinDepth)
             {
                 //  We expected this node to be a bad one, so give it an extra depth reduction
-                //  if the depth is at or above a threshold (currently 6).
+                //  if the depth is at or above a threshold (currently 4).
                 depth--;
             }
 
@@ -398,7 +398,7 @@ namespace Lizard.Logic.Search
 
                     bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB[moveTo]) != 0);
 
-                    if (skipQuiets && depth <= SkipQuietsMinDepth && !(givesCheck || isCapture))
+                    if (skipQuiets && depth <= SkipQuietsMaxDepth && !(givesCheck || isCapture))
                     {
                         continue;
                     }
@@ -418,7 +418,7 @@ namespace Lizard.Logic.Search
                 //  non-root nodes
                 //  which aren't a response to a previous singular extension search,
                 //  haven't already been extended significantly,
-                //  and have a depth at or above 7 (or 8 for PV searches + PV TT entry hits),
+                //  and have a depth at or above 5 (or 6 for PV searches + PV TT entry hits),
                 //  so long as:
                 //  The current move is the TT hit's move,
                 //  the TT hit's score isn't a definitive win/loss,
@@ -1053,9 +1053,9 @@ namespace Lizard.Logic.Search
         /// Returns a safety margin score given the <paramref name="depth"/> and whether or not our 
         /// static evaluation is <paramref name="improving"/> or not.
         /// </summary>
-        private static int GetReverseFutilityMargin(int depth, bool improving)
+        private static int GetRFPMargin(int depth, bool improving)
         {
-            return (depth - (improving ? 1 : 0)) * ReverseFutilityPruningPerDepth;
+            return (depth - (improving ? 1 : 0)) * RFPMargin;
         }
 
 

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -639,6 +639,9 @@ namespace Lizard.Logic.UCI
             Options[nameof(FutilityExchangeBase)].AutoMinMax();
 
             Options[nameof(ExtraCutNodeReductionMinDepth)].SetMinMax(2, 10);
+            Options[nameof(SkipQuietsMinDepth)].SetMinMax(3, 13);
+            Options[nameof(QSSeeThreshold)].SetMinMax(30, 150);
+
             Options[nameof(AspirationWindowMargin)].AutoMinMax();
 
             Options[nameof(HistoryCaptureBonusMargin)].AutoMinMax();

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -624,8 +624,8 @@ namespace Lizard.Logic.UCI
             Options[nameof(NMPEvalDivisor)].AutoMinMax();
             Options[nameof(NMPEvalMin)].SetMinMax(0, 6); 
 
-            Options[nameof(ReverseFutilityPruningMaxDepth)].SetMinMax(4, 12);
-            Options[nameof(ReverseFutilityPruningPerDepth)].AutoMinMax();
+            Options[nameof(RFPMaxDepth)].SetMinMax(4, 12);
+            Options[nameof(RFPMargin)].AutoMinMax();
 
             Options[nameof(ProbCutMinDepth)].SetMinMax(1, 8);
             Options[nameof(ProbCutBeta)].AutoMinMax();
@@ -639,7 +639,7 @@ namespace Lizard.Logic.UCI
             Options[nameof(FutilityExchangeBase)].AutoMinMax();
 
             Options[nameof(ExtraCutNodeReductionMinDepth)].SetMinMax(2, 10);
-            Options[nameof(SkipQuietsMinDepth)].SetMinMax(3, 13);
+            Options[nameof(SkipQuietsMaxDepth)].SetMinMax(3, 13);
             Options[nameof(QSSeeThreshold)].SetMinMax(30, 150);
 
             Options[nameof(AspirationWindowMargin)].AutoMinMax();
@@ -705,7 +705,7 @@ namespace Lizard.Logic.UCI
         {
             string output =
                 "" +
-                "SingularExtensionsMinDepth, 7\r\nSingularExtensionsNumerator, 9\r\nSingularExtensionsBeta, 22\r\nSingularExtensionsDepthAugment, -1\r\nNMPMinDepth, 6\r\nNMPReductionBase, 5\r\nNMPReductionDivisor, 5\r\nReverseFutilityPruningMaxDepth, 7\r\nReverseFutilityPruningPerDepth, 47\r\nProbCutBeta, 191\r\nProbCutBetaImproving, 100\r\nProbCutMinDepth, 2\r\nLMRExtensionThreshold, 131\r\nLMRExchangeBase, 216\r\nHistoryReductionMultiplier, 3\r\nFutilityExchangeBase, 181\r\nExtraCutNodeReductionMinDepth, 5\r\nAspirationWindowMargin, 11\r\nHistoryCaptureBonusMargin, 158\r\nOrderingGivesCheckBonus, 10345\r\nOrderingVictimValueMultiplier, 14\r\nOrderingHistoryDivisor, 11\r\nStatBonusMult, 170\r\nStatBonusSub, 95\r\nStatBonusMax, 1822\r\nStatMalusMult, 466\r\nStatMalusSub, 97\r\nStatMalusMax, 1787\r\nSEEValue_Pawn, 112\r\nSEEValue_Knight, 794\r\nSEEValue_Bishop, 868\r\nSEEValue_Rook, 1324\r\nSEEValue_Queen, 2107\r\nValuePawn, 199\r\nValueKnight, 920\r\nValueBishop, 1058\r\nValueRook, 1553\r\nValueQueen, 3127" +
+                "SingularExtensionsMinDepth, 5\r\nSingularExtensionsNumerator, 10\r\nSingularExtensionsBeta, 25\r\nSingularExtensionsDepthAugment, 0\r\nNMPMinDepth, 6\r\nNMPReductionBase, 4\r\nNMPReductionDivisor, 4\r\nNMPEvalDivisor, 197\r\nNMPEvalMin, 2\r\nReverseFutilityPruningMaxDepth, 6\r\nReverseFutilityPruningPerDepth, 47\r\nProbCutBeta, 245\r\nProbCutBetaImproving, 105\r\nLMRExtensionThreshold, 123\r\nLMRExchangeBase, 212\r\nHistoryReductionMultiplier, 3\r\nFutilityExchangeBase, 186\r\nExtraCutNodeReductionMinDepth, 4\r\nSkipQuietsMaxDepth, 9\r\nQSSeeThreshold, 78\r\nAspirationWindowMargin, 12\r\nHistoryCaptureBonusMargin, 166\r\nOrderingGivesCheckBonus, 9611\r\nOrderingVictimValueMultiplier, 14\r\nStatBonusMult, 178\r\nStatBonusSub, 81\r\nStatBonusMax, 1592\r\nStatMalusMult, 574\r\nStatMalusSub, 109\r\nStatMalusMax, 1569\r\nSEEValue_Pawn, 103\r\nSEEValue_Knight, 863\r\nSEEValue_Bishop, 1009\r\nSEEValue_Rook, 1396\r\nSEEValue_Queen, 2222\r\nValuePawn, 170\r\nValueKnight, 797\r\nValueBishop, 975\r\nValueRook, 1604\r\nValueQueen, 3149" +
                 "";
 
             var lines = output.Split("\r\n");


### PR DESCRIPTION
```
Elo   | 5.61 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 13244 W: 3358 L: 3144 D: 6742
Penta | [75, 1492, 3285, 1684, 86]
http://somelizard.pythonanywhere.com/test/962/
```

Neutral-ish at LTC:
```
Elo   | 0.87 +- 7.57 (95%)
Conf  | 40.0+0.40s Threads=1 Hash=32MB
Games | N: 2002 W: 475 L: 470 D: 1057
Penta | [2, 236, 521, 239, 3]
http://somelizard.pythonanywhere.com/test/963/
```