### PR TITLE
General cleanups

### DIFF
--- a/Logic/Core/Bitboard.cs
+++ b/Logic/Core/Bitboard.cs
@@ -152,27 +152,6 @@ namespace Lizard.Logic.Core
             return lsb(Colors[pc] & Pieces[Piece.King]);
         }
 
-        /// <summary>
-        /// Returns the sum of the <see cref="Piece"/> values for the <see cref="Color"/> <paramref name="pc"/>.
-        /// </summary>
-        public int MaterialCount(int pc, bool excludePawns = false)
-        {
-            int mat = 0;
-            ulong temp = Colors[pc];
-            while (temp != 0)
-            {
-                int idx = poplsb(&temp);
-
-                int pt = GetPieceAtIndex(idx);
-                if (!(excludePawns && pt == Pawn))
-                {
-                    mat += GetPieceValue(pt);
-                }
-            }
-
-            return mat;
-        }
-
 
         /// <summary>
         /// Returns a mask of the pieces
@@ -251,19 +230,5 @@ namespace Lizard.Logic.Core
             };
         }
 
-        /// <summary>
-        /// Returns a mask of all of the squares that pieces of type <paramref name="pt"/> and color <paramref name="pc"/> attack.
-        /// </summary>
-        public ulong AttackMask(int pc, int pt)
-        {
-            ulong mask = 0;
-            ulong occ = Occupancy;
-            ulong pieces = Colors[pc] & Pieces[pt];
-            while (pieces != 0)
-            {
-                mask |= AttackMask(poplsb(&pieces), pc, pt, occ);
-            }
-            return mask;
-        }
     }
 }

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -93,7 +93,7 @@ namespace Lizard.Logic.Core
         public bool HasCastlingRook(ulong us, CastlingStatus cr) => (bb.Pieces[Rook] & SquareBB[CastlingRookSquares[(int)cr]] & us) != 0;
 
         [MethodImpl(Inline)]
-        public bool HasNonPawnMaterial(int pc) => (((bb.Occupancy ^ bb.Pieces[Pawn]) & bb.Colors[pc]) != 0);
+        public bool HasNonPawnMaterial(int pc) => (((bb.Occupancy ^ bb.Pieces[Pawn] ^ bb.Pieces[King]) & bb.Colors[pc]) != 0);
 
         /// <summary>
         /// Creates a new Position object and loads the provided FEN.

--- a/Logic/Core/PrecomputedData.cs
+++ b/Logic/Core/PrecomputedData.cs
@@ -16,33 +16,33 @@
         /// <summary>
         /// At each index, contains a ulong with bits set at each neighboring square.
         /// </summary>
-        public static readonly ulong* NeighborsMask = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong* NeighborsMask = AlignedAllocZeroed<ulong>(SquareNB);
 
         /// <summary>
         /// At each index, contains a mask of each of the squares that a knight could move to.
         /// </summary>
-        public static readonly ulong* KnightMasks = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong* KnightMasks = AlignedAllocZeroed<ulong>(SquareNB);
 
-        public static readonly ulong* RookRays = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong* RookRays = AlignedAllocZeroed<ulong>(SquareNB);
 
-        public static readonly ulong* BishopRays = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong* BishopRays = AlignedAllocZeroed<ulong>(SquareNB);
 
         /// <summary>
         /// Bitboards containing all of the squares that a White pawn on an index attacks. A White pawn on A2 attacks B3 etc.
         /// </summary>
-        public static readonly ulong* WhitePawnAttackMasks = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong* WhitePawnAttackMasks = AlignedAllocZeroed<ulong>(SquareNB);
 
         /// <summary>
         /// Bitboards containing all of the squares that a Black pawn on an index attacks. A Black pawn on A7 attacks B6 etc.
         /// </summary>
-        public static readonly ulong* BlackPawnAttackMasks = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong* BlackPawnAttackMasks = AlignedAllocZeroed<ulong>(SquareNB);
 
-        public static readonly ulong** PawnAttackMasks = (ulong**)AlignedAllocZeroed(sizeof(ulong) * 2, AllocAlignment);
+        public static readonly ulong** PawnAttackMasks = (ulong**)AlignedAllocZeroed(sizeof(ulong) * 2);
 
         /// <summary>
         /// At each index, contains a ulong equal to (1UL << index).
         /// </summary>
-        public static readonly ulong* SquareBB = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * SquareNB), AllocAlignment);
+        public static readonly ulong* SquareBB = AlignedAllocZeroed<ulong>(SquareNB);
 
         /// <summary>
         /// Bitboards with bits set at every index that exists in a line between two indices.
@@ -52,7 +52,7 @@
         /// <para></para>
         /// So LineBB[A1][H1] gives 254, or 01111111
         /// </summary>
-        public static readonly ulong** LineBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong** LineBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB);
 
 
         /// <summary>
@@ -60,7 +60,7 @@
         /// <para></para>
         /// So BetweenBB[A1][H1] gives 126, or 01111110
         /// </summary>
-        public static readonly ulong** BetweenBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong** BetweenBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB);
 
         /// <summary>
         /// Bitboards with bits set at every index that exists along the entire ray that two squares have in common.
@@ -69,7 +69,7 @@
         /// and likewise for diagonals. Otherwise, those squares' RayBB is 0.
         /// <br></br>
         /// </summary>
-        public static readonly ulong** RayBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong** RayBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB);
 
 
         /// <summary>
@@ -86,7 +86,7 @@
         /// claiming that it was the piece giving check, instead of the rook.
         /// <br></br>
         /// </summary>
-        public static readonly ulong** XrayBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+        public static readonly ulong** XrayBB = (ulong**)AlignedAllocZeroed(sizeof(ulong) * SquareNB);
 
 
         static PrecomputedData()
@@ -149,8 +149,8 @@
         {
             for (int s1 = 0; s1 < 64; s1++)
             {
-                RayBB[s1] = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
-                XrayBB[s1] = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+                RayBB[s1] = AlignedAllocZeroed<ulong>(SquareNB);
+                XrayBB[s1] = AlignedAllocZeroed<ulong>(SquareNB);
 
 
                 for (int s2 = 0; s2 < 64; s2++)
@@ -288,8 +288,8 @@
 
             for (int s1 = 0; s1 < 64; s1++)
             {
-                LineBB[s1] = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
-                BetweenBB[s1] = (ulong*)AlignedAllocZeroed(sizeof(ulong) * SquareNB, AllocAlignment);
+                LineBB[s1] = AlignedAllocZeroed<ulong>(SquareNB);
+                BetweenBB[s1] = AlignedAllocZeroed<ulong>(SquareNB);
 
                 int f1 = GetIndexFile(s1);
                 int r1 = GetIndexRank(s1);

--- a/Logic/Data/PredicateType.cs
+++ b/Logic/Data/PredicateType.cs
@@ -1,8 +1,0 @@
-﻿namespace Lizard.Logic.Data
-{
-    public interface PredicateType { }
-
-    public struct PredicateNext : PredicateType { }
-    public struct PredicateBest : PredicateType { }
-
-}

--- a/Logic/Magic/MagicBitboards.cs
+++ b/Logic/Magic/MagicBitboards.cs
@@ -52,8 +52,8 @@ namespace Lizard.Logic.Magic
                 return;
             }
 
-            RookTable = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * 0x19000), AllocAlignment);
-            BishopTable = (ulong*)AlignedAllocZeroed((nuint)(sizeof(ulong) * 0x19000), AllocAlignment);
+            RookTable = AlignedAllocZeroed<ulong>(0x19000);
+            BishopTable = AlignedAllocZeroed<ulong>(0x19000);
             FancyRookMagics = InitializeFancyMagics(Piece.Rook, RookTable);
             FancyBishopMagics = InitializeFancyMagics(Piece.Bishop, BishopTable);
 
@@ -198,7 +198,7 @@ namespace Lizard.Logic.Magic
         /// </summary>
         private static FancyMagicSquare* InitializeFancyMagics(int pt, ulong* table)
         {
-            FancyMagicSquare* magicArray = (FancyMagicSquare*)AlignedAllocZeroed((nuint)(sizeof(FancyMagicSquare) * 64), AllocAlignment);
+            FancyMagicSquare* magicArray = AlignedAllocZeroed<FancyMagicSquare>(64);
 
             ulong b;
             int size = 0;

--- a/Logic/NN/Accumulator.cs
+++ b/Logic/NN/Accumulator.cs
@@ -10,8 +10,8 @@ namespace Lizard.Logic.NN
     {
         public const int ByteSize = Bucketed768.HiddenSize * sizeof(short);
 
-        public readonly Vector256<short>* White;
-        public readonly Vector256<short>* Black;
+        public readonly short* White;
+        public readonly short* Black;
 
         public fixed bool NeedsRefresh[2];
         public fixed bool Computed[2];
@@ -19,14 +19,14 @@ namespace Lizard.Logic.NN
 
         public Accumulator()
         {
-            White = (Vector256<short>*)AlignedAllocZeroed(ByteSize, AllocAlignment);
-            Black = (Vector256<short>*)AlignedAllocZeroed(ByteSize, AllocAlignment);
+            White = AlignedAllocZeroed<short>(Bucketed768.HiddenSize);
+            Black = AlignedAllocZeroed<short>(Bucketed768.HiddenSize);
 
             NeedsRefresh[Color.White] = NeedsRefresh[Color.Black] = true;
             Computed[Color.White] = Computed[Color.Black] = false;
         }
 
-        public Vector256<short>* this[int perspective] => (perspective == Color.White) ? White : Black;
+        public Vector256<short>* this[int perspective] => (perspective == Color.White) ? (Vector256<short>*)White : (Vector256<short>*)Black;
 
         public void CopyTo(Accumulator* target)
         {

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -54,11 +54,11 @@ namespace Lizard.Logic.NN
 
         static Bucketed768()
         {
-            FeatureWeights = (short*)AlignedAllocZeroed(sizeof(short) * FeatureWeightElements);
-            FeatureBiases = (short*)AlignedAllocZeroed(sizeof(short) * FeatureBiasElements);
+            FeatureWeights = AlignedAllocZeroed<short>(FeatureWeightElements);
+            FeatureBiases = AlignedAllocZeroed<short>(FeatureBiasElements);
 
-            LayerWeights = (short*)AlignedAllocZeroed(sizeof(short) * LayerWeightElements);
-            LayerBiases = (short*)AlignedAllocZeroed(sizeof(short) * (nuint)Math.Max(LayerBiasElements, Vector512<short>.Count));
+            LayerWeights = AlignedAllocZeroed<short>(LayerWeightElements);
+            LayerBiases = AlignedAllocZeroed<short>(Math.Max(LayerBiasElements, Vector512<short>.Count));
 
             string networkToLoad = NetworkName;
 
@@ -173,29 +173,6 @@ namespace Lizard.Logic.NN
             accumulator.CopyTo(ref entryAcc, perspective);
             bb.CopyTo(ref entryBB);
         }
-
-        public static void RefreshAccumulatorState(StateInfo* st, ref Accumulator accumulator, ref Bitboard bb, int perspective)
-        {
-            var ourAccumulation = (short*)accumulator[perspective];
-            Unsafe.CopyBlock(ourAccumulation, FeatureBiases, sizeof(short) * HiddenSize);
-            accumulator.NeedsRefresh[perspective] = false;
-            accumulator.Computed[perspective] = true;
-
-            int ourKing = st->KingSquares[perspective];
-            ulong occ = bb.Occupancy;
-            while (occ != 0)
-            {
-                int pieceIdx = poplsb(&occ);
-
-                int pt = bb.GetPieceAtIndex(pieceIdx);
-                int pc = bb.GetColorAtIndex(pieceIdx);
-
-                int idx = FeatureIndexSingle(pc, pt, pieceIdx, ourKing, perspective);
-                var ourWeights = (Vector512<short>*)(FeatureWeights + idx);
-                UnrollAdd(ourAccumulation, ourAccumulation, FeatureWeights + idx);
-            }
-        }
-
 
         public static void RefreshAccumulatorPerspective(Position pos, int perspective)
         {

--- a/Logic/Search/History/CaptureHistoryTable.cs
+++ b/Logic/Search/History/CaptureHistoryTable.cs
@@ -9,7 +9,7 @@ namespace Lizard.Logic.Search.History
 
         public CaptureHistoryTable()
         {
-            _History = (StatEntry*)AlignedAllocZeroed((nuint)sizeof(StatEntry) * CaptureHistoryElements, AllocAlignment);
+            _History = AlignedAllocZeroed<StatEntry>(CaptureHistoryElements);
         }
 
         public StatEntry this[int idx]

--- a/Logic/Search/History/ContinuationHistory.cs
+++ b/Logic/Search/History/ContinuationHistory.cs
@@ -17,22 +17,21 @@ namespace Lizard.Logic.Search.History
         /// <summary>
         /// 12 * 64 == 768 elements
         /// </summary>
-        public const nuint Length = DimX * DimY;
+        public const int Length = DimX * DimY;
 
-        /// <summary>
-        /// 8 * (<inheritdoc cref="Length"/>) == 6144 bytes
-        /// </summary>
-        private const nuint ByteSize = (nuint)(sizeof(ulong) * Length);
 
         public ContinuationHistory()
         {
-            _History = (PieceToHistory*)AlignedAllocZeroed(ByteSize, AllocAlignment);
+            _History = (PieceToHistory*)AlignedAllocZeroed((nuint)(sizeof(ulong) * Length), AllocAlignment);
 
             for (nuint i = 0; i < Length; i++)
             {
                 (_History + i)->Alloc();
             }
         }
+
+        public PieceToHistory* this[int pc, int pt, int sq] => &_History[PieceToHistory.GetIndex(pc, pt, sq)];
+        public PieceToHistory* this[int idx] => &_History[idx];
 
         public void Dispose()
         {
@@ -43,25 +42,6 @@ namespace Lizard.Logic.Search.History
 
             NativeMemory.AlignedFree(_History);
         }
-
-
-        public PieceToHistory* this[int pc, int pt, int sq]
-        {
-            get
-            {
-                int idx = PieceToHistory.GetIndex(pc, pt, sq);
-                return &_History[idx];
-            }
-        }
-
-        public PieceToHistory* this[int idx]
-        {
-            get
-            {
-                return &_History[idx];
-            }
-        }
-
 
         public void Clear()
         {

--- a/Logic/Search/History/MainHistoryTable.cs
+++ b/Logic/Search/History/MainHistoryTable.cs
@@ -10,7 +10,7 @@ namespace Lizard.Logic.Search.History
 
         public MainHistoryTable()
         {
-            _History = (StatEntry*)AlignedAllocZeroed((nuint)sizeof(StatEntry) * MainHistoryElements, AllocAlignment);
+            _History = AlignedAllocZeroed<StatEntry>(MainHistoryElements);
         }
 
         public StatEntry this[int idx]

--- a/Logic/Search/History/PieceToHistory.cs
+++ b/Logic/Search/History/PieceToHistory.cs
@@ -21,12 +21,7 @@ namespace Lizard.Logic.Search.History
         /// <summary>
         /// 12 * 64 == 768 elements
         /// </summary>
-        public const nuint Length = DimX * DimY;
-
-        /// <summary>
-        /// 2 * (<inheritdoc cref="Length"/>) == 1536 bytes
-        /// </summary>
-        public const nuint ByteSize = sizeof(short) * Length;
+        public const int Length = DimX * DimY;
 
         public PieceToHistory() { }
 
@@ -63,7 +58,7 @@ namespace Lizard.Logic.Search.History
         /// </summary>
         public void Alloc()
         {
-            _History = (StatEntry*)AlignedAllocZeroed(ByteSize, AllocAlignment);
+            _History = AlignedAllocZeroed<StatEntry>(Length);
         }
 
         /// <summary>
@@ -71,7 +66,7 @@ namespace Lizard.Logic.Search.History
         /// </summary>
         public void Clear()
         {
-            NativeMemory.Clear(_History, ByteSize);
+            NativeMemory.Clear(_History, (nuint)(sizeof(StatEntry) * Length));
             Span<StatEntry> span = new Span<StatEntry>(_History, (int)Length);
             span.Fill(FillValue);
         }

--- a/Logic/Search/Ordering/HistoryTable.cs
+++ b/Logic/Search/Ordering/HistoryTable.cs
@@ -35,9 +35,9 @@ namespace Lizard.Logic.Search.History
 
             //  5D arrays aren't real, they can't hurt you.
             //  5D arrays:
-            Continuations = (ContinuationHistory**)AlignedAllocZeroed((nuint)(sizeof(ContinuationHistory*) * 2), AllocAlignment);
-            ContinuationHistory* cont0 = (ContinuationHistory*)AlignedAllocZeroed((nuint)(sizeof(ContinuationHistory*) * 2), AllocAlignment);
-            ContinuationHistory* cont1 = (ContinuationHistory*)AlignedAllocZeroed((nuint)(sizeof(ContinuationHistory*) * 2), AllocAlignment);
+            Continuations = (ContinuationHistory**)AlignedAllocZeroed((nuint)(sizeof(ContinuationHistory*) * 2));
+            ContinuationHistory* cont0 = (ContinuationHistory*)AlignedAllocZeroed((nuint)(sizeof(ContinuationHistory*) * 2));
+            ContinuationHistory* cont1 = (ContinuationHistory*)AlignedAllocZeroed((nuint)(sizeof(ContinuationHistory*) * 2));
 
             cont0[0] = new ContinuationHistory();
             cont0[1] = new ContinuationHistory();

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -240,7 +240,7 @@ namespace Lizard.Logic.Search
                 && eval >= ss->StaticEval
                 && !doSkip
                 && (ss - 1)->CurrentMove != Move.Null
-                && pos.MaterialCountNonPawn[pos.ToMove] > 0)
+                && pos.HasNonPawnMaterial(pos.ToMove))
             {
                 int reduction = NMPReductionBase + (depth / NMPReductionDivisor) + Math.Min((eval - beta) / NMPEvalDivisor, NMPEvalMin);
                 ss->CurrentMove = Move.Null;
@@ -389,7 +389,7 @@ namespace Lizard.Logic.Search
                 //  We can start skipping quiet moves if we have already seen enough of them at this depth.
                 if (!isRoot
                     && bestScore > ScoreMatedMax
-                    && pos.MaterialCountNonPawn[pos.ToMove] > 0)
+                    && pos.HasNonPawnMaterial(pos.ToMove))
                 {
                     if (skipQuiets == false)
                     {

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -334,7 +334,7 @@ namespace Lizard.Logic.Threads
             {
                 (ss + i)->Clear();
                 (ss + i)->Ply = (short)i;
-                (ss + i)->PV = (Move*)AlignedAllocZeroed((nuint)(MaxPly * sizeof(Move)), AllocAlignment);
+                (ss + i)->PV = AlignedAllocZeroed<Move>(MaxPly);
                 (ss + i)->ContinuationHistory = History.Continuations[0][0][0, 0, 0];
             }
 
@@ -401,7 +401,7 @@ namespace Lizard.Logic.Threads
                     {
                         score = Logic.Search.Searches.Negamax<RootNode>(info.Position, ss, alpha, beta, Math.Max(1, usedDepth), false);
 
-                        StableSort(ref RootMoves, PVIndex);
+                        StableSort(RootMoves, PVIndex);
 
                         if (SearchPool.StopThreads)
                             break;
@@ -423,7 +423,7 @@ namespace Lizard.Logic.Threads
                         window += window / 2;
                     }
 
-                    StableSort(ref RootMoves, 0, PVIndex + 1);
+                    StableSort(RootMoves, 0, PVIndex + 1);
 
                     if (IsMain && (SearchPool.StopThreads || PVIndex == multiPV - 1))
                     {

--- a/Logic/Transposition/Cuckoo.cs
+++ b/Logic/Transposition/Cuckoo.cs
@@ -12,8 +12,8 @@
 
         static Cuckoo()
         {
-            Moves = (Move*)AlignedAllocZeroed((nuint)sizeof(Move) * TableSize, AllocAlignment);
-            Keys = (ulong*)AlignedAllocZeroed((nuint)sizeof(ulong) * TableSize, AllocAlignment);
+            Moves = AlignedAllocZeroed<Move>(TableSize);
+            Keys = AlignedAllocZeroed<ulong>(TableSize);
             new Span<Move>(Moves, TableSize).Fill(Move.Null);
 
             for (int pc = White; pc <= Black; pc++)

--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -55,7 +55,7 @@ namespace Lizard.Logic.Transposition
             }
 
             ClusterCount = (ulong)mb * 0x100000UL / (ulong)sizeof(TTCluster);
-            Clusters = (TTCluster*)AlignedAllocZeroed(((nuint)sizeof(TTCluster) * (nuint)ClusterCount), (1024 * 1024));
+            Clusters = AlignedAllocZeroed<TTCluster>((int)ClusterCount, (1024 * 1024));
             AdviseHugePage(Clusters, ((nuint)sizeof(TTCluster) * (nuint)ClusterCount));
 
             for (ulong i = 0; i < ClusterCount; i++)

--- a/Logic/Util/Interop.cs
+++ b/Logic/Util/Interop.cs
@@ -3,6 +3,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
+#pragma warning disable CS8500 // This takes the address of, gets the size of, or declares a pointer to a managed type
+
 namespace Lizard.Logic.Util
 {
     public static class Interop
@@ -146,6 +148,17 @@ namespace Lizard.Logic.Util
             NativeMemory.Clear(block, byteCount);
 
             return block;
+        }
+
+        /// <summary>
+        /// <inheritdoc cref="AlignedAllocZeroed(nuint, nuint)"/>
+        /// </summary>
+        public static unsafe T* AlignedAllocZeroed<T>(int items, nuint alignment = AllocAlignment)
+        {
+            void* block = NativeMemory.AlignedAlloc((nuint)(sizeof(T) * items), alignment);
+            NativeMemory.Clear(block, (nuint)(sizeof(T) * items));
+
+            return (T*)block;
         }
 
 

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -603,7 +603,7 @@ namespace Lizard.Logic.Util
         /// This is a rather inefficient algorithm ( O(n^2)? ) but for small amounts of <paramref name="items"/> or small ranges 
         /// of [<paramref name="offset"/>, <paramref name="end"/>] this works well enough.
         /// </summary>
-        public static void StableSort<T>(ref List<T> items, int offset = 0, int end = -1) where T : IComparable<T>
+        public static void StableSort(List<RootMove> items, int offset = 0, int end = -1)
         {
             if (end == -1)
             {
@@ -630,16 +630,8 @@ namespace Lizard.Logic.Util
         }
 
 
-        public static int AsInt(this bool v)
-        {
-            return v ? 1 : 0;
-        }
-
-
-        public static bool AsBool(this int v)
-        {
-            return (v != 0);
-        }
+        public static int AsInt(this bool v) => v ? 1 : 0;
+        public static bool AsBool(this int v) => v != 0;
     }
 
 


### PR DESCRIPTION
Did non-reg with HasNonPawnMaterial bugged, which was still fine.
```
Elo   | -0.36 +- 2.60 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 1.31 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 17588 W: 4482 L: 4500 D: 8606
Penta | [121, 1778, 5012, 1764, 119]
http://somelizard.pythonanywhere.com/test/1184/
```