### PR TITLE
Default to non-AOT compilation

### DIFF
--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -26,6 +26,5 @@ global using static Lizard.Logic.Util.Utilities;
 global using Color = Lizard.Logic.Data.Color;
 global using Debug = System.Diagnostics.Debug;
 global using Stopwatch = System.Diagnostics.Stopwatch;
-global using MethodImpl = System.Runtime.CompilerServices.MethodImplAttribute;
 global using MethodImplOptions = System.Runtime.CompilerServices.MethodImplOptions;
 global using Unsafe = System.Runtime.CompilerServices.Unsafe;

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -108,7 +108,7 @@
   <!-- The "instruction-set" argument is required for AOT to generate code with intrinsics -->
   <ItemGroup>
     <ilcArg Include="--Ot" />
-    <ilcArg Include="--instruction-set=native" />
+    <IlcArg Condition="$(IlcInstructionSet) == ''" Include="--instruction-set=native" />
   </ItemGroup>
 
   <!-- If "-p:EVALFILE=(path to network here...)" is passed during the MSBuild, this will set the EvalFile

--- a/Logic/Core/Bitboard.cs
+++ b/Logic/Core/Bitboard.cs
@@ -1,4 +1,6 @@
-﻿namespace Lizard.Logic.Core
+﻿using System.Runtime.CompilerServices;
+
+namespace Lizard.Logic.Core
 {
     /// <summary>
     /// Manages the bitboards for a position, which are 64-bit number arrays for each piece type and color.
@@ -125,6 +127,7 @@
         /// <summary>
         /// Returns the <see cref="Color"/> of the piece on the square <paramref name="idx"/>
         /// </summary>
+        [MethodImpl(Inline)]
         public int GetColorAtIndex(int idx)
         {
             return ((Colors[Color.White] & SquareBB[idx]) != 0) ? Color.White : Color.Black;
@@ -133,6 +136,7 @@
         /// <summary>
         /// Returns the type of the <see cref="Piece"/> on the square <paramref name="idx"/>
         /// </summary>
+        [MethodImpl(Inline)]
         public int GetPieceAtIndex(int idx)
         {
             return PieceTypes[idx];
@@ -142,6 +146,7 @@
         /// <summary>
         /// Returns the index of the square that the <see cref="Color"/> <paramref name="pc"/>'s king is on.
         /// </summary>
+        [MethodImpl(Inline)]
         public int KingIndex(int pc)
         {
             return lsb(Colors[pc] & Pieces[Piece.King]);

--- a/Logic/Core/MoveGeneration.cs
+++ b/Logic/Core/MoveGeneration.cs
@@ -140,8 +140,7 @@
                     int from = poplsb(&mask);
 
                     ref Move m = ref list[size++].Move;
-                    m.SetNew(from, State->EPSquare);
-                    m.EnPassant = true;
+                    m.SetNewEnPassant(from, State->EPSquare);
                 }
             }
 
@@ -229,8 +228,7 @@
                         && (bb.Pieces[Rook] & SquareBB[CastlingRookSquares[(int)CastlingStatus.WK]] & us) != 0)
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.WK]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.WK]);
                     }
 
                     if (State->CastleStatus.HasFlag(CastlingStatus.WQ)
@@ -238,8 +236,7 @@
                         && (bb.Pieces[Rook] & SquareBB[CastlingRookSquares[(int)CastlingStatus.WQ]] & us) != 0)
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.WQ]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.WQ]);
                     }
                 }
                 else if (ToMove == Black && (ourKing == E8 || IsChess960))
@@ -249,8 +246,7 @@
                         && (bb.Pieces[Rook] & SquareBB[CastlingRookSquares[(int)CastlingStatus.BK]] & us) != 0)
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.BK]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.BK]);
                     }
 
                     if (State->CastleStatus.HasFlag(CastlingStatus.BQ)
@@ -258,8 +254,7 @@
                         && (bb.Pieces[Rook] & SquareBB[CastlingRookSquares[(int)CastlingStatus.BQ]] & us) != 0)
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.BQ]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.BQ]);
                     }
                 }
 
@@ -455,8 +450,7 @@
                         && HasCastlingRook(us, CastlingStatus.WK))
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.WK]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.WK]);
                     }
 
                     if (State->CastleStatus.HasFlag(CastlingStatus.WQ)
@@ -464,8 +458,7 @@
                         && HasCastlingRook(us, CastlingStatus.WQ))
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.WQ]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.WQ]);
                     }
                 }
                 else if (ToMove == Black && (ourKing == E8 || IsChess960))
