### PR TITLE
Movegen changes

### DIFF
--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -242,8 +242,8 @@ namespace Lizard.Logic.Core
                 FullMoves++;
             }
 
-            int moveFrom = move.GetFrom();
-            int moveTo = move.GetTo();
+            int moveFrom = move.From;
+            int moveTo = move.To;
 
             int ourPiece = bb.GetPieceAtIndex(moveFrom);
             int ourColor = ToMove;
@@ -253,12 +253,12 @@ namespace Lizard.Logic.Core
 
             Assert(ourPiece != None,   $"Move {move.ToString()} in FEN '{GetFEN()}' doesn't have a piece on the From square!");
             Assert(theirPiece != King, $"Move {move.ToString()} in FEN '{GetFEN()}' captures a king!");
-            Assert(theirPiece == None || (ourColor != bb.GetColorAtIndex(moveTo) || move.GetCastle()),
+            Assert(theirPiece == None || (ourColor != bb.GetColorAtIndex(moveTo) || move.IsCastle),
                 $"Move {move.ToString()} in FEN '{GetFEN()}' captures our own {PieceToString(theirPiece)} on {IndexToString(moveTo)}");
 
             if (ourPiece == King)
             {
-                if (move.GetCastle())
+                if (move.IsCastle)
                 {
                     //  Castling moves are KxR, so "theirPiece" is actually our own rook.
                     theirPiece = None;
@@ -310,7 +310,7 @@ namespace Lizard.Logic.Core
 
             if (ourPiece == Pawn)
             {
-                if (move.GetEnPassant())
+                if (move.IsEnPassant)
                 {
 
                     int idxPawn = ((bb.Pieces[Pawn] & SquareBB[tempEPSquare - 8]) != 0) ? tempEPSquare - 8 : tempEPSquare + 8;
@@ -336,22 +336,22 @@ namespace Lizard.Logic.Core
                 State->HalfmoveClock = 0;
             }
 
-            if (!move.GetCastle())
+            if (!move.IsCastle)
             {
                 bb.MoveSimple(moveFrom, moveTo, ourColor, ourPiece);
                 State->Hash.ZobristMove(moveFrom, moveTo, ourColor, ourPiece);
             }
 
-            if (move.GetPromotion())
+            if (move.IsPromotion)
             {
                 //  Get rid of the pawn we just put there
                 bb.RemovePiece(moveTo, ourColor, ourPiece);
 
                 //  And replace it with the promotion piece
-                bb.AddPiece(moveTo, ourColor, move.GetPromotionTo());
+                bb.AddPiece(moveTo, ourColor, move.PromotionTo);
 
                 State->Hash.ZobristToggleSquare(ourColor, ourPiece, moveTo);
-                State->Hash.ZobristToggleSquare(ourColor, move.GetPromotionTo(), moveTo);
+                State->Hash.ZobristToggleSquare(ourColor, move.PromotionTo, moveTo);
             }
 
             State->Hash.ZobristChangeToMove();
@@ -364,8 +364,8 @@ namespace Lizard.Logic.Core
 
         public void UnmakeMove(Move move)
         {
-            int moveFrom = move.GetFrom();
-            int moveTo = move.GetTo();
+            int moveFrom = move.From;
+            int moveTo = move.To;
 
             //  Assume that "we" just made the last move, and "they" are undoing it.
             int ourPiece = bb.GetPieceAtIndex(moveTo);
@@ -374,7 +374,7 @@ namespace Lizard.Logic.Core
 
             GamePly--;
 
-            if (move.GetPromotion())
+            if (move.IsPromotion)
             {
                 //  Remove the promotion piece and replace it with a pawn
                 bb.RemovePiece(moveTo, ourColor, ourPiece);
@@ -383,13 +383,13 @@ namespace Lizard.Logic.Core
 
                 bb.AddPiece(moveTo, ourColor, ourPiece);
             }
-            else if (move.GetCastle())
+            else if (move.IsCastle)
             {
                 //  Put both pieces back
                 DoCastling(ourColor, moveFrom, moveTo, undo: true);
             }
 
-            if (!move.GetCastle())
+            if (!move.IsCastle)
             {
                 //  Put our piece back to the square it came from.
                 bb.MoveSimple(moveTo, moveFrom, ourColor, ourPiece);
@@ -398,7 +398,7 @@ namespace Lizard.Logic.Core
             if (State->CapturedPiece != Piece.None)
             {
                 //  CapturedPiece is set for captures and en passant, so check which it was
-                if (move.GetEnPassant())
+                if (move.IsEnPassant)
                 {
                     //  If the move was an en passant, put the captured pawn back
 
@@ -563,8 +563,8 @@ namespace Lizard.Logic.Core
         {
             ulong hash = State->Hash;
 
-            int from = m.GetFrom();
-            int to = m.GetTo();
+            int from = m.From;
+            int to = m.To;
             int us = bb.GetColorAtIndex(from);
             int ourPiece = bb.GetPieceAtIndex(from);
 
@@ -589,8 +589,8 @@ namespace Lizard.Logic.Core
         /// </summary>
         public bool IsPseudoLegal(in Move move)
         {
-            int moveTo = move.GetTo();
-            int moveFrom = move.GetFrom();
+            int moveTo = move.To;
+            int moveFrom = move.From;
 
             int pt = bb.GetPieceAtIndex(moveFrom);
             if (pt == None)
@@ -606,7 +606,7 @@ namespace Lizard.Logic.Core
                 return false;
             }
 
-            if (bb.GetPieceAtIndex(moveTo) != None && pc == bb.GetColorAtIndex(moveTo) && !move.GetCastle())
+            if (bb.GetPieceAtIndex(moveTo) != None && pc == bb.GetColorAtIndex(moveTo) && !move.IsCastle)
             {
                 //  There is a piece on the square we are moving to, and it is ours, so we can't capture it.
                 //  The one exception is castling, which is encoded as king captures rook.
@@ -615,7 +615,7 @@ namespace Lizard.Logic.Core
 
             if (pt == Pawn)
             {
-                if (move.GetEnPassant())
+                if (move.IsEnPassant)
                 {
                     return State->EPSquare != EPNone && (SquareBB[moveTo - ShiftUpDir(ToMove)] & bb.Pieces[Pawn] & bb.Colors[Not(ToMove)]) != 0;
                 }
@@ -639,7 +639,7 @@ namespace Lizard.Logic.Core
 
             //  This move is only pseudo-legal if the piece that is moving is actually able to get there.
             //  Pieces can only move to squares that they attack, with the one exception of queenside castling
-            return (bb.AttackMask(moveFrom, pc, pt, bb.Occupancy) & SquareBB[moveTo]) != 0 || move.GetCastle();
+            return (bb.AttackMask(moveFrom, pc, pt, bb.Occupancy) & SquareBB[moveTo]) != 0 || move.IsCastle;
         }
 
 
@@ -653,8 +653,8 @@ namespace Lizard.Logic.Core
         /// </summary>
         public bool IsLegal(Move move, int ourKing, int theirKing, ulong pinnedPieces)
         {
-            int moveFrom = move.GetFrom();
-            int moveTo = move.GetTo();
+            int moveFrom = move.From;
+            int moveTo = move.To;
 
             int pt = bb.GetPieceAtIndex(moveFrom);
 
@@ -686,7 +686,7 @@ namespace Lizard.Logic.Core
 
                 int checker = lsb(State->Checkers);
                 if (((LineBB[ourKing][checker] & SquareBB[moveTo]) != 0)
-                    || (move.GetEnPassant() && GetIndexFile(moveTo) == GetIndexFile(checker)))
+                    || (move.IsEnPassant && GetIndexFile(moveTo) == GetIndexFile(checker)))
                 {
                     //  This move is another piece which has moved into the LineBB between our king and the checking piece.
                     //  This will be legal as long as it isn't pinned.
@@ -700,9 +700,9 @@ namespace Lizard.Logic.Core
 
             if (pt == Piece.King)
             {
-                if (move.GetCastle())
+                if (move.IsCastle)
                 {
-                    var thisCr = move.RelevantCastlingRight;
+                    var thisCr = move.RelevantCastlingRight();
                     int rookSq = CastlingRookSquares[(int)thisCr];
 
                     if ((SquareBB[rookSq] & bb.Pieces[Rook] & bb.Colors[ourColor]) == 0)
@@ -741,7 +741,7 @@ namespace Lizard.Logic.Core
                 return ((bb.AttackersTo(moveTo, bb.Occupancy ^ SquareBB[ourKing]) & bb.Colors[theirColor])
                        | (NeighborsMask[moveTo] & SquareBB[theirKing])) == 0;
             }
-            else if (move.GetEnPassant())
+            else if (move.IsEnPassant)
             {
                 //  En passant will remove both our pawn and the opponents pawn from the rank so this needs a special check
                 //  to make sure it is still legal

--- a/Logic/Data/Move.cs
+++ b/Logic/Data/Move.cs
@@ -7,21 +7,16 @@ using System.Runtime.CompilerServices;
 
 namespace Lizard.Logic.Data
 {
-
-
-    public unsafe struct Move
+    public unsafe readonly struct Move(int from, int to, int flags = 0)
     {
         public static readonly Move Null = new Move();
 
-        //  6 bits for: From, To, SqChecker
+        //  6 bits for From and To
         //  
+        //  2 bits for the EnPassant/Castle/Promotion flags
         //  2 bits for PromotionTo, which defaults to a knight (1), so the "Promotion" flag MUST be looked at before "PromotionTo" is.
         //  (Otherwise every move would show up as a promotion to a knight, woohoo for horses!).
-        //  
-        //  6 bits for the 6 move flags.
-        //  
-        //  Total of 26, padded to 32.
-        private ushort _data;
+        private readonly ushort _data = (ushort)(to | (from << 6) | flags);
 
 
         [MethodImpl(Inline)] 
@@ -47,79 +42,56 @@ namespace Lizard.Logic.Data
 
 
 
-        [MethodImpl(Inline)]
-        public int GetTo() => (_data & 0x3F);
+        public readonly int To   => (_data >> 0) & 0x3F;
+        public readonly int From => (_data >> 6) & 0x3F;
 
-
-        [MethodImpl(Inline)]
-        public int GetFrom() => (_data >> 6) & 0x3F;
-
-
-        [MethodImpl(Inline)] 
-        public int GetMoveMask() => (_data & Mask_ToFrom);
+        public readonly int MoveMask => (_data & Mask_ToFrom);
 
         /// <summary>
         /// Gets the piece type that this pawn is promoting to. This is stored as (piece type - 1) to save space,
         /// so a PromotionTo == 0 (Piece.Pawn) is treated as 1 (Piece.Knight).
         /// </summary>
-        [MethodImpl(Inline)]
-        public int GetPromotionTo() => ((_data >> 14) & 0x3) + 1;
+        public readonly int PromotionTo => ((_data >> 14) & 0x3) + 1;
 
-
-        [MethodImpl(Inline)]
-        public bool GetEnPassant() => (_data & SpecialFlagsMask) == FlagEnPassant;
-
+        public readonly bool IsEnPassant => (_data & SpecialFlagsMask) == FlagEnPassant;
+        public readonly bool IsCastle    => (_data & SpecialFlagsMask) == FlagCastle;
+        public readonly bool IsPromotion => (_data & SpecialFlagsMask) == FlagPromotion;
 
         [MethodImpl(Inline)]
-        public bool GetCastle() => (_data & SpecialFlagsMask) == FlagCastle;
+        public readonly bool IsNull() => (_data & Mask_ToFrom) == 0;
 
 
         [MethodImpl(Inline)]
-        public bool GetPromotion() => (_data & SpecialFlagsMask) == FlagPromotion;
-
-
-        public Move(int from, int to, int flags = 0)
+        public readonly int CastlingKingSquare()
         {
-            _data = (ushort)(to | (from << 6) | flags);
+            if (From < A2)
+            {
+                return (To > From) ? G1 : C1;
+            }
+
+            return (To > From) ? G8 : C8;
         }
 
         [MethodImpl(Inline)]
-        public bool IsNull() => (_data & Mask_ToFrom) == 0;
-
-
-        [MethodImpl(Inline)]
-        public int CastlingKingSquare()
+        public readonly int CastlingRookSquare()
         {
-            if (GetFrom() < A2)
+            if (From < A2)
             {
-                return (GetTo() > GetFrom()) ? G1 : C1;
+                return (To > From) ? F1 : D1;
             }
 
-            return (GetTo() > GetFrom()) ? G8 : C8;
+            return (To > From) ? F8 : D8;
         }
 
         [MethodImpl(Inline)]
-        public int CastlingRookSquare()
+        public readonly CastlingStatus RelevantCastlingRight()
         {
-            if (GetFrom() < A2)
+            if (From < A2)
             {
-                return (GetTo() > GetFrom()) ? F1 : D1;
+                return (To > From) ? CastlingStatus.WK : CastlingStatus.WQ;
             }
 
-            return (GetTo() > GetFrom()) ? F8 : D8;
-        }
-
-        public CastlingStatus RelevantCastlingRight
-        {
-            get
-            {
-                if (GetFrom() < A2)
-                {
-                    return (GetTo() > GetFrom()) ? CastlingStatus.WK : CastlingStatus.WQ;
-                }
-
-                return (GetTo() > GetFrom()) ? CastlingStatus.BK : CastlingStatus.BQ;
-            }
+            return (To > From) ? CastlingStatus.BK : CastlingStatus.BQ;
         }
 
         /// <summary>
@@ -130,17 +102,17 @@ namespace Lizard.Logic.Data
         /// </summary>
         public string SmithNotation(bool is960 = false)
         {
-            IndexToCoord(GetFrom(), out int fx, out int fy);
-            IndexToCoord(GetTo(), out int tx, out int ty);
+            IndexToCoord(From, out int fx, out int fy);
+            IndexToCoord(To, out int tx, out int ty);
 
-            if (GetCastle() && !is960)
+            if (IsCastle && !is960)
             {
                 tx = (tx > fx) ? Files.G : Files.C;
             }
 
-            if (GetPromotion())
+            if (IsPromotion)
             {
-                return "" + GetFileChar(fx) + (fy + 1) + GetFileChar(tx) + (ty + 1) + char.ToLower(PieceToFENChar(GetPromotionTo()));
+                return "" + GetFileChar(fx) + (fy + 1) + GetFileChar(tx) + (ty + 1) + char.ToLower(PieceToFENChar(PromotionTo));
             }
             else
             {
@@ -153,12 +125,12 @@ namespace Lizard.Logic.Data
             StringBuilder sb = new StringBuilder();
             ref Bitboard bb = ref position.bb;
 
-            int moveTo = GetTo();
-            int moveFrom = GetFrom();
+            int moveTo = To;
+            int moveFrom = From;
 
             int pt = bb.GetPieceAtIndex(moveFrom);
 
-            if (GetCastle())
+            if (IsCastle)
             {
                 if (moveTo > moveFrom)
                 {
@@ -175,7 +147,7 @@ namespace Lizard.Logic.Data
 
                 if (pt == Piece.Pawn)
                 {
-                    if (cap || GetEnPassant())
+                    if (cap || IsEnPassant)
                     {
                         sb.Append(GetFileChar(GetIndexFile(moveFrom)));
                     }
@@ -210,7 +182,7 @@ namespace Lizard.Logic.Data
                     }
                 }
 
-                if (cap || GetEnPassant())
+                if (cap || IsEnPassant)
                 {
                     sb.Append('x');
                 }
@@ -218,9 +190,9 @@ namespace Lizard.Logic.Data
 
                 sb.Append(IndexToString(moveTo));
 
-                if (GetPromotion())
+                if (IsPromotion)
                 {
-                    sb.Append("=" + PieceToFENChar(GetPromotionTo()));
+                    sb.Append("=" + PieceToFENChar(PromotionTo));
                 }
             }
 

--- a/Logic/Data/Move.cs
+++ b/Logic/Data/Move.cs
@@ -29,12 +29,16 @@ namespace Lizard.Logic.Data
 
 
 
-        public const int FlagEnPassant = 0b000001 << 14;
-        public const int FlagCastle = 0b000010 << 14;
-        public const int FlagPromotion = 0b000011 << 14;
+        public const int FlagEnPassant  = 0b0001 << 12;
+        public const int FlagCastle     = 0b0010 << 12;
+        public const int FlagPromotion  = 0b0011 << 12;
 
-        private const int SpecialFlagsMask = 0b000011 << 14;
+        private const int SpecialFlagsMask = 0b0011 << 12;
 
+        public const int FlagPromoKnight = 0b00 << 14 | FlagPromotion;
+        public const int FlagPromoBishop = 0b01 << 14 | FlagPromotion;
+        public const int FlagPromoRook   = 0b10 << 14 | FlagPromotion;
+        public const int FlagPromoQueen  = 0b11 << 14 | FlagPromotion;
 
         /// <summary>
         /// A mask of <see cref="GetTo()"/> and <see cref="GetFrom()"/>
@@ -59,7 +63,7 @@ namespace Lizard.Logic.Data
         /// so a PromotionTo == 0 (Piece.Pawn) is treated as 1 (Piece.Knight).
         /// </summary>
         [MethodImpl(Inline)]
-        public int GetPromotionTo() => ((_data >> 12) & 0x3) + 1;
+        public int GetPromotionTo() => ((_data >> 14) & 0x3) + 1;
 
 
         [MethodImpl(Inline)]
@@ -74,20 +78,10 @@ namespace Lizard.Logic.Data
         public bool GetPromotion() => (_data & SpecialFlagsMask) == FlagPromotion;
 
 
-        public Move(int from, int to) => _data = (ushort)(to | (from << 6));
-
-        [MethodImpl(Inline)] 
-        public void SetNew(int from, int to) => _data = (ushort)(to | (from << 6));
-
-        [MethodImpl(Inline)] 
-        public void SetNew(int from, int to, int promotionTo) => _data = (ushort)(to | (from << 6) | ((promotionTo - 1) << 12) | FlagPromotion);
-
-        [MethodImpl(Inline)] 
-        public void SetNewCastle(int from, int to) => _data = (ushort)(to | (from << 6) | FlagCastle);
-
-        [MethodImpl(Inline)] 
-        public void SetNewEnPassant(int from, int to) => _data = (ushort)(to | (from << 6) | FlagEnPassant);
-
+        public Move(int from, int to, int flags = 0)
+        {
+            _data = (ushort)(to | (from << 6) | flags);
+        }
 
         [MethodImpl(Inline)]
         public bool IsNull() => (_data & Mask_ToFrom) == 0;

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -327,8 +327,8 @@ namespace Lizard.Logic.NN
 
             dst->Computed[0] = dst->Computed[1] = false;
 
-            int moveTo = m.GetTo();
-            int moveFrom = m.GetFrom();
+            int moveTo = m.To;
+            int moveFrom = m.From;
 
             int us = pos.ToMove;
             int ourPiece = bb.GetPieceAtIndex(moveFrom);
@@ -356,12 +356,12 @@ namespace Lizard.Logic.NN
                 int from = FeatureIndexSingle(us, ourPiece, moveFrom, theirKing, them);
                 int to = FeatureIndexSingle(us, ourPiece, moveTo, theirKing, them);
 
-                if (theirPiece != None && !m.GetCastle())
+                if (theirPiece != None && !m.IsCastle)
                 {
                     int cap = FeatureIndexSingle(them, theirPiece, moveTo, theirKing, them);
                     theirUpdate.PushSubSubAdd(from, cap, to);
                 }
-                else if (m.GetCastle())
+                else if (m.IsCastle)
                 {
                     int rookFromSq = moveTo;
                     int rookToSq = m.CastlingRookSquare();
@@ -384,7 +384,7 @@ namespace Lizard.Logic.NN
                 int bKing = pos.State->KingSquares[Black];
 
                 (int wFrom, int bFrom) = FeatureIndex(us, ourPiece, moveFrom, wKing, bKing);
-                (int wTo, int bTo) = FeatureIndex(us, m.GetPromotion() ? m.GetPromotionTo() : ourPiece, moveTo, wKing, bKing);
+                (int wTo, int bTo) = FeatureIndex(us, m.IsPromotion ? m.PromotionTo : ourPiece, moveTo, wKing, bKing);
 
                 wUpdate.PushSubAdd(wFrom, wTo);
                 bUpdate.PushSubAdd(bFrom, bTo);
@@ -396,7 +396,7 @@ namespace Lizard.Logic.NN
                     wUpdate.PushSub(wCap);
                     bUpdate.PushSub(bCap);
                 }
-                else if (m.GetEnPassant())
+                else if (m.IsEnPassant)
                 {
                     int idxPawn = moveTo - ShiftUpDir(us);
 

--- a/Logic/Search/History/MainHistoryTable.cs
+++ b/Logic/Search/History/MainHistoryTable.cs
@@ -37,10 +37,10 @@ namespace Lizard.Logic.Search.History
 
         public static int HistoryIndex(int pc, Move m)
         {
-            Assert(((pc * MainHistoryPCStride) + m.GetMoveMask()) is >= 0 and < MainHistoryElements, 
-                $"HistoryIndex({pc}, {m.GetMoveMask()}) should be < {MainHistoryElements}");
+            Assert(((pc * MainHistoryPCStride) + m.MoveMask) is >= 0 and < MainHistoryElements, 
+                $"HistoryIndex({pc}, {m.MoveMask}) should be < {MainHistoryElements}");
 
-            return (pc * MainHistoryPCStride) + m.GetMoveMask();
+            return (pc * MainHistoryPCStride) + m.MoveMask;
         }
     }
 }

--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -22,8 +22,8 @@ namespace Lizard.Logic.Search.Ordering
             {
                 ref ScoredMove sm = ref list[i];
                 Move m = sm.Move;
-                int moveTo = m.GetTo();
-                int moveFrom = m.GetFrom();
+                int moveTo = m.To;
+                int moveFrom = m.From;
 
                 if (m.Equals(ttMove))
                 {
@@ -33,7 +33,7 @@ namespace Lizard.Logic.Search.Ordering
                 {
                     sm.Score = int.MaxValue - 1000000;
                 }
-                else if (bb.GetPieceAtIndex(moveTo) != None && !m.GetCastle())
+                else if (bb.GetPieceAtIndex(moveTo) != None && !m.IsCastle)
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
                     sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
@@ -74,14 +74,14 @@ namespace Lizard.Logic.Search.Ordering
             {
                 ref ScoredMove sm = ref list[i];
                 Move m = sm.Move;
-                int moveTo = m.GetTo();
-                int moveFrom = m.GetFrom();
+                int moveTo = m.To;
+                int moveFrom = m.From;
 
                 if (m.Equals(ttMove))
                 {
                     sm.Score = int.MaxValue - 100000;
                 }
-                else if (bb.GetPieceAtIndex(moveTo) != None && !m.GetCastle())
+                else if (bb.GetPieceAtIndex(moveTo) != None && !m.IsCastle)
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
                     sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
@@ -119,8 +119,8 @@ namespace Lizard.Logic.Search.Ordering
                 ref ScoredMove sm = ref list[i];
                 Move m = sm.Move;
 
-                sm.Score = GetSEEValue(m.GetEnPassant() ? Pawn : bb.GetPieceAtIndex(m.GetTo()));
-                if (m.GetPromotion())
+                sm.Score = GetSEEValue(m.IsEnPassant ? Pawn : bb.GetPieceAtIndex(m.To));
+                if (m.IsPromotion)
                 {
                     //  Gives promotions a higher score than captures.
                     //  We can assume a queen promotion is better than most captures.

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -510,7 +510,7 @@ namespace Lizard.Logic.Threads
             double multFactor = 1.0;
             if (RootDepth > 7)
             {
-                double proportion = NodeTable[RootMoves[0].Move.GetFrom()][RootMoves[0].Move.GetTo()] / (double)Nodes;
+                double proportion = NodeTable[RootMoves[0].Move.From][RootMoves[0].Move.To] / (double)Nodes;
                 multFactor = ((1.5 - proportion) * 1.75) * StabilityCoefficients[Math.Min(stability, StabilityMax)];
             }
 

--- a/Logic/Transposition/Cuckoo.cs
+++ b/Logic/Transposition/Cuckoo.cs
@@ -83,8 +83,8 @@
                     continue;
 
                 Move m = Moves[slot];
-                int moveFrom = m.GetFrom();
-                int moveTo = m.GetTo();
+                int moveFrom = m.From;
+                int moveTo = m.To;
 
                 if ((bb.Occupancy & LineBB[moveFrom][moveTo]) == 0)
                 {

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -124,32 +124,24 @@ namespace Lizard.Logic.Util
 
 
         /// <summary>
-        /// Returns a bitboard with bits set 1 "above" the bits in <paramref name="b"/>.
-        /// So Forward(Color.White) with a bitboard that has A2 set will return one with A3 set,
-        /// and Forward(Color.Black) returns one with A1 set instead.
-        /// </summary>
-        public static ulong Forward(int color, ulong b)
-        {
-            return Shift(ShiftUpDir(color), b);
-        }
-
-
-        /// <summary>
         /// Shifts the bits in <paramref name="b"/> in the direction <paramref name="dir"/>.
         /// </summary>
         public static ulong Shift(int dir, ulong b)
         {
-            return dir == Direction.NORTH ? b << 8
-                 : dir == Direction.SOUTH ? b >> 8
-                 : dir == Direction.NORTH + Direction.NORTH ? b << 16
-                 : dir == Direction.SOUTH + Direction.SOUTH ? b >> 16
-                 : dir == Direction.EAST  ? (b & ~FileHBB) << 1
-                 : dir == Direction.WEST  ? (b & ~FileABB) >> 1
-                 : dir == Direction.NORTH_EAST ? (b & ~FileHBB) << 9
-                 : dir == Direction.NORTH_WEST ? (b & ~FileABB) << 7
-                 : dir == Direction.SOUTH_EAST ? (b & ~FileHBB) >> 7
-                 : dir == Direction.SOUTH_WEST ? (b & ~FileABB) >> 9
-                 : 0;
+            return dir switch
+            {
+                Direction.NORTH => b << 8,
+                Direction.SOUTH => b >> 8,
+                Direction.NORTH + Direction.NORTH => b << 16,
+                Direction.SOUTH + Direction.SOUTH => b >> 16,
+                Direction.EAST => (b & ~FileHBB) << 1,
+                Direction.WEST => (b & ~FileABB) >> 1,
+                Direction.NORTH_EAST => (b & ~FileHBB) << 9,
+                Direction.NORTH_WEST => (b & ~FileABB) << 7,
+                Direction.SOUTH_EAST => (b & ~FileHBB) >> 7,
+                Direction.SOUTH_WEST => (b & ~FileABB) >> 9,
+                _ => 0
+            };
         }
 
 


### PR DESCRIPTION
Simplifications to movegen, including generating promotions in QNRB order and reverting the previous Move property changes.
```
Elo   | 1.34 +- 2.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 13986 W: 3477 L: 3423 D: 7086
Penta | [68, 1589, 3616, 1661, 59]
http://somelizard.pythonanywhere.com/test/1257/
```