### PR TITLE
Reordered SearchStackEntry layout

### DIFF
--- a/Logic/Search/SearchStackEntry.cs
+++ b/Logic/Search/SearchStackEntry.cs
@@ -8,23 +8,23 @@ namespace Lizard.Logic.Search
     /// <summary>
     /// Used during a search to keep track of information from earlier plies/depths
     /// </summary>
-    [StructLayout(LayoutKind.Explicit, Size = 40)]
+    [StructLayout(LayoutKind.Explicit, Size = 32)]
     public unsafe struct SearchStackEntry
     {
         public static SearchStackEntry NullEntry = new SearchStackEntry();
 
-        [FieldOffset( 0)] public Move CurrentMove;
-        [FieldOffset( 4)] public Move Skip;
+        [FieldOffset( 0)] public Move* PV;
         [FieldOffset( 8)] public PieceToHistory* ContinuationHistory;
-        [FieldOffset(16)] public int DoubleExtensions;
-        [FieldOffset(20)] public short Ply;
-        [FieldOffset(22)] public short StaticEval;
-        [FieldOffset(24)] public bool InCheck;
-        [FieldOffset(25)] public bool TTPV;
-        [FieldOffset(26)] public bool TTHit;
-        [FieldOffset(27)] private fixed byte _pad0[1];
-        [FieldOffset(28)] public Move KillerMove;
-        [FieldOffset(32)] public Move* PV;
+        [FieldOffset(16)] public short DoubleExtensions;
+        [FieldOffset(18)] public short Ply;
+        [FieldOffset(20)] public short StaticEval;
+        [FieldOffset(22)] public Move KillerMove;
+        [FieldOffset(24)] public Move CurrentMove;
+        [FieldOffset(26)] public Move Skip;
+        [FieldOffset(28)] public bool InCheck;
+        [FieldOffset(29)] public bool TTPV;
+        [FieldOffset(30)] public bool TTHit;
+        [FieldOffset(31)] private fixed byte _pad0[1];
 
 
         public SearchStackEntry()

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -477,7 +477,7 @@ namespace Lizard.Logic.Search
 
                 int histIdx = PieceToHistory.GetIndex(us, ourPiece, moveTo);
 
-                ss->DoubleExtensions = (ss - 1)->DoubleExtensions + (extend == 2 ? 1 : 0);
+                ss->DoubleExtensions = (short)((ss - 1)->DoubleExtensions + (extend >= 2).AsInt());
                 ss->CurrentMove = m;
                 ss->ContinuationHistory = history.Continuations[ss->InCheck.AsInt()][isCapture.AsInt()][histIdx];
                 thisThread.Nodes++;


### PR DESCRIPTION
Move structs haven't been 4 bytes in a few months, and by reordering the fields the total size can be reduced to 32.
```
Elo   | 2.04 +- 3.27 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 10892 W: 2793 L: 2729 D: 5370
Penta | [75, 1032, 3168, 1096, 75]
http://somelizard.pythonanywhere.com/test/1258/
```