@@ -475,8 +468,7 @@
                         && HasCastlingRook(us, CastlingStatus.BK))
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.BK]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.BK]);
                     }
 
                     if (State->CastleStatus.HasFlag(CastlingStatus.BQ)
@@ -484,8 +476,7 @@
                         && HasCastlingRook(us, CastlingStatus.BQ))
                     {
                         ref Move m = ref list[size++].Move;
-                        m.SetNew(ourKing, CastlingRookSquares[(int)CastlingStatus.BQ]);
-                        m.Castle = true;
+                        m.SetNewCastle(ourKing, CastlingRookSquares[(int)CastlingStatus.BQ]);
                     }
                 }
 

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -350,8 +350,8 @@ namespace Lizard.Logic.NN
 
             dst->Computed[0] = dst->Computed[1] = false;
 
-            int moveTo = m.To;
-            int moveFrom = m.From;
+            int moveTo = m.GetTo();
+            int moveFrom = m.GetFrom();
 
             int us = pos.ToMove;
             int ourPiece = bb.GetPieceAtIndex(moveFrom);
@@ -379,17 +379,17 @@ namespace Lizard.Logic.NN
                 int from = FeatureIndexSingle(us, ourPiece, moveFrom, theirKing, them);
                 int to = FeatureIndexSingle(us, ourPiece, moveTo, theirKing, them);
 
-                if (theirPiece != None && !m.Castle)
+                if (theirPiece != None && !m.GetCastle())
                 {
                     int cap = FeatureIndexSingle(them, theirPiece, moveTo, theirKing, them);
                     theirUpdate.PushSubSubAdd(from, cap, to);
                 }
-                else if (m.Castle)
+                else if (m.GetCastle())
                 {
                     int rookFromSq = moveTo;
-                    int rookToSq = m.CastlingRookSquare;
+                    int rookToSq = m.CastlingRookSquare();
 
-                    to = FeatureIndexSingle(us, ourPiece, m.CastlingKingSquare, theirKing, them);
+                    to = FeatureIndexSingle(us, ourPiece, m.CastlingKingSquare(), theirKing, them);
 
                     int rookFrom = FeatureIndexSingle(us, Rook, rookFromSq, theirKing, them);
                     int rookTo = FeatureIndexSingle(us, Rook, rookToSq, theirKing, them);
@@ -407,7 +407,7 @@ namespace Lizard.Logic.NN
                 int bKing = pos.State->KingSquares[Black];
 
                 (int wFrom, int bFrom) = FeatureIndex(us, ourPiece, moveFrom, wKing, bKing);
-                (int wTo, int bTo) = FeatureIndex(us, m.Promotion ? m.PromotionTo : ourPiece, moveTo, wKing, bKing);
+                (int wTo, int bTo) = FeatureIndex(us, m.GetPromotion() ? m.GetPromotionTo() : ourPiece, moveTo, wKing, bKing);
 
                 wUpdate.PushSubAdd(wFrom, wTo);
                 bUpdate.PushSubAdd(bFrom, bTo);
@@ -419,7 +419,7 @@ namespace Lizard.Logic.NN
                     wUpdate.PushSub(wCap);
                     bUpdate.PushSub(bCap);
                 }
-                else if (m.EnPassant)
+                else if (m.GetEnPassant())
                 {
                     int idxPawn = moveTo - ShiftUpDir(us);
 

--- a/Logic/NN/NNUE.cs
+++ b/Logic/NN/NNUE.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
@@ -11,11 +12,13 @@ namespace Lizard.Logic.NN
         public const NetworkArchitecture NetArch = NetworkArchitecture.Bucketed768;
         public static readonly bool UseAvx = Avx2.IsSupported;
 
+        [MethodImpl(Inline)]
         public static void RefreshAccumulator(Position pos)
         {
             Bucketed768.RefreshAccumulator(pos);
         }
 
+        [MethodImpl(Inline)]
         public static short GetEvaluation(Position pos)
         {
             if (UseAvx)
@@ -28,11 +31,13 @@ namespace Lizard.Logic.NN
             }
         }
 
+        [MethodImpl(Inline)]
         public static void MakeMove(Position pos, Move m)
         {
             Bucketed768.MakeMove(pos, m);
         }
 
