### PR TITLE
Re-added inlinings and added SkipLocalsInit

### DIFF
--- a/Logic/Core/Bitboard.cs
+++ b/Logic/Core/Bitboard.cs
@@ -202,6 +202,7 @@ namespace Lizard.Logic.Core
         /// Returns a ulong with bits set at the positions of any piece that can attack the square <paramref name="idx"/>, 
         /// given the board occupancy <paramref name="occupied"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         public ulong AttackersTo(int idx, ulong occupied)
         {
             return (GetBishopMoves(occupied, idx) & (Pieces[Bishop] | Pieces[Queen]))
@@ -216,6 +217,7 @@ namespace Lizard.Logic.Core
         /// Returns a mask of the squares that a piece of type <paramref name="pt"/> and color <paramref name="pc"/> 
         /// on the square <paramref name="idx"/> attacks, given the board occupancy <paramref name="occupied"/>
         /// </summary>
+        [MethodImpl(Inline)]
         public ulong AttackMask(int idx, int pc, int pt, ulong occupied)
         {
             return pt switch

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -473,6 +473,7 @@ namespace Lizard.Logic.Core
         /// Moves the king and rook for castle moves, and updates the position hash accordingly.
         /// Adapted from https://github.com/official-stockfish/Stockfish/blob/632f1c21cd271e7c4c242fdafa328a55ec63b9cb/src/position.cpp#L931
         /// </summary>
+        [MethodImpl(Inline)]
         public void DoCastling(int ourColor, int from, int to, bool undo = false)
         {
             bool kingSide = to > from;
@@ -506,6 +507,7 @@ namespace Lizard.Logic.Core
 
 
 
+        [MethodImpl(Inline)]
         public void SetState()
         {
             State->Checkers = bb.AttackersTo(State->KingSquares[ToMove], bb.Occupancy) & bb.Colors[Not(ToMove)];
@@ -516,6 +518,7 @@ namespace Lizard.Logic.Core
         }
 
 
+        [MethodImpl(Inline)]
         public void SetCheckInfo()
         {
             State->BlockingPieces[White] = bb.BlockingPieces(White, &State->Pinners[Black]);
@@ -587,6 +590,7 @@ namespace Lizard.Logic.Core
         /// Returns true if the move <paramref name="move"/> is pseudo-legal.
         /// Only determines if there is a piece at move.From and the piece at move.To isn't the same color.
         /// </summary>
+        [MethodImpl(Inline)]
         public bool IsPseudoLegal(in Move move)
         {
             int moveTo = move.To;
@@ -646,11 +650,13 @@ namespace Lizard.Logic.Core
         /// <summary>
         /// Returns true if the move <paramref name="move"/> is legal in the current position.
         /// </summary>
+        [MethodImpl(Inline)] 
         public bool IsLegal(in Move move) => IsLegal(move, State->KingSquares[ToMove], State->KingSquares[Not(ToMove)], State->BlockingPieces[ToMove]);
 
         /// <summary>
         /// Returns true if the move <paramref name="move"/> is legal given the current position.
         /// </summary>
+        [MethodImpl(Inline)]
         public bool IsLegal(Move move, int ourKing, int theirKing, ulong pinnedPieces)
         {
             int moveFrom = move.From;
@@ -763,7 +769,7 @@ namespace Lizard.Logic.Core
 
 
 
-
+        [MethodImpl(Inline)]
         public bool IsDraw()
         {
             return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsThreefoldRepetition();
@@ -842,6 +848,7 @@ namespace Lizard.Logic.Core
         /// Returns the <see cref="CastlingStatus"/> for the piece on the <paramref name="sq"/>, 
         /// which is <see cref="CastlingStatus.None"/> if the square isn't one of the values in <see cref="CastlingRookSquares"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         private CastlingStatus GetCastlingForRook(int sq)
         {
             CastlingStatus cr = sq == CastlingRookSquares[(int)CastlingStatus.WQ] ? CastlingStatus.WQ :
@@ -856,6 +863,7 @@ namespace Lizard.Logic.Core
         /// <summary>
         /// Updates the hash to reflect the changes in castling rights, and removes the given rights from the current state.
         /// </summary>
+        [MethodImpl(Inline)]
         private void RemoveCastling(CastlingStatus cr)
         {
             State->Hash.ZobristCastle(State->CastleStatus, cr);

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -875,6 +875,7 @@ namespace Lizard.Logic.Core
         /// Returns the number of leaf nodes in the current position up to <paramref name="depth"/>.
         /// </summary>
         /// <param name="depth">The number of moves that will be made from the starting position. Depth 1 returns the current number of legal moves.</param>
+        [SkipLocalsInit]
         public ulong Perft(int depth)
         {
             ScoredMove* list = stackalloc ScoredMove[MoveListSize];
@@ -898,6 +899,7 @@ namespace Lizard.Logic.Core
 
         private Stopwatch PerftTimer = new Stopwatch();
         private const int PerftParallelMinDepth = 6;
+        [SkipLocalsInit]
         public ulong PerftParallel(int depth, bool isRoot = false)
         {
             if (isRoot)
@@ -942,6 +944,7 @@ namespace Lizard.Logic.Core
         /// Same as perft but returns the evaluation at each of the leaves. 
         /// Only for benchmarking/debugging.
         /// </summary>
+        [SkipLocalsInit]
         public long PerftNN(int depth)
         {
             ScoredMove* list = stackalloc ScoredMove[MoveListSize];

--- a/Logic/Data/Move.cs
+++ b/Logic/Data/Move.cs
@@ -213,6 +213,7 @@ namespace Lizard.Logic.Data
         /// <summary>
         /// Returns true if the <see cref="Move"/> <paramref name="move"/> has the same From/To squares, the same "Castle" flag, and the same PromotionTo piece.
         /// </summary>
+        [MethodImpl(Inline)]
         public bool Equals(Move move)
         {
             //  Today we learned that the JIT doesn't appear to create separate paths for Equals(object) and Equals(Move/CondensedMove).
@@ -224,6 +225,7 @@ namespace Lizard.Logic.Data
 
 
 
+        [MethodImpl(Inline)]
         public bool Equals(ScoredMove move)
         {
             return move.Move.Equals(this);

--- a/Logic/Data/RootMove.cs
+++ b/Logic/Data/RootMove.cs
@@ -1,4 +1,6 @@
-﻿namespace Lizard.Logic.Data
+﻿using System.Runtime.CompilerServices;
+
+namespace Lizard.Logic.Data
 {
     public class RootMove : IComparable<RootMove>
     {
@@ -25,6 +27,7 @@
             PVLength = 1;
         }
 
+        [MethodImpl(Inline)]
         public int CompareTo(RootMove other)
         {
             if (Score != other.Score)

--- a/Logic/Magic/MagicBitboards.cs
+++ b/Logic/Magic/MagicBitboards.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
 namespace Lizard.Logic.Magic
@@ -85,22 +87,30 @@ namespace Lizard.Logic.Magic
                     for (int m = 0; m < 100; m++)
                         foreach ((int sq, ulong blockers) in pextTests)
                             temp ^= TestPextFancy(blockers, sq);
-
-                    sw.Stop();
-                    if (n > 0)
-                        fancyElapsed += sw.ElapsedTicks;
-
+                    if (n > 0) fancyElapsed += sw.ElapsedTicks;
 
                     sw.Restart();
                     for (int m = 0; m < 100; m++)
                         foreach ((int sq, ulong blockers) in pextTests)
                             temp ^= TestPextNormal(blockers, sq);
-                    sw.Stop();
-                    if (n > 0)
-                        normalElapsed += sw.ElapsedTicks;
+                    if (n > 0) normalElapsed += sw.ElapsedTicks;
+
+                    sw.Restart();
+                    for (int m = 0; m < 100; m++)
+                        foreach ((int sq, ulong blockers) in pextTests)
+                            temp ^= TestPextFancy(blockers, sq);
+                    if (n > 0) fancyElapsed += sw.ElapsedTicks;
+
+                    sw.Restart();
+                    for (int m = 0; m < 100; m++)
+                        foreach ((int sq, ulong blockers) in pextTests)
+                            temp ^= TestPextNormal(blockers, sq);
+                    if (n > 0) normalElapsed += sw.ElapsedTicks;
                 }
 
                 UsePext = (fancyElapsed < normalElapsed);
+
+                if (UsePext) Log($"Pext enabled for a {normalElapsed / (double)fancyElapsed:N3}x speedup");
             }
 
             if (UsePext)
@@ -136,6 +146,7 @@ namespace Lizard.Logic.Magic
         /// and the returned mask treats the mask <paramref name="boardAll"/> as if every piece can be captured.
         /// Friendly pieces will need to be masked out so we aren't able to capture them.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetRookMoves(ulong boardAll, int idx)
         {
             if (UsePext)
@@ -157,6 +168,7 @@ namespace Lizard.Logic.Magic
         /// and the returned mask treats the mask <paramref name="boardAll"/> as if every piece can be captured.
         /// Friendly pieces will need to be masked out so we aren't able to capture them.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetBishopMoves(ulong boardAll, int idx)
         {
             if (UsePext)

--- a/Logic/NN/Accumulator.cs
+++ b/Logic/NN/Accumulator.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
 namespace Lizard.Logic.NN
@@ -28,6 +29,7 @@ namespace Lizard.Logic.NN
 
         public Vector256<short>* this[int perspective] => (perspective == Color.White) ? (Vector256<short>*)White : (Vector256<short>*)Black;
 
+        [MethodImpl(Inline)]
         public void CopyTo(Accumulator* target)
         {
             Unsafe.CopyBlock(target->White, White, ByteSize);
@@ -38,6 +40,7 @@ namespace Lizard.Logic.NN
 
         }
 
+        [MethodImpl(Inline)]
         public void CopyTo(ref Accumulator target, int perspective)
         {
             Unsafe.CopyBlock(target[perspective], this[perspective], ByteSize);

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 using Lizard.Logic.Threads;
@@ -268,6 +269,7 @@ namespace Lizard.Logic.NN
             return (output / QA + LayerBiases[outputBucket]) * OutputScale / (QA * QB);
         }
 
+        [MethodImpl(Inline)]
         private static int FeatureIndexSingle(int pc, int pt, int sq, int kingSq, int perspective)
         {
             const int ColorStride = 64 * 6;
@@ -288,6 +290,7 @@ namespace Lizard.Logic.NN
             return ((768 * KingBuckets[kingSq]) + ((pc ^ perspective) * ColorStride) + (pt * PieceStride) + (sq)) * HiddenSize;
         }
 
+        [MethodImpl(Inline)]
         private static (int, int) FeatureIndex(int pc, int pt, int sq, int wk, int bk)
         {
             const int ColorStride = 64 * 6;
@@ -408,6 +411,7 @@ namespace Lizard.Logic.NN
             }
         }
 
+        [MethodImpl(Inline)]
         public static void MakeNullMove(Position pos)
         {
             pos.State->Accumulator->CopyTo(pos.NextState->Accumulator);
@@ -421,6 +425,7 @@ namespace Lizard.Logic.NN
 
         //  The general concept here is based off of Stormphrax's implementation:
         //  https://github.com/Ciekce/Stormphrax/commit/9b76f2a35531513239ed7078acc21294a11e75c6
+        [MethodImpl(Inline)]
         public static void ProcessUpdates(Position pos)
         {
             StateInfo* st = pos.State;
@@ -462,6 +467,7 @@ namespace Lizard.Logic.NN
             }
         }
 
+        [MethodImpl(Inline)]
         public static void UpdateSingle(Accumulator* prev, Accumulator* curr, int perspective)
         {
             ref var updates = ref curr->Update[perspective];

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Runtime.CompilerServices;
+using System.Text;
 
 using Lizard.Logic.NN;
 using Lizard.Logic.Search.History;
@@ -50,6 +51,7 @@ namespace Lizard.Logic.Search
         ///     The depth to search to, which is then extended by QSearch.
         /// </param>
         /// <returns>The evaluation of the best move.</returns>
+        [SkipLocalsInit]
         public static int Negamax<NodeType>(Position pos, SearchStackEntry* ss, int alpha, int beta, int depth, bool cutNode) where NodeType : SearchNodeType
         {
             bool isRoot = typeof(NodeType) == typeof(RootNode);
@@ -714,6 +716,7 @@ namespace Lizard.Logic.Search
         /// This is similar to Negamax, but there is far less pruning going on here, and we are only interested in ensuring that
         /// the score for a particular Negamax node is reasonable if we look at the forcing moves that can be made after that node.
         /// </summary>
+        [SkipLocalsInit]
         public static int QSearch<NodeType>(Position pos, SearchStackEntry* ss, int alpha, int beta, int depth) where NodeType : SearchNodeType
         {
             bool isPV = typeof(NodeType) != typeof(NonPVNode);

--- a/Logic/Transposition/TTEntry.cs
+++ b/Logic/Transposition/TTEntry.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 using static Lizard.Logic.Transposition.TranspositionTable;
 
@@ -40,7 +41,7 @@ namespace Lizard.Logic.Transposition
         public readonly TTNodeType NodeType => (TTNodeType)(_AgePVType & TT_BOUND_MASK);
         public readonly int Bound => _AgePVType & TT_BOUND_MASK;
 
-
+        [MethodImpl(Inline)]
         public readonly sbyte RelAge(byte age) => (sbyte)((TT_AGE_CYCLE + age - _AgePVType) & TT_AGE_MASK);
         public readonly bool IsEmpty => _Depth == 0;
 
@@ -73,22 +74,13 @@ namespace Lizard.Logic.Transposition
         /// </summary>
         public static short MakeNormalScore(short ttScore, int ply)
         {
-            if (ttScore == ScoreNone)
+            return ttScore switch
             {
-                return ttScore;
-            }
-
-            if (ttScore >= ScoreTTWin)
-            {
-                return (short)(ttScore - ply);
-            }
-
-            if (ttScore <= ScoreTTLoss)
-            {
-                return (short)(ttScore + ply);
-            }
-
-            return ttScore;
+                   ScoreNone   => ttScore,
+                >= ScoreTTWin  => (short)(ttScore - ply),
+                <= ScoreTTLoss => (short)(ttScore + ply),
+                   _           => ttScore
+            };
         }
 
         /// <summary>
@@ -100,22 +92,13 @@ namespace Lizard.Logic.Transposition
         /// </summary>
         public static short MakeTTScore(short score, int ply)
         {
-            if (score == ScoreNone)
+            return score switch
             {
-                return score;
-            }
-
-            if (score >= ScoreTTWin)
-            {
-                return (short)(score + ply);
-            }
-
-            if (score <= ScoreTTLoss)
-            {
-                return (short)(score - ply);
-            }
-
-            return score;
+                   ScoreNone   => score,
+                >= ScoreTTWin  => (short)(score + ply),
+                <= ScoreTTLoss => (short)(score - ply),
+                   _           => score
+            };
         }
 
         public override string ToString()

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
@@ -120,12 +121,14 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the <see cref="Direction"/> that the <paramref name="color"/> pawns move in, white pawns up, black pawns down.
         /// </summary>
+        [MethodImpl(Inline)]
         public static int ShiftUpDir(int color) => (color == Color.White) ? Direction.NORTH : Direction.SOUTH;
 
 
         /// <summary>
         /// Shifts the bits in <paramref name="b"/> in the direction <paramref name="dir"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong Shift(int dir, ulong b)
         {
             return dir switch
@@ -148,6 +151,7 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns a ulong with bits set along whichever file <paramref name="idx"/> is in.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetFileBB(int idx)
         {
             return FileABB << GetIndexFile(idx);
@@ -157,6 +161,7 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns a ulong with bits set along whichever rank <paramref name="idx"/> is on.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetRankBB(int idx)
         {
             return Rank1BB << (8 * GetIndexRank(idx));
@@ -309,24 +314,28 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the number of the file with the letter <paramref name="fileLetter"/>, so GetFileInt('a') returns 0.
         /// </summary>
+        [MethodImpl(Inline)] 
         public static int GetFileInt(char fileLetter) => fileLetter - 97;
 
 
         /// <summary>
         /// Returns the file (x coordinate) for the index, which is between A=0 and H=7.
         /// </summary>
+        [MethodImpl(Inline)] 
         public static int GetIndexFile(int index) => index & 7;
 
 
         /// <summary>
         /// Returns the rank (y coordinate) for the index, which is between 0 and 7.
         /// </summary>
+        [MethodImpl(Inline)] 
         public static int GetIndexRank(int index) => index >> 3;
 
 
         /// <summary>
         /// Sets <paramref name="x"/> to the file of <paramref name="index"/>, and <paramref name="y"/> to its rank.
         /// </summary>
+        [MethodImpl(Inline)]
         public static void IndexToCoord(in int index, out int x, out int y)
         {
             x = index % 8;
@@ -337,6 +346,7 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the index of the square with the rank <paramref name="x"/> and file <paramref name="y"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         public static int CoordToIndex(int x, int y)
         {
             return (y * 8) + x;


### PR DESCRIPTION
This has a relatively minimal effect on search elo, but increases perft speed by nearly 50%.
```
Elo   | 7.29 +- 3.65 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9678 W: 2569 L: 2366 D: 4743
Penta | [69, 962, 2586, 1141, 81]
http://somelizard.pythonanywhere.com/test/1393/
```