### PR TITLE
Added lazy NNUE updates

### DIFF
--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -499,6 +499,11 @@ namespace Lizard.Logic.Core
             Unsafe.CopyBlock(State + 1, State, (uint)StateInfo.StateCopySize);
             State->Accumulator->CopyTo(NextState->Accumulator);
 
+            NextState->Accumulator->Computed[White] = State->Accumulator->Computed[White];
+            NextState->Accumulator->Computed[Black] = State->Accumulator->Computed[Black];
+            NextState->Accumulator->Update[White].Clear();
+            NextState->Accumulator->Update[Black].Clear();
+
             State++;
 
             if (State->EPSquare != EPNone)

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using System.Text;
 
+using Lizard.Logic.Data;
 using Lizard.Logic.NN;
 using Lizard.Logic.Threads;
 
@@ -497,13 +498,12 @@ namespace Lizard.Logic.Core
         {
             //  Copy everything except the pointer to the accumulator, which should never change.
             Unsafe.CopyBlock(State + 1, State, (uint)StateInfo.StateCopySize);
-            State->Accumulator->CopyTo(NextState->Accumulator);
 
-            NextState->Accumulator->Computed[White] = State->Accumulator->Computed[White];
-            NextState->Accumulator->Computed[Black] = State->Accumulator->Computed[Black];
-            NextState->Accumulator->Update[White].Clear();
-            NextState->Accumulator->Update[Black].Clear();
-
+            if (UpdateNN)
+            {
+                NNUE.MakeNullMove(this);
+            }
+            
             State++;
 
             if (State->EPSquare != EPNone)

--- a/Logic/NN/Accumulator.cs
+++ b/Logic/NN/Accumulator.cs
@@ -14,6 +14,8 @@ namespace Lizard.Logic.NN
         public readonly Vector256<short>* Black;
 
         public fixed bool NeedsRefresh[2];
+        public fixed bool Computed[2];
+        public NetworkUpdate Update;
 
         public Accumulator()
         {
@@ -21,6 +23,7 @@ namespace Lizard.Logic.NN
             Black = (Vector256<short>*)AlignedAllocZeroed(ByteSize, AllocAlignment);
 
             NeedsRefresh[Color.White] = NeedsRefresh[Color.Black] = true;
+            Computed[Color.White] = Computed[Color.Black] = false;
         }
 
         public Vector256<short>* this[int perspective] => (perspective == Color.White) ? White : Black;
@@ -32,12 +35,7 @@ namespace Lizard.Logic.NN
 
             target->NeedsRefresh[0] = NeedsRefresh[0];
             target->NeedsRefresh[1] = NeedsRefresh[1];
-        }
 
-        public void CopyTo(Accumulator* target, int perspective)
-        {
-            Unsafe.CopyBlock((*target)[perspective], this[perspective], ByteSize);
-            target->NeedsRefresh[perspective] = NeedsRefresh[perspective];
         }
 
         public void CopyTo(ref Accumulator target, int perspective)

--- a/Logic/NN/Bucketed768Unroll.cs
+++ b/Logic/NN/Bucketed768Unroll.cs
@@ -39,15 +39,7 @@ namespace Lizard.Logic.NN
             var zeroVec = VShort.Zero;
             var sumVec = VInt.Zero;
 
-            if (accumulator.NeedsRefresh[White])
-            {
-                RefreshAccumulatorPerspective(pos, White);
-            }
-
-            if (accumulator.NeedsRefresh[Black])
-            {
-                RefreshAccumulatorPerspective(pos, Black);
-            }
+            Bucketed768.ProcessUpdates(pos);
 
             //  Formula from BlackMarlin
             int occ = (int)popcount(pos.bb.Occupancy);

--- a/Logic/NN/NNUE.cs
+++ b/Logic/NN/NNUE.cs
@@ -13,34 +13,29 @@ namespace Lizard.Logic.NN
 
         public static void RefreshAccumulator(Position pos)
         {
-            if (NetArch == NetworkArchitecture.Bucketed768)
-            {
-                Bucketed768.RefreshAccumulator(pos);
-            }
+            Bucketed768.RefreshAccumulator(pos);
         }
 
         public static short GetEvaluation(Position pos)
         {
-            if (NetArch == NetworkArchitecture.Bucketed768)
+            if (UseAvx)
             {
-                if (UseAvx)
-                {
-                    return (short)Bucketed768.GetEvaluationUnrolled512(pos);
-                }
-                else
-                {
-                    return (short)Bucketed768.GetEvaluation(pos);
-                }
+                return (short)Bucketed768.GetEvaluationUnrolled512(pos);
             }
-
+            else
+            {
+                return (short)Bucketed768.GetEvaluation(pos);
+            }
         }
 
         public static void MakeMove(Position pos, Move m)
         {
-            if (NetArch == NetworkArchitecture.Bucketed768)
-            {
-                Bucketed768.MakeMove(pos, m);
-            }
+            Bucketed768.MakeMove(pos, m);
+        }
+
+        public static void MakeNullMove(Position pos)
+        {
+            Bucketed768.MakeNullMove(pos);
         }
 
 
@@ -52,10 +47,7 @@ namespace Lizard.Logic.NN
         /// </summary>
         public static void LoadNewNetwork(string networkToLoad)
         {
-            if (NetArch == NetworkArchitecture.Bucketed768)
-            {
-                Bucketed768.Initialize(networkToLoad, exitIfFail: false);
-            }
+            Bucketed768.Initialize(networkToLoad, exitIfFail: false);
         }
 
 

--- a/Logic/NN/NetworkUpdate.cs
+++ b/Logic/NN/NetworkUpdate.cs
@@ -1,0 +1,52 @@
+﻿
+using System.Runtime.CompilerServices;
+
+namespace Lizard.Logic.NN
+{
+    public unsafe struct PerspectiveUpdate
+    {
+        public fixed int Adds[2];
+        public fixed int Subs[2];
+        public int AddCnt = 0;
+        public int SubCnt = 0;
+
+        public PerspectiveUpdate() { }
+
+        public void Clear()
+        {
+            AddCnt = SubCnt = 0;
+        }
+
+        public void PushSub(int sub1)
+        {
+            Subs[SubCnt++] = sub1;
+        }
+
+        public void PushSubAdd(int sub1, int add1)
+        {
+            Subs[SubCnt++] = sub1;
+            Adds[AddCnt++] = add1;
+        }
+
+        public void PushSubSubAdd(int sub1, int sub2, int add1)
+        {
+            Subs[SubCnt++] = sub1;
+            Subs[SubCnt++] = sub2;
+            Adds[AddCnt++] = add1;
+        }
+
+        public void PushSubSubAddAdd(int sub1, int sub2, int add1, int add2)
+        {
+            Subs[SubCnt++] = sub1;
+            Subs[SubCnt++] = sub2;
+            Adds[AddCnt++] = add1;
+            Adds[AddCnt++] = add2;
+        }
+    }
+
+    [InlineArray(2)]
+    public unsafe struct NetworkUpdate
+    {
+        public PerspectiveUpdate _Update;
+    }
+}


### PR DESCRIPTION
A very significant speedup:

```
Elo   | 29.84 +- 7.81 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2346 W: 718 L: 517 D: 1111
Penta | [16, 190, 578, 355, 34]
http://somelizard.pythonanywhere.com/test/1133/
```
```
Elo   | 27.52 +- 7.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2252 W: 644 L: 466 D: 1142
Penta | [7, 152, 641, 308, 18]
http://somelizard.pythonanywhere.com/test/1136/
```

The implementation is based on Ciekce/Stormphrax#165