+        [MethodImpl(Inline)]
         public static void MakeNullMove(Position pos)
         {
             Bucketed768.MakeNullMove(pos);
@@ -96,6 +101,7 @@ namespace Lizard.Logic.NN
         }
 
 
+        [MethodImpl(Inline)]
         public static int SumVectorNoHadd(Vector256<int> vect)
         {
             Vector128<int> lo = vect.GetLower();
@@ -113,6 +119,7 @@ namespace Lizard.Logic.NN
             return Sse2.ConvertToInt32(sum128);
         }
 
+        [MethodImpl(Inline)]
         public static int SumVectorNoHadd(Vector512<int> vect)
         {
             //  _mm512_reduce_add_epi32 is a sequence instruction and isn't callable

--- a/Logic/NN/NetworkUpdate.cs
+++ b/Logic/NN/NetworkUpdate.cs
@@ -12,22 +12,26 @@ namespace Lizard.Logic.NN
 
         public PerspectiveUpdate() { }
 
+        [MethodImpl(Inline)]
         public void Clear()
         {
             AddCnt = SubCnt = 0;
         }
 
+        [MethodImpl(Inline)]
         public void PushSub(int sub1)
         {
             Subs[SubCnt++] = sub1;
         }
 
+        [MethodImpl(Inline)]
         public void PushSubAdd(int sub1, int add1)
         {
             Subs[SubCnt++] = sub1;
             Adds[AddCnt++] = add1;
         }
 
+        [MethodImpl(Inline)]
         public void PushSubSubAdd(int sub1, int sub2, int add1)
         {
             Subs[SubCnt++] = sub1;
@@ -35,6 +39,7 @@ namespace Lizard.Logic.NN
             Adds[AddCnt++] = add1;
         }
 
+        [MethodImpl(Inline)]
         public void PushSubSubAddAdd(int sub1, int sub2, int add1, int add2)
         {
             Subs[SubCnt++] = sub1;

--- a/Logic/Search/Evaluation.cs
+++ b/Logic/Search/Evaluation.cs
@@ -1,7 +1,10 @@
-﻿namespace Lizard.Logic.Search
+﻿using System.Runtime.CompilerServices;
+
+namespace Lizard.Logic.Search
 {
     public static unsafe class Evaluation
     {
+        [MethodImpl(Inline)]
         public static int MakeMateScore(int ply)
         {
             return -ScoreMate + ply;
@@ -12,44 +15,32 @@
             return Math.Abs(Math.Abs(score) - ScoreMate) < MaxDepth;
         }
 
+        [MethodImpl(Inline)]
         public static int GetPieceValue(int pt)
         {
-            switch (pt)
+            return pt switch
             {
-                case Pawn:
-                    return ValuePawn;
-                case Knight:
-                    return ValueKnight;
-                case Bishop:
-                    return ValueBishop;
-                case Rook:
-                    return ValueRook;
-                case Queen:
-                    return ValueQueen;
-                default:
-                    break;
-            }
-
-            return 0;
+                Pawn   => ValuePawn,
+                Knight => ValueKnight,
+                Bishop => ValueBishop,
+                Rook   => ValueRook,
+                Queen  => ValueQueen,
+                _      => 0,
+            };
         }
 
+        [MethodImpl(Inline)]
         public static int GetSEEValue(int pt)
         {
-            switch (pt)
+            return pt switch
             {
-                case Pawn:
-                    return SEEValue_Pawn;
-                case Knight:
-                    return SEEValue_Knight;
-                case Bishop:
-                    return SEEValue_Bishop;
-                case Rook:
-                    return SEEValue_Rook;
-                case Queen:
-                    return SEEValue_Queen;
-                default:
-                    return 0;
-            }
+                Pawn   => SEEValue_Pawn,
+                Knight => SEEValue_Knight,
+                Bishop => SEEValue_Bishop,
+                Rook   => SEEValue_Rook,
+                Queen  => SEEValue_Queen,
+                _      => 0,
+            };
         }
     }
 }

--- a/Logic/Search/History/MainHistoryTable.cs
+++ b/Logic/Search/History/MainHistoryTable.cs
@@ -37,10 +37,10 @@ namespace Lizard.Logic.Search.History
 
         public static int HistoryIndex(int pc, Move m)
         {
-            Assert(((pc * MainHistoryPCStride) + m.MoveMask) is >= 0 and < MainHistoryElements, 
-                $"HistoryIndex({pc}, {m.MoveMask}) should be < {MainHistoryElements}");
+            Assert(((pc * MainHistoryPCStride) + m.GetMoveMask()) is >= 0 and < MainHistoryElements, 
+                $"HistoryIndex({pc}, {m.GetMoveMask()}) should be < {MainHistoryElements}");
 
-            return (pc * MainHistoryPCStride) + m.MoveMask;
+            return (pc * MainHistoryPCStride) + m.GetMoveMask();
         }
     }
 }

