### PR TITLE
Adjust depth for aspiration window fails

### DIFF
--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -377,6 +377,8 @@ namespace Lizard.Logic.Threads
                     rm.PreviousScore = rm.Score;
                 }
 
+                int usedDepth = RootDepth;
+
                 for (PVIndex = 0; PVIndex < multiPV; PVIndex++)
                 {
                     if (SearchPool.StopThreads)
@@ -388,7 +390,7 @@ namespace Lizard.Logic.Threads
                     int score = RootMoves[PVIndex].AverageScore;
                     SelDepth = 0;
 
-                    if (RootDepth >= 5)
+                    if (usedDepth >= 5)
                     {
                         window = AspirationWindowMargin;
                         alpha = Math.Max(AlphaStart, score - window);
@@ -397,7 +399,7 @@ namespace Lizard.Logic.Threads
 
                     while (true)
                     {
-                        score = Logic.Search.Searches.Negamax<RootNode>(info.Position, ss, alpha, beta, Math.Max(1, RootDepth), false);
+                        score = Logic.Search.Searches.Negamax<RootNode>(info.Position, ss, alpha, beta, Math.Max(1, usedDepth), false);
 
                         StableSort(ref RootMoves, PVIndex);
 
@@ -408,10 +410,12 @@ namespace Lizard.Logic.Threads
                         {
                             beta = (alpha + beta) / 2;
                             alpha = Math.Max(alpha - window, AlphaStart);
+                            usedDepth = RootDepth;
                         }
                         else if (score >= beta)
                         {
                             beta = Math.Min(beta + window, BetaStart);
+                            usedDepth = Math.Max(usedDepth - 1, RootDepth - 5);
                         }
                         else
                             break;
@@ -445,7 +449,7 @@ namespace Lizard.Logic.Threads
                     return;
                 }
 
-                
+
                 if (lastBestRootMove.Move == RootMoves[0].Move)
                 {
                     stability++;


### PR DESCRIPTION
```
Elo   | 11.60 +- 4.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5902 W: 1571 L: 1374 D: 2957
Penta | [23, 624, 1492, 757, 55]
http://somelizard.pythonanywhere.com/test/981/
```

```
Elo   | 5.92 +- 3.55 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=32MB
LLR   | 2.36 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9162 W: 2249 L: 2093 D: 4820
Penta | [17, 985, 2433, 1117, 29]
http://somelizard.pythonanywhere.com/test/991/
```