### PR TITLE
Retrained network with DFRC data

### DIFF
--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -23,7 +23,7 @@ namespace Lizard.Logic.NN
         /// <summary>
         /// (768x5 -> 1536)x2 -> 8
         /// </summary>
-        public const string NetworkName = "L1536x5x8_cos51_from315_dfrc08b-550.bin";
+        public const string NetworkName = "L1536x5x8_cos51_from315_dfrc08b-680.bin";
 
         public static readonly short* FeatureWeights;
         public static readonly short* FeatureBiases;

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -15,7 +15,7 @@ namespace Lizard.Logic.NN
         public const int HiddenSize = 1536;
         public const int OutputBuckets = 8;
 
-        public const int QA = 255;
+        public const int QA = 258;
         public const int QB = 64;
 
         public const int OutputScale = 400;
@@ -23,7 +23,7 @@ namespace Lizard.Logic.NN
         /// <summary>
         /// (768x5 -> 1536)x2 -> 8
         /// </summary>
-        public const string NetworkName = "L1536x5x8_g75_s20-550.bin";
+        public const string NetworkName = "L1536x5x8_cos51_from315_dfrc08b-550.bin";
 
         public static readonly short* FeatureWeights;
         public static readonly short* FeatureBiases;

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -63,9 +63,9 @@ namespace Lizard.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
-        public static byte[] L1536x5x8_cos51_from315_dfrc08b_550 {
+        public static byte[] L1536x5x8_cos51_from315_dfrc08b_680 {
             get {
-                object obj = ResourceManager.GetObject("L1536x5x8_cos51_from315_dfrc08b-550", resourceCulture);
+                object obj = ResourceManager.GetObject("L1536x5x8_cos51_from315_dfrc08b-680", resourceCulture);
                 return ((byte[])(obj));
             }
         }

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -63,9 +63,9 @@ namespace Lizard.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
-        public static byte[] L1536x5x8_g75_s20_550 {
+        public static byte[] L1536x5x8_cos51_from315_dfrc08b_550 {
             get {
-                object obj = ResourceManager.GetObject("L1536x5x8_g75_s20-550", resourceCulture);
+                object obj = ResourceManager.GetObject("L1536x5x8_cos51_from315_dfrc08b-550", resourceCulture);
                 return ((byte[])(obj));
             }
         }

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="L1536x5x8_g75_s20-550" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\L1536x5x8_g75_s20-550.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="L1536x5x8_cos51_from315_dfrc08b-550" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\L1536x5x8_cos51_from315_dfrc08b-550.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/Properties/Resources.resx
+++ b/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="L1536x5x8_cos51_from315_dfrc08b-550" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\L1536x5x8_cos51_from315_dfrc08b-550.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="L1536x5x8_cos51_from315_dfrc08b-680" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\L1536x5x8_cos51_from315_dfrc08b-680.bin;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>


### PR DESCRIPTION
Added 0.8b DFRC positions, and retrained from superbatch 315 using cosine annealing.

Might be slightly better at standard:
```
Elo   | 2.23 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.23 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 15904 W: 4000 L: 3898 D: 8006
Penta | [107, 1814, 4006, 1920, 105]
http://somelizard.pythonanywhere.com/test/1058/
```

And significantly better at DFRC:
```
Elo   | 26.55 +- 7.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 3108 W: 911 L: 674 D: 1523
Penta | [67, 264, 678, 455, 90]
http://somelizard.pythonanywhere.com/test/1059/
```