--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -22,8 +22,8 @@ namespace Lizard.Logic.Search.Ordering
             {
                 ref ScoredMove sm = ref list[i];
                 Move m = sm.Move;
-                int moveTo = m.To;
-                int moveFrom = m.From;
+                int moveTo = m.GetTo();
+                int moveFrom = m.GetFrom();
 
                 if (m.Equals(ttMove))
                 {
@@ -37,7 +37,7 @@ namespace Lizard.Logic.Search.Ordering
                 {
                     sm.Score = int.MaxValue - 2000000;
                 }
-                else if (bb.GetPieceAtIndex(moveTo) != None && !m.Castle)
+                else if (bb.GetPieceAtIndex(moveTo) != None && !m.GetCastle())
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
                     sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
@@ -78,14 +78,14 @@ namespace Lizard.Logic.Search.Ordering
             {
                 ref ScoredMove sm = ref list[i];
                 Move m = sm.Move;
-                int moveTo = m.To;
-                int moveFrom = m.From;
+                int moveTo = m.GetTo();
+                int moveFrom = m.GetFrom();
 
                 if (m.Equals(ttMove))
                 {
                     sm.Score = int.MaxValue - 100000;
                 }
-                else if (bb.GetPieceAtIndex(moveTo) != None && !m.Castle)
+                else if (bb.GetPieceAtIndex(moveTo) != None && !m.GetCastle())
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
                     sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
@@ -123,8 +123,8 @@ namespace Lizard.Logic.Search.Ordering
                 ref ScoredMove sm = ref list[i];
                 Move m = sm.Move;
 
-                sm.Score = GetSEEValue(m.EnPassant ? Pawn : bb.GetPieceAtIndex(m.To));
-                if (m.Promotion)
+                sm.Score = GetSEEValue(m.GetEnPassant() ? Pawn : bb.GetPieceAtIndex(m.GetTo()));
+                if (m.GetPromotion())
                 {
                     //  Gives promotions a higher score than captures.
                     //  We can assume a queen promotion is better than most captures.

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -294,8 +294,8 @@ namespace Lizard.Logic.Search
 
                     prefetch(TranspositionTable.GetCluster(pos.HashAfter(m)));
 
-                    bool isCap = (bb.GetPieceAtIndex(m.To) != None && !m.Castle);
-                    int histIdx = PieceToHistory.GetIndex(us, bb.GetPieceAtIndex(m.From), m.To);
+                    bool isCap = (bb.GetPieceAtIndex(m.GetTo()) != None && !m.GetCastle());
+                    int histIdx = PieceToHistory.GetIndex(us, bb.GetPieceAtIndex(m.GetFrom()), m.GetTo());
                     
                     ss->CurrentMove = m;
                     ss->ContinuationHistory = history.Continuations[ss->InCheck.AsInt()][isCap.AsInt()][histIdx];
@@ -374,11 +374,11 @@ namespace Lizard.Logic.Search
 
                 Assert(pos.IsPseudoLegal(m), $"The move {m} = {m.ToString(pos)} was legal for FEN {pos.GetFEN()}, but it isn't pseudo-legal!");
 
-                int moveFrom = m.From;
-                int moveTo = m.To;
+                int moveFrom = m.GetFrom();
+                int moveTo = m.GetTo();
                 int theirPiece = bb.GetPieceAtIndex(moveTo);
                 int ourPiece = bb.GetPieceAtIndex(moveFrom);
-                bool isCapture = (theirPiece != None && !m.Castle);
+                bool isCapture = (theirPiece != None && !m.GetCastle());
 
                 legalMoves++;
                 int extend = 0;
@@ -558,7 +558,7 @@ namespace Lizard.Logic.Search
                             bonus = StatBonus(newDepth - 1);
                         }
 
-                        UpdateContinuations(ss, us, ourPiece, m.To, bonus);
+                        UpdateContinuations(ss, us, ourPiece, m.GetTo(), bonus);
                     }
                 }
                 else if (!isPV || legalMoves > 1)
@@ -813,7 +813,7 @@ namespace Lizard.Logic.Search
                 futility = (short)(Math.Min(ss->StaticEval, bestScore) + FutilityExchangeBase);
             }
 
-            int prevSquare = (ss - 1)->CurrentMove.IsNull() ? SquareNB : (ss - 1)->CurrentMove.To;
+            int prevSquare = (ss - 1)->CurrentMove.IsNull() ? SquareNB : (ss - 1)->CurrentMove.GetTo();
             int legalMoves = 0;
             int movesMade = 0;
             int checkEvasions = 0;
@@ -835,18 +835,18 @@ namespace Lizard.Logic.Search
 
                 legalMoves++;
 
-                int moveFrom = m.From;
-                int moveTo = m.To;
+                int moveFrom = m.GetFrom();
+                int moveTo = m.GetTo();
                 int theirPiece = bb.GetPieceAtIndex(moveTo);
                 int ourPiece = bb.GetPieceAtIndex(moveFrom);
-                bool isCapture = (theirPiece != None && !m.Castle);
+                bool isCapture = (theirPiece != None && !m.GetCastle());
                 bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB[moveTo]) != 0);
 
                 movesMade++;
 
                 if (bestScore > ScoreTTLoss)
                 {
-                    if (!(givesCheck || m.Promotion)
+                    if (!(givesCheck || m.GetPromotion())
                         && (prevSquare != moveTo)
                         && futility > -ScoreWin)
                     {
@@ -966,8 +966,8 @@ namespace Lizard.Logic.Search
                                 Move* quietMoves, int quietCount, Move* captureMoves, int captureCount)
         {
             ref HistoryTable history = ref pos.Owner.History;
-            int moveFrom = bestMove.From;
-            int moveTo = bestMove.To;
+            int moveFrom = bestMove.GetFrom();
+            int moveTo = bestMove.GetTo();
 
             ref Bitboard bb = ref pos.bb;
 
@@ -978,7 +978,7 @@ namespace Lizard.Logic.Search
             int quietMoveBonus = StatBonus(depth + 1);
             int quietMovePenalty = StatMalus(depth);
 
-            if (capturedPiece != None && !bestMove.Castle)
+            if (capturedPiece != None && !bestMove.GetCastle())
             {
                 history.CaptureHistory[thisColor, thisPiece, moveTo, capturedPiece] <<= quietMoveBonus;
             }
@@ -987,7 +987,7 @@ namespace Lizard.Logic.Search
 
                 int bestMoveBonus = (bestScore > beta + HistoryCaptureBonusMargin) ? quietMoveBonus : StatBonus(depth);
 
-                if (ss->Killer0 != bestMove && !bestMove.EnPassant)
+                if (ss->Killer0 != bestMove && !bestMove.GetEnPassant())
                 {
                     ss->Killer1 = ss->Killer0;
                     ss->Killer0 = bestMove;
@@ -1000,14 +1000,14 @@ namespace Lizard.Logic.Search
                 {
                     Move m = quietMoves[i];
                     history.MainHistory[thisColor, m] <<= -quietMovePenalty;
-                    UpdateContinuations(ss, thisColor, bb.GetPieceAtIndex(m.From), m.To, -quietMovePenalty);
+                    UpdateContinuations(ss, thisColor, bb.GetPieceAtIndex(m.GetFrom()), m.GetTo(), -quietMovePenalty);
                 }
             }
 
             for (int i = 0; i < captureCount; i++)
             {
                 Move m = captureMoves[i];
-                history.CaptureHistory[thisColor, bb.GetPieceAtIndex(m.From), m.To, bb.GetPieceAtIndex(m.To)] <<= -quietMoveBonus;
+                history.CaptureHistory[thisColor, bb.GetPieceAtIndex(m.GetFrom()), m.GetTo(), bb.GetPieceAtIndex(m.GetTo())] <<= -quietMoveBonus;
             }
         }
 
@@ -1070,15 +1070,15 @@ namespace Lizard.Logic.Search
         /// </summary>
         public static bool SEE_GE(Position pos, in Move m, int threshold = 1)
         {
-            if (m.Castle || m.EnPassant || m.Promotion)
+            if (m.GetCastle() || m.GetEnPassant() || m.GetPromotion())
             {
                 return threshold <= 0;
             }
 
             ref Bitboard bb = ref pos.bb;
 
-            int from = m.From;
-            int to = m.To;
+            int from = m.GetFrom();
+            int to = m.GetTo();
 
             int swap = GetSEEValue(bb.GetPieceAtIndex(to)) - threshold;
             if (swap < 0)

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -510,7 +510,7 @@ namespace Lizard.Logic.Threads
             double multFactor = 1.0;
             if (RootDepth > 7)
             {
-                double proportion = NodeTable[RootMoves[0].Move.From][RootMoves[0].Move.To] / (double)Nodes;
+                double proportion = NodeTable[RootMoves[0].Move.GetFrom()][RootMoves[0].Move.GetTo()] / (double)Nodes;
                 multFactor = ((1.5 - proportion) * 1.75) * StabilityCoefficients[Math.Min(stability, StabilityMax)];
             }
 

--- a/Logic/Transposition/Cuckoo.cs
+++ b/Logic/Transposition/Cuckoo.cs
@@ -83,8 +83,8 @@
                     continue;
 
                 Move m = Moves[slot];
-                int moveFrom = m.From;
-                int moveTo = m.To;
+                int moveFrom = m.GetFrom();
+                int moveTo = m.GetTo();
 
                 if ((bb.Occupancy & LineBB[moveFrom][moveTo]) == 0)
                 {

--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Lizard.Logic.Transposition
 {
@@ -83,6 +84,7 @@ namespace Lizard.Logic.Transposition
         /// <summary>
         /// Returns a pointer to the <see cref="TTCluster"/> that the <paramref name="hash"/> maps to.
         /// </summary>
+        [MethodImpl(Inline)]
         public static TTCluster* GetCluster(ulong hash)
         {
             return Clusters + ((ulong)(((UInt128)hash * (UInt128)ClusterCount) >> 64));

--- a/Logic/Util/ExceptionHandling.cs
+++ b/Logic/Util/ExceptionHandling.cs
@@ -5,7 +5,7 @@ namespace Lizard.Logic.Util
     public static class ExceptionHandling
     {
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.MethodImpl(MethodImplOptions.NoInlining)]
         [Conditional("ENABLE_ASSERTIONS")]
         public static void Assert(bool condition, string message)
         {

--- a/Logic/Util/Interop.cs
+++ b/Logic/Util/Interop.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
@@ -13,6 +14,7 @@ namespace Lizard.Logic.Util
         /// This isn't a guarantee, and the time it takes for <see cref="Unsafe.AsPointer"/> to compute the address does hurt, 
         /// but regardless this seems to help.
         /// </summary>
+        [MethodImpl(Inline)]
         public static unsafe void prefetch(void* address)
         {
             if (Sse.IsSupported)
@@ -25,21 +27,16 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the number of bits set in <paramref name="value"/> using <c>_mm_popcnt_u64</c>
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong popcount(ulong value)
         {
-            if (Popcnt.X64.IsSupported)
-            {
-                return Popcnt.X64.PopCount(value);
-            }
-            else
-            {
-                return ulong.PopCount(value);
-            }
+            return ulong.PopCount(value);
         }
 
         /// <summary>
         /// Returns true if <paramref name="value"/> has more than one bit set.
         /// </summary>
+        [MethodImpl(Inline)]
         public static bool MoreThanOne(ulong value)
         {
             return poplsb(value) != 0;
@@ -49,58 +46,39 @@ namespace Lizard.Logic.Util
         /// Returns the number of trailing least significant zero bits in <paramref name="value"/> using <c>Bmi1.X64.TrailingZeroCount</c>. 
         /// So lsb(100_2) returns 2.
         /// </summary>
+        [MethodImpl(Inline)]
         public static int lsb(ulong value)
         {
-            if (Bmi1.X64.IsSupported)
-            {
-                return (int)Bmi1.X64.TrailingZeroCount(value);
-            }
-            else
-            {
-                return (int)ulong.TrailingZeroCount(value);
-            }
+            return (int)ulong.TrailingZeroCount(value);
         }
 
         /// <summary>
         /// Sets the least significant bit to 0 using <c>Bmi1.X64.ResetLowestSetBit</c>. 
         /// So PopLsb(10110_2) returns 10100_2.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong poplsb(ulong value)
         {
-            if (Bmi1.X64.IsSupported)
-            {
-                return Bmi1.X64.ResetLowestSetBit(value);
-            }
-            else
-            {
-                return value & (value - 1);
-            }
+            return value & (value - 1);
         }
 
         /// <summary>
         /// Returns the number of trailing least significant zero bits in <paramref name="value"/> using <c>_mm_tzcnt_64</c>,
         /// and clears the lowest set bit with <c>_blsr_u64</c>.
         /// </summary>
+        [MethodImpl(Inline)]
         public static unsafe int poplsb(ulong* value)
         {
-            if (Bmi1.X64.IsSupported)
-            {
-                int sq = (int)Bmi1.X64.TrailingZeroCount(*value);
-                *value = Bmi1.X64.ResetLowestSetBit(*value);
-                return sq;
-            }
-            else
-            {
-                int sq = (int)ulong.TrailingZeroCount(*value);
-                *value = *value & (*value - 1);
-                return sq;
-            }
+            int sq = (int)ulong.TrailingZeroCount(*value);
+            *value = *value & (*value - 1);
+            return sq;
         }
 
         /// <summary>
         /// Returns the index of the most significant bit (highest, toward the square H8) 
         /// set in the mask <paramref name="value"/> using <c>Lzcnt.X64.LeadingZeroCount</c>
         /// </summary>
+        [MethodImpl(Inline)]
         public static int msb(ulong value)
         {
             if (Lzcnt.X64.IsSupported)
@@ -131,6 +109,7 @@ namespace Lizard.Logic.Util
         /// So <c>pext("ABCD EFGH", 1011 0001)</c> would return <c>"0000 ACDH"</c>,
         /// where ACDH could each be 0 or 1 depending on if they were set in <paramref name="value"/>
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong pext(ulong value, ulong mask)
         {
             if (Bmi2.X64.IsSupported)

--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,28 @@ ifndef OUT_PATH
 endif
 
 ifeq ($(OS),Windows_NT) 
-	FULL_EXE_PATH = $(OUT_PATH)$(EXE).exe
+	
+	BINARY_SUFFIX = .exe
 	PDB_SUFF = pdb
 
+	RENAME_CMD = -ren
 	RM_FILE_CMD = del
 	RM_FOLDER_CMD = rmdir /s /q
 else
-	FULL_EXE_PATH = $(OUT_PATH)$(EXE)
 	PDB_SUFF = dbg
+	BINARY_SUFFIX = 
 
+	RENAME_CMD = mv
 	RM_FILE_CMD = rm
 	RM_FOLDER_CMD = rm -rf
 endif
 
+FULL_EXE_PATH = $(EXE)$(BINARY_SUFFIX)
 RM_PDB = -$(RM_FILE_CMD) $(EXE).$(PDB_SUFF)
 RM_BLD_FOLDER = -cd bin && $(RM_FOLDER_CMD) Release && cd ..
+RM_OBJ_FOLDER = -$(RM_FOLDER_CMD) obj
 
+INST_SET = native
 
 #  self-contained              .NET Core won't need to be installed to run the binary
 #  -v quiet                    Silences CS#### warnings during building (e.g. "CS0162: Unreachable code detected")
@@ -42,17 +48,17 @@ RM_BLD_FOLDER = -cd bin && $(RM_FOLDER_CMD) Release && cd ..
 BUILD_OPTS := --self-contained -v quiet --property WarningLevel=0 -o ./ -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
 
 
-#  -p:PublishAOT=true           Actually enables AOT
-#  -p:PublishSingleFile=false   AOT is incompatible with single file publishing
-#  -p:IS_AOT=true               Sets a variable during runtime signalling AOT is enabled, same to how EVALFILE works.
-AOT_OPTS = -p:PublishAOT=true -p:PublishSingleFile=false -p:IS_AOT=true
+#  -p:PublishAOT=true                 Actually enables AOT
+#  -p:PublishSingleFile=false         AOT is incompatible with single file publishing
+#  -p:IS_AOT=true                     Sets a variable during runtime signalling AOT is enabled, same to how EVALFILE works.
+#  -p:IlcInstructionSet=$(INST_SET)   Instruction set to use, should be "native" if you are only running the binary on your cpu.
+AOT_OPTS = -p:PublishAOT=true -p:PublishSingleFile=false -p:IS_AOT=true -p:IlcInstructionSet=$(INST_SET)
 
 
 #  Try building the non-AOT version first, and then try to build the AOT version if possible.
 #  This recipe should always work, but AOT requires some additional setup so that recipe may fail.
 release:
 	dotnet publish . $(BUILD_OPTS)
-	$(MAKE) aot
 
 
 #  This will/might only succeed if you have the right toolchain
@@ -62,13 +68,26 @@ aot:
 
 512:
 	dotnet publish . $(BUILD_OPTS) -p:DefineConstants="AVX512"
-	$(MAKE) aot_512
 
 
 aot_512:
 	-dotnet publish . $(BUILD_OPTS) $(AOT_OPTS) -p:DefineConstants="AVX512"
 
+all:
+	$(MAKE) aot INST_SET=x86-x64
+	$(RENAME_CMD) $(FULL_EXE_PATH) $(EXE)-aot-v1$(BINARY_SUFFIX)
+	$(MAKE) aot INST_SET=x86-x64-v2
+	$(RENAME_CMD) $(FULL_EXE_PATH) $(EXE)-aot-v2$(BINARY_SUFFIX)
+	$(MAKE) aot INST_SET=x86-x64-v3
+	$(RENAME_CMD) $(FULL_EXE_PATH) $(EXE)-aot-v3$(BINARY_SUFFIX)
+	$(MAKE) aot_512 INST_SET=x86-x64-v4
+	$(RENAME_CMD) $(FULL_EXE_PATH) $(EXE)-aot-v4$(BINARY_SUFFIX)
+	$(MAKE) 512
+	$(RENAME_CMD) $(FULL_EXE_PATH) $(EXE)-512$(BINARY_SUFFIX)
+	$(MAKE) release
+	$(RENAME_CMD) $(FULL_EXE_PATH) $(EXE)$(BINARY_SUFFIX)
 
 clean:
+	$(RM_OBJ_FOLDER)
 	$(RM_BLD_FOLDER)
 	$(RM_PDB)

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,10 @@ RM_OBJ_FOLDER = -$(RM_FOLDER_CMD) obj
 INST_SET = native
 
 # Macos doesn't seem to like this parameter and the GenerateBundle task fails during building.
-ifneq ($(OS),Darwin)
-    OUT_DIR = -o ./
+ifeq ($(OS),Windows_NT)
+	OUT_DIR = -o ./
+else ifeq ($(OS),Linux)
+	OUT_DIR = -o ./
 endif
 
 #  self-contained              .NET Core won't need to be installed to run the binary

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ ifndef OUT_PATH
 endif
 
 ifeq ($(OS),Windows_NT) 
-	
 	BINARY_SUFFIX = .exe
 	PDB_SUFF = pdb
 
@@ -36,16 +35,21 @@ RM_OBJ_FOLDER = -$(RM_FOLDER_CMD) obj
 
 INST_SET = native
 
+# Macos doesn't seem to like this parameter and the GenerateBundle task fails during building.
+ifneq ($(OS),Darwin)
+    OUT_DIR = -o ./
+endif
+
 #  self-contained              .NET Core won't need to be installed to run the binary
 #  -v quiet                    Silences CS#### warnings during building (e.g. "CS0162: Unreachable code detected")
-#  --property WarningLevel=0   Silences CS#### warnings during building
-#  -o ./                       Outputs the binary in the current directory
+#  -p:WarningLevel=0           Silences CS#### warnings during building
+#  $(OUT_DIR)                  Should be "-o ./", which outputs the binary in the current directory
 #  -c Release                  Builds using the Release configuration in Lizard.csproj
 #  -p:AssemblyName=$(EXE)      Renames the binary to whatever $(EXE) is.
 #  -p:DebugType=embedded       Places the PDB file inside the binary
 #  -p:EVALFILE=$(EVALFILE)     Path to a network to be loaded. Note the file is NOT embedded, so it can't be moved or the binary will fail to load it.
 #                              This should probably be an absolute path.
-BUILD_OPTS := --self-contained -v quiet --property WarningLevel=0 -o ./ -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
+BUILD_OPTS := --self-contained -v quiet -p:WarningLevel=0 $(OUT_DIR) -c Release -p:AssemblyName=$(EXE) -p:DebugType=embedded -p:EVALFILE=$(EVALFILE)
 
 
 #  -p:PublishAOT=true                 Actually enables AOT


### PR DESCRIPTION
Reverts to non-AOT compilation by default, which is now faster apparently:
```
Elo   | 16.24 +- 5.63 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4132 W: 1130 L: 937 D: 2065
Penta | [32, 359, 1096, 542, 37]
http://somelizard.pythonanywhere.com/test/1142/
```
Also added a few AggressiveInlining attributes in logical places. The changes to the Move classes properties (`move.From`, `move.To`, etc.) might be reverted in the future if it becomes annoying. Most of the speedup here comes from the non-AOT part, not the inlining.