### PR TITLE
Don't save exact entries in QSearch

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -934,9 +934,7 @@ namespace Lizard.Logic.Search
                 return MakeMateScore(ss->Ply);
             }
 
-            TTNodeType bound = (bestScore >= beta) ? TTNodeType.Alpha :
-                      ((bestScore > startingAlpha) ? TTNodeType.Exact : 
-                                                     TTNodeType.Beta);
+            var bound = (bestScore >= beta) ? TTNodeType.Alpha : TTNodeType.Beta;
 
             tte->Update(pos.Hash, MakeTTScore((short)bestScore, ss->Ply), bound, ttDepth, bestMove, ss->StaticEval, ss->TTPV);
 


### PR DESCRIPTION
Probably doesn't scale but I'm tired of looking at this
```
Elo   | 1.24 +- 0.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 135460 W: 33390 L: 32905 D: 69165
Penta | [586, 15648, 34887, 15913, 696]
http://somelizard.pythonanywhere.com/test/1273/
```

```
Elo   | 0.52 +- 1.80 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=64MB
LLR   | -0.38 (-2.94, 2.94) [0.00, 3.00]
Games | N: 34740 W: 8276 L: 8224 D: 18240
Penta | [64, 3939, 9318, 3979, 70]
http://somelizard.pythonanywhere.com/test/1283/
```