### PR TITLE
Removed second killer move

### DIFF
--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -29,13 +29,9 @@ namespace Lizard.Logic.Search.Ordering
                 {
                     sm.Score = int.MaxValue - 100000;
                 }
-                else if (m == ss->Killer0)
+                else if (m == ss->KillerMove)
                 {
                     sm.Score = int.MaxValue - 1000000;
-                }
-                else if (m == ss->Killer1)
-                {
-                    sm.Score = int.MaxValue - 2000000;
                 }
                 else if (bb.GetPieceAtIndex(moveTo) != None && !m.GetCastle())
                 {

--- a/Logic/Search/SearchStackEntry.cs
+++ b/Logic/Search/SearchStackEntry.cs
@@ -8,7 +8,7 @@ namespace Lizard.Logic.Search
     /// <summary>
     /// Used during a search to keep track of information from earlier plies/depths
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Size = 64)]
+    [StructLayout(LayoutKind.Explicit, Size = 40)]
     public unsafe struct SearchStackEntry
     {
         public static SearchStackEntry NullEntry = new SearchStackEntry();
@@ -22,13 +22,9 @@ namespace Lizard.Logic.Search
         [FieldOffset(24)] public bool InCheck;
         [FieldOffset(25)] public bool TTPV;
         [FieldOffset(26)] public bool TTHit;
-        [FieldOffset(27)] private fixed byte _pad0[5];
+        [FieldOffset(27)] private fixed byte _pad0[1];
+        [FieldOffset(28)] public Move KillerMove;
         [FieldOffset(32)] public Move* PV;
-        [FieldOffset(40)] private fixed byte _pad1[8];
-        [FieldOffset(48)] public Move Killer0;
-        [FieldOffset(52)] private fixed byte _pad2[4];
-        [FieldOffset(56)] public Move Killer1;
-        [FieldOffset(60)] private fixed byte _pad3[4];
 
 
         public SearchStackEntry()
@@ -59,8 +55,7 @@ namespace Lizard.Logic.Search
                 PV = null;
             }
 
-            Killer0 = Move.Null;
-            Killer1 = Move.Null;
+            KillerMove = Move.Null;
         }
 
         public static string GetMovesPlayed(SearchStackEntry* curr)

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -126,7 +126,7 @@ namespace Lizard.Logic.Search
                 }
             }
 
-            (ss + 1)->Killer0 = (ss + 1)->Killer1 = Move.Null;
+            (ss + 1)->KillerMove = Move.Null;
 
             ss->DoubleExtensions = (ss - 1)->DoubleExtensions;
             ss->InCheck = pos.Checked;
@@ -514,7 +514,7 @@ namespace Lizard.Logic.Search
                         R--;
 
                     //  Extend killer moves
-                    if (m.Equals(ss->Killer0) || m.Equals(ss->Killer1))
+                    if (m.Equals(ss->KillerMove))
                         R--;
 
                     var histScore = 2 * history.MainHistory[us, m] + 
@@ -987,10 +987,9 @@ namespace Lizard.Logic.Search
 
                 int bestMoveBonus = (bestScore > beta + HistoryCaptureBonusMargin) ? quietMoveBonus : StatBonus(depth);
 
-                if (ss->Killer0 != bestMove && !bestMove.GetEnPassant())
+                if (ss->KillerMove != bestMove && !bestMove.GetEnPassant())
                 {
-                    ss->Killer1 = ss->Killer0;
-                    ss->Killer0 = bestMove;
+                    ss->KillerMove = bestMove;
                 }
 
                 history.MainHistory[thisColor, bestMove] <<= bestMoveBonus;


### PR DESCRIPTION
```
Elo   | 3.01 +- 3.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 8772 W: 2192 L: 2116 D: 4464
Penta | [39, 1004, 2239, 1050, 54]
http://somelizard.pythonanywhere.com/test/1218/
```