### PR TITLE
Added data generation functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /Properties/launchSettings.json
 /*.exe
 /*.pdb
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /*.exe
 /*.pdb
 /data
+/.vs/ProjectEvaluation

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -25,7 +25,7 @@
     <LangVersion>Latest</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     
-    <Configurations>Debug;Release;Development</Configurations>
+    <Configurations>Debug;Release;Datagen</Configurations>
     <EnforceCodeStyleInBuild>False</EnforceCodeStyleInBuild>
     <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
     <AnalysisLevel>latest-all</AnalysisLevel>
@@ -143,9 +143,8 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Datagen|x64'">
     <PlatformTarget>x64</PlatformTarget>
-    <DefineConstants>$(DefineConstants);DEV</DefineConstants>
     <DebugType>embedded</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/Logic/Core/Bitboard.cs
+++ b/Logic/Core/Bitboard.cs
@@ -202,6 +202,7 @@ namespace Lizard.Logic.Core
         /// Returns a ulong with bits set at the positions of any piece that can attack the square <paramref name="idx"/>, 
         /// given the board occupancy <paramref name="occupied"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         public ulong AttackersTo(int idx, ulong occupied)
         {
             return (GetBishopMoves(occupied, idx) & (Pieces[Bishop] | Pieces[Queen]))
@@ -216,6 +217,7 @@ namespace Lizard.Logic.Core
         /// Returns a mask of the squares that a piece of type <paramref name="pt"/> and color <paramref name="pc"/> 
         /// on the square <paramref name="idx"/> attacks, given the board occupancy <paramref name="occupied"/>
         /// </summary>
+        [MethodImpl(Inline)]
         public ulong AttackMask(int idx, int pc, int pt, ulong occupied)
         {
             return pt switch

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -470,6 +470,7 @@ namespace Lizard.Logic.Core
         /// Moves the king and rook for castle moves, and updates the position hash accordingly.
         /// Adapted from https://github.com/official-stockfish/Stockfish/blob/632f1c21cd271e7c4c242fdafa328a55ec63b9cb/src/position.cpp#L931
         /// </summary>
+        [MethodImpl(Inline)]
         public void DoCastling(int ourColor, int from, int to, bool undo = false)
         {
             bool kingSide = to > from;
@@ -503,6 +504,7 @@ namespace Lizard.Logic.Core
 
 
 
+        [MethodImpl(Inline)]
         public void SetState()
         {
             State->Checkers = bb.AttackersTo(State->KingSquares[ToMove], bb.Occupancy) & bb.Colors[Not(ToMove)];
@@ -513,6 +515,7 @@ namespace Lizard.Logic.Core
         }
 
 
+        [MethodImpl(Inline)]
         public void SetCheckInfo()
         {
             State->BlockingPieces[White] = bb.BlockingPieces(White, &State->Pinners[Black]);
@@ -584,6 +587,7 @@ namespace Lizard.Logic.Core
         /// Returns true if the move <paramref name="move"/> is pseudo-legal.
         /// Only determines if there is a piece at move.From and the piece at move.To isn't the same color.
         /// </summary>
+        [MethodImpl(Inline)]
         public bool IsPseudoLegal(in Move move)
         {
             int moveTo = move.To;
@@ -643,11 +647,13 @@ namespace Lizard.Logic.Core
         /// <summary>
         /// Returns true if the move <paramref name="move"/> is legal in the current position.
         /// </summary>
+        [MethodImpl(Inline)] 
         public bool IsLegal(in Move move) => IsLegal(move, State->KingSquares[ToMove], State->KingSquares[Not(ToMove)], State->BlockingPieces[ToMove]);
 
         /// <summary>
         /// Returns true if the move <paramref name="move"/> is legal given the current position.
         /// </summary>
+        [MethodImpl(Inline)]
         public bool IsLegal(Move move, int ourKing, int theirKing, ulong pinnedPieces)
         {
             int moveFrom = move.From;
@@ -760,7 +766,7 @@ namespace Lizard.Logic.Core
 
 
 
-
+        [MethodImpl(Inline)]
         public bool IsDraw()
         {
             return IsFiftyMoveDraw() || IsInsufficientMaterial() || IsThreefoldRepetition();
@@ -839,6 +845,7 @@ namespace Lizard.Logic.Core
         /// Returns the <see cref="CastlingStatus"/> for the piece on the <paramref name="sq"/>, 
         /// which is <see cref="CastlingStatus.None"/> if the square isn't one of the values in <see cref="CastlingRookSquares"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         private CastlingStatus GetCastlingForRook(int sq)
         {
             CastlingStatus cr = sq == CastlingRookSquares[(int)CastlingStatus.WQ] ? CastlingStatus.WQ :
@@ -853,6 +860,7 @@ namespace Lizard.Logic.Core
         /// <summary>
         /// Updates the hash to reflect the changes in castling rights, and removes the given rights from the current state.
         /// </summary>
+        [MethodImpl(Inline)]
         private void RemoveCastling(CastlingStatus cr)
         {
             State->Hash.ZobristCastle(State->CastleStatus, cr);
@@ -909,6 +917,7 @@ namespace Lizard.Logic.Core
         /// Returns the number of leaf nodes in the current position up to <paramref name="depth"/>.
         /// </summary>
         /// <param name="depth">The number of moves that will be made from the starting position. Depth 1 returns the current number of legal moves.</param>
+        [SkipLocalsInit]
         public ulong Perft(int depth)
         {
             ScoredMove* list = stackalloc ScoredMove[MoveListSize];
@@ -932,6 +941,7 @@ namespace Lizard.Logic.Core
 
         private Stopwatch PerftTimer = new Stopwatch();
         private const int PerftParallelMinDepth = 6;
+        [SkipLocalsInit]
         public ulong PerftParallel(int depth, bool isRoot = false)
         {
             if (isRoot)
@@ -976,6 +986,7 @@ namespace Lizard.Logic.Core
         /// Same as perft but returns the evaluation at each of the leaves. 
         /// Only for benchmarking/debugging.
         /// </summary>
+        [SkipLocalsInit]
         public long PerftNN(int depth)
         {
             ScoredMove* list = stackalloc ScoredMove[MoveListSize];

--- a/Logic/Core/Position.cs
+++ b/Logic/Core/Position.cs
@@ -860,6 +860,51 @@ namespace Lizard.Logic.Core
         }
 
 
+
+        public void SetupForDFRC(int wIdx, int bIdx)
+        {
+            bb.Reset();
+
+            for (int sq = A2; sq <= H2; sq++)
+                bb.AddPiece(sq, White, Pawn);
+
+            for (int sq = A7; sq <= H7; sq++)
+                bb.AddPiece(sq, Black, Pawn);
+
+            IsChess960 = true;
+            int* wBackrank = stackalloc int[8];
+            int* bBackrank = stackalloc int[8];
+
+            FillWithScharnaglNumber(wIdx, wBackrank);
+            FillWithScharnaglNumber(bIdx, bBackrank);
+
+            var w = new Span<int>(wBackrank, 8);
+            var b = new Span<int>(bBackrank, 8);
+
+            for (int sq = 0; sq < 8; sq++)
+            {
+                bb.AddPiece(A1 + sq, White, wBackrank[sq]);
+                bb.AddPiece(A8 + sq, Black, bBackrank[sq]);
+
+                if (wBackrank[sq] == King)
+                    State->KingSquares[White] = A1 + sq;
+
+                if (bBackrank[sq] == King)
+                    State->KingSquares[Black] = A8 + sq;
+            }
+
+            for (int sq = 0; sq < 8; sq++)
+            {
+                //  SetCastlingStatus needs State->KingSquare which might not be set yet if we do this in the above loop
+                if (wBackrank[sq] == Rook)
+                    SetCastlingStatus(White, A1 + sq);
+
+                if (bBackrank[sq] == Rook)
+                    SetCastlingStatus(Black, A8 + sq);
+            }
+        }
+
+
         /// <summary>
         /// Returns the number of leaf nodes in the current position up to <paramref name="depth"/>.
         /// </summary>

--- a/Logic/Data/Move.cs
+++ b/Logic/Data/Move.cs
@@ -213,6 +213,7 @@ namespace Lizard.Logic.Data
         /// <summary>
         /// Returns true if the <see cref="Move"/> <paramref name="move"/> has the same From/To squares, the same "Castle" flag, and the same PromotionTo piece.
         /// </summary>
+        [MethodImpl(Inline)]
         public bool Equals(Move move)
         {
             //  Today we learned that the JIT doesn't appear to create separate paths for Equals(object) and Equals(Move/CondensedMove).
@@ -224,6 +225,7 @@ namespace Lizard.Logic.Data
 
 
 
+        [MethodImpl(Inline)]
         public bool Equals(ScoredMove move)
         {
             return move.Move.Equals(this);

--- a/Logic/Data/RootMove.cs
+++ b/Logic/Data/RootMove.cs
@@ -1,4 +1,6 @@
-﻿namespace Lizard.Logic.Data
+﻿using System.Runtime.CompilerServices;
+
+namespace Lizard.Logic.Data
 {
     public class RootMove : IComparable<RootMove>
     {
@@ -25,6 +27,7 @@
             PVLength = 1;
         }
 
+        [MethodImpl(Inline)]
         public int CompareTo(RootMove other)
         {
             if (Score != other.Score)

--- a/Logic/Datagen/BulletDataFormat.cs
+++ b/Logic/Datagen/BulletDataFormat.cs
@@ -11,6 +11,7 @@ namespace Lizard.Logic.Datagen
         //  WE don't know the result when creating the entries, and STM isn't stored within them anywhere,
         //  So manually place the STM in the last byte of padding of the entries.
         [FieldOffset( 0)] BulletFormatEntry BFE;
+        [FieldOffset(29)] Move BestMove;
         [FieldOffset(31)] byte STM;
 
         public int Score
@@ -54,10 +55,11 @@ namespace Lizard.Logic.Datagen
             return myBuffer;
         }
 
-        public void Fill(Position pos, int score)
+        public void Fill(Position pos, Move bestMove, int score)
         {
             BFE = BulletFormatEntry.FromBitboard(ref pos.bb, pos.ToMove, (short)score, GameResult.Draw);
             STM = (byte)pos.ToMove;
+            BestMove = bestMove;
         }
 
     }

--- a/Logic/Datagen/BulletDataFormat.cs
+++ b/Logic/Datagen/BulletDataFormat.cs
@@ -1,0 +1,64 @@
+﻿
+using System.Runtime.InteropServices;
+
+namespace Lizard.Logic.Datagen
+{
+    [StructLayout(LayoutKind.Explicit)]
+    public unsafe struct BulletDataFormat : TOutputFormat
+    {
+        //  STM here is used to fix the game result, which is dependent on the STM:
+        //  If black is to move, the result is flipped around WhiteWin <-> BlackWin.
+        //  WE don't know the result when creating the entries, and STM isn't stored within them anywhere,
+        //  So manually place the STM in the last byte of padding of the entries.
+        [FieldOffset( 0)] BulletFormatEntry BFE;
+        [FieldOffset(31)] byte STM;
+
+        public int Score
+        {
+            get => BFE.score;
+            set => BFE.score = (short)value;
+        }
+
+        public GameResult Result
+        {
+            get => (GameResult)BFE.result;
+            set => BFE.result = (byte)value;
+        }
+
+        public void SetSTM(int stm) { STM = (byte)stm; }
+        public void SetResult(GameResult gr)
+        {
+            if (STM == Black)
+            {
+                gr = (GameResult)(2 - gr);
+            }
+
+            Result = gr;
+        }
+
+        public string GetWritableTextData()
+        {
+            return "";
+        }
+
+        public byte[] GetWritableData()
+        {
+            int len = Marshal.SizeOf<BulletFormatEntry>();
+            IntPtr ptr = Marshal.AllocHGlobal(len);
+            byte[] myBuffer = new byte[len];
+
+            Marshal.StructureToPtr(BFE, ptr, false);
+            Marshal.Copy(ptr, myBuffer, 0, len);
+            Marshal.FreeHGlobal(ptr);
+
+            return myBuffer;
+        }
+
+        public void Fill(Position pos, int score)
+        {
+            BFE = BulletFormatEntry.FromBitboard(ref pos.bb, pos.ToMove, (short)score, GameResult.Draw);
+            STM = (byte)pos.ToMove;
+        }
+
+    }
+}

--- a/Logic/Datagen/BulletFormatEntry.cs
+++ b/Logic/Datagen/BulletFormatEntry.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lizard.Logic.Datagen
+{
+    [StructLayout(LayoutKind.Explicit, Size = 32)]
+    public unsafe struct BulletFormatEntry
+    {
+        public const int Size = 32;
+
+        [FieldOffset(0)] public ulong occ;
+        [FieldOffset(8)] public fixed byte pcs[16];
+        [FieldOffset(24)] public short score;
+        [FieldOffset(26)] public byte result;
+        [FieldOffset(27)] public byte ksq;
+        [FieldOffset(28)] public byte opp_ksq;
+        [FieldOffset(29)] public fixed byte _pad[3];
+
+
+
+        public void FillBitboard(ref Bitboard bb)
+        {
+            bb.Reset();
+
+            bb.Occupancy = occ;
+
+            ulong temp = occ;
+            int idx = 0;
+            while (temp != 0)
+            {
+                int sq = poplsb(&temp);
+                int piece = (pcs[idx / 2] >> (4 * (idx & 1))) & 0b1111;
+
+                bb.AddPiece(sq, piece / 8, piece % 8);
+
+                idx++;
+            }
+        }
+
+
+
+        public static BulletFormatEntry FromBitboard(ref Bitboard bb, int stm, short score, GameResult result)
+        {
+            Span<ulong> bbs = [
+                bb.Colors[White], bb.Colors[Black],
+                bb.Pieces[0], bb.Pieces[1], bb.Pieces[2],
+                bb.Pieces[3], bb.Pieces[4], bb.Pieces[5],
+            ];
+
+            if (stm == Black)
+            {
+                for (int i = 0; i < bbs.Length; i++)
+                {
+                    bbs[i] = BinaryPrimitives.ReverseEndianness(bbs[i]);
+                }
+
+                (bbs[0], bbs[1]) = (bbs[1], bbs[0]);
+
+                score = (short)-score;
+                result = 1 - result;
+            }
+
+            ulong occ = bbs[0] | bbs[1];
+            byte[] pieces = new byte[16];
+
+            int idx = 0;
+            ulong occ2 = occ;
+            while (occ2 > 0)
+            {
+                int sq = BitOperations.TrailingZeroCount(occ2);
+                ulong bit = 1UL << sq;
+                occ2 &= occ2 - 1;
+
+                byte colour = (byte)(((bit & bbs[1]) > 0 ? 1 : 0) << 3);
+                var piece = FindIndex(bbs[2..], bb => (bit & bb) > 0);
+                if (piece == -1) throw new Exception("No Piece Found!");
+
+                byte pc = (byte)(colour | (byte)piece);
+
+                pieces[idx / 2] |= (byte)(pc << (4 * (idx & 1)));
+
+                idx += 1;
+            }
+
+            byte resultByte = (byte)(2 * (int)result);
+            byte ksq = (byte)BitOperations.TrailingZeroCount(bbs[0] & bbs[7]);
+            byte oppKsq = (byte)(BitOperations.TrailingZeroCount(bbs[1] & bbs[7]) ^ 56);
+
+            BulletFormatEntry bfe = new BulletFormatEntry()
+            {
+                occ = occ,
+                score = score,
+                result = resultByte,
+                ksq = ksq,
+                opp_ksq = oppKsq,
+            };
+
+            fixed (byte* pcsPtr = pieces)
+                Unsafe.CopyBlock(bfe.pcs, pcsPtr, sizeof(byte) * 16);
+
+            return bfe;
+
+            static int FindIndex(Span<ulong> span, Func<ulong, bool> predicate)
+            {
+                for (int i = 0; i < span.Length; i++)
+                    if (predicate(span[i]))
+                        return i;
+
+                return -1;
+            }
+        }
+
+
+
+        public void WriteToBuffer(Span<byte> buff)
+        {
+            fixed (void* buffPtr = &buff[0], thisPtr = &this)
+            {
+                Unsafe.CopyBlock(buffPtr, thisPtr, BulletFormatEntry.Size);
+            }
+        }
+    }
+}

--- a/Logic/Datagen/DatagenMatch.cs
+++ b/Logic/Datagen/DatagenMatch.cs
@@ -279,7 +279,7 @@ namespace Lizard.Logic.Datagen
                 while (ring != 0)
                 {
                     int idx = poplsb(&ring);
-                    if ((bb.AttackersTo(idx, bb.Occupancy ^ SquareBB[nstmKing]) & bb.Colors[us]) != 0)
+                    if ((bb.AttackersTo(idx, bb.Occupancy ^ SquareBB[nstmKing]) & bb.Colors[us]) == 0)
                     {
                         bb.MoveSimple(nstmKing, idx, them, King);
                         kingPlaced = true;
@@ -295,7 +295,7 @@ namespace Lizard.Logic.Datagen
                     while (sqrs != 0)
                     {
                         int idx = (them == White) ? poplsb(&sqrs) : popmsb(&sqrs);
-                        if ((bb.AttackersTo(idx, bb.Occupancy ^ SquareBB[nstmKing]) & bb.Colors[us]) != 0)
+                        if ((bb.AttackersTo(idx, bb.Occupancy ^ SquareBB[nstmKing]) & bb.Colors[us]) == 0)
                         {
                             bb.MoveSimple(nstmKing, idx, them, King);
                             cr &= ~((them == Black) ? CastlingStatus.Black : CastlingStatus.White);

--- a/Logic/Datagen/DatagenMatch.cs
+++ b/Logic/Datagen/DatagenMatch.cs
@@ -1,0 +1,357 @@
+﻿
+//#define WRITE_PGN
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Lizard.Logic.NN;
+using Lizard.Logic.Threads;
+
+namespace Lizard.Logic.Datagen
+{
+    public static unsafe class DatagenMatch
+    {
+        private const int HashSize = 8;
+
+        private const int MinPly = 8;
+        private const int MaxPly = 9;
+
+        public const int SoftNodeLimit = 5000;
+        public const int HardNodeLimit = 20000;
+
+        private const int WritableDataLimit = 512;
+        private const int DepthLimit = 10;
+
+        private const int AdjudicateMoves = 2;
+        private const int AdjudicateScore = 4000;
+        private const int MaxFilteringScore = 5000;
+
+        private static int Seed = Environment.TickCount;
+        private static readonly ThreadLocal<Random> Rand = new(() => new Random(Interlocked.Increment(ref Seed)));
+
+        public static long CumulativeGames = 0;
+
+
+        public static void RunGames(int gamesToRun = 1, int threadID = 0, bool scramble = false)
+        {
+            SearchOptions.Hash = HashSize;
+
+            SearchThreadPool pool = new SearchThreadPool(1);
+            Position pos = new Position(owner: pool.MainThread);
+            ref Bitboard bb = ref pos.bb;
+
+            Move bestMove = Move.Null;
+            int bestMoveScore = 0;
+
+#if RAW_STRING
+                StringBuilder outputBuffer = new StringBuilder();
+#endif
+
+            using StreamWriter outputWriter = new StreamWriter($"datagen{threadID}.txt", true);
+
+            long totalBadPositions = 0;
+            long totalGoodPositions = 0;
+
+            SearchInformation info = new SearchInformation(pos)
+            {
+                SoftNodeLimit = SoftNodeLimit,
+                MaxNodes = HardNodeLimit,
+                MaxDepth = DepthLimit,
+                OnDepthFinish = null,
+                OnSearchFinish = null,
+            };
+
+            ScoredMove* legalMoves = stackalloc ScoredMove[MoveListSize];
+            Span<PlaintextData> datapoints = stackalloc PlaintextData[WritableDataLimit];
+
+            Stopwatch sw = Stopwatch.StartNew();
+
+            for (int gameNum = 0; gameNum < gamesToRun; gameNum++)
+            {
+                pool.TTable.Clear();
+                pool.Clear();
+                pos.LoadFromFEN(InitialFEN);
+
+                int randMoveCount = Rand.Value.Next(MinPly, MaxPly + 1);
+                for (int i = 0; i < randMoveCount; i++)
+                {
+                    int l = pos.GenLegal(legalMoves);
+                    if (l == 0) { gameNum--; continue; }
+                    Move t = legalMoves[Rand.Value.Next(0, l)].Move;
+
+                    pos.MakeMove(t);
+                }
+
+                if (scramble)
+                {
+                    ScrambleBoard(pos, Rand.Value);
+                }
+
+                if (pos.GenLegal(legalMoves) == 0) { gameNum--; continue; }
+
+#if RAW_STRING
+                outputBuffer.Clear();
+#endif
+
+                GameResult result = GameResult.Draw;
+                int toWrite = 0;
+                int filtered = 0;
+                int adjudicationCounter = 0;
+
+                while (true)
+                {
+                    pool.StartSearch(pos, ref info);
+                    pool.BlockCallerUntilFinished();
+
+                    bestMove = pool.GetBestThread().RootMoves[0].Move;
+                    bestMoveScore = pool.GetBestThread().RootMoves[0].Score;
+                    bestMoveScore *= (pos.ToMove == Black ? -1 : 1);
+
+
+                    if (Math.Abs(bestMoveScore) >= AdjudicateScore)
+                    {
+                        if (++adjudicationCounter > AdjudicateMoves)
+                        {
+                            result = (bestMoveScore > 0) ? GameResult.WhiteWin : GameResult.BlackWin;
+                            break;
+                        }
+                    }
+                    else
+                        adjudicationCounter = 0;
+
+
+                    bool inCheck = pos.InCheck;
+                    bool bmCap = ((bb.GetPieceAtIndex(bestMove.GetTo()) != None && !bestMove.GetCastle()) || bestMove.GetEnPassant());
+                    bool badScore = Math.Abs(bestMoveScore) > MaxFilteringScore;
+                    if (!(inCheck || bmCap || badScore))
+                    {
+#if RAW_STRING
+                        outputBuffer.Append(pos.GetFEN());
+                        outputBuffer.Append(" | ");
+                        outputBuffer.Append(bestMoveScore);
+                        outputBuffer.Append(" | ");
+                        outputBuffer.AppendLine(bestMove.ToString(pos));
+#else
+                        datapoints[toWrite].Fill(pos, bestMoveScore);
+#endif
+
+                        toWrite++;
+                    }
+                    else
+                    {
+                        filtered++;
+                    }
+
+                    pos.MakeMove(bestMove);
+
+                    if (pos.GenLegal(legalMoves) == 0)
+                    {
+                        result = (pos.ToMove == White) ? GameResult.BlackWin : GameResult.WhiteWin;
+                        break;
+                    }
+                    else if (pos.IsDraw())
+                    {
+                        result = GameResult.Draw;
+                        break;
+                    }
+                    else if (toWrite == WritableDataLimit - 1)
+                    {
+                        result = bestMoveScore >  400 ? GameResult.WhiteWin :
+                                 bestMoveScore < -400 ? GameResult.BlackWin :
+                                                        GameResult.Draw;
+                        break;
+                    }
+                }
+
+
+
+                totalBadPositions += filtered;
+                totalGoodPositions += toWrite;
+
+                var goodPerSec = totalGoodPositions / sw.Elapsed.TotalSeconds;
+                var totalPerSec = (totalGoodPositions + totalBadPositions) / sw.Elapsed.TotalSeconds;
+
+                Log($"{Environment.CurrentManagedThreadId, 2}:{threadID, 2}\t" +
+                    $"{toWrite,4} / {toWrite + filtered,4} good" +
+                    $"\t{result,8}" +
+                    $"{goodPerSec,10:N1}/sec");
+
+#if RAW_STRING
+                outputWriter.Write(outputBuffer);
+#else
+                AddResultsAndWrite(datapoints[..toWrite], result, outputWriter);
+#endif
+            }
+
+            
+            Interlocked.Add(ref CumulativeGames, gamesToRun);
+        }
+
+
+
+        private static void AddResultsAndWrite<Format>(Span<Format> datapoints, GameResult gr, StreamWriter outputWriter) where Format : TOutputFormat
+        {
+            if (typeof(Format) == typeof(PlaintextData))
+            {
+                for (int i = 0; i < datapoints.Length; i++)
+                {
+                    datapoints[i].Result = gr;
+                    outputWriter.WriteLine(datapoints[i].GetWritableData());
+                }
+                
+            }
+            else
+            {
+                for (int i = 0; i < datapoints.Length; i++)
+                    datapoints[i].Result = gr;
+
+                using BinaryWriter br = new BinaryWriter(outputWriter.BaseStream);
+                fixed (Format* fmt = datapoints)
+                {
+                    byte* data = (byte*)fmt;
+                    br.Write(new Span<byte>(data, datapoints.Length * sizeof(Format)));
+                }
+            }
+
+            outputWriter.Flush();
+        }
+
+        static unsafe TDest reinterpret_cast<TSource, TDest>(TSource source)
+        {
+            var sourceRef = __makeref(source);
+            var dest = default(TDest);
+            var destRef = __makeref(dest);
+            *(IntPtr*)&destRef = *(IntPtr*)&sourceRef;
+            return __refvalue(destRef, TDest);
+        }
+
+
+        public static void ScrambleBoard(Position pos, Random rand)
+        {
+            ref Bitboard bb = ref pos.bb;
+
+            int us = pos.ToMove;
+            int them = Not(us);
+
+            //  0.25 + 0.5 - (0.25 * 0.5) == 62.5% == ~40 squares
+            ulong scrambleMask = (ulong)((rand.NextInt64() & rand.NextInt64()) | rand.NextInt64());
+            CastlingStatus cr = pos.State->CastleStatus;
+
+            while (scrambleMask != 0)
+            {
+                int idx = poplsb(&scrambleMask);
+
+                int pt = bb.GetPieceAtIndex(idx);
+                if (pt != None)
+                {
+                    int pc = bb.GetColorAtIndex(idx);
+
+                    int mob = rand.Next(0, pt + 1);
+                    if (pt == King)
+                        mob = 1;
+
+
+                    int sq = RandomManhattanDist(rand, idx, mob);
+                    if (bb.GetPieceAtIndex(sq) == None)
+                    {
+                        bb.MoveSimple(idx, sq, pc, pt);
+                        scrambleMask &= ~SquareBB[sq];
+                        //Log($"   Scrambled {ColorToString(pc)} {PieceToString(pt)}\t{IndexToString(idx)} -> {IndexToString(sq)}");
+
+                        if (pt == King)
+                            cr &= ~((pc == White) ? CastlingStatus.White : CastlingStatus.Black);
+                        else if (pt == Rook)
+                        {
+                            var toRemove = (pc == White) ? CastlingStatus.White : CastlingStatus.Black;
+                            toRemove &= (GetIndexFile(idx) >= Files.E) ? CastlingStatus.Kingside : CastlingStatus.Queenside;
+
+                            cr &= ~toRemove;
+                        }
+                    }
+                }
+            }
+
+            int nstmKing = bb.KingIndex(them);
+            if ((bb.AttackersTo(nstmKing, bb.Occupancy) & bb.Colors[us]) != 0)
+            {
+                bool kingPlaced = false;
+                ulong ring = NeighborsMask[nstmKing] & ~bb.Occupancy;
+                while (ring != 0)
+                {
+                    int idx = poplsb(&ring);
+                    if ((bb.AttackersTo(idx, bb.Occupancy ^ SquareBB[nstmKing]) & bb.Colors[us]) != 0)
+                    {
+                        bb.MoveSimple(nstmKing, idx, them, King);
+                        kingPlaced = true;
+                        cr &= ~((them == Black) ? CastlingStatus.Black : CastlingStatus.White);
+                        //Log($"*  Scrambled {ColorToString(them)} {PieceToString(King)}\t{IndexToString(nstmKing)} -> {IndexToString(idx)}");
+                        break;
+                    }
+                }
+
+                if (!kingPlaced)
+                {
+                    ulong sqrs = ~bb.Occupancy;
+                    while (sqrs != 0)
+                    {
+                        int idx = (them == White) ? poplsb(&sqrs) : popmsb(&sqrs);
+                        if ((bb.AttackersTo(idx, bb.Occupancy ^ SquareBB[nstmKing]) & bb.Colors[us]) != 0)
+                        {
+                            bb.MoveSimple(nstmKing, idx, them, King);
+                            cr &= ~((them == Black) ? CastlingStatus.Black : CastlingStatus.White);
+                            //Log($"** Scrambled {ColorToString(them)} {PieceToString(King)}\t{IndexToString(nstmKing)} -> {IndexToString(idx)}");
+                            break;
+                        }
+                    }
+                }
+            }
+
+
+            //pos.LoadFromFEN(pos.GetFEN());
+            DatagenScrambleReset(pos, cr);
+
+            static void DatagenScrambleReset(Position pos, CastlingStatus cr = CastlingStatus.None)
+            {
+                ref Bitboard bb = ref pos.bb;
+
+                pos.FullMoves = 1;
+                pos.GamePly = 0;
+
+                pos.State = pos.StartingState;
+
+                var st = pos.State;
+                NativeMemory.Clear(st, StateInfo.StateCopySize);
+                st->CastleStatus = cr;
+                st->HalfmoveClock = 0;
+                st->PliesFromNull = 0;
+                st->EPSquare = EPNone;
+                st->CapturedPiece = None;
+                st->KingSquares[White] = bb.KingIndex(White);
+                st->KingSquares[Black] = bb.KingIndex(Black);
+
+                pos.SetState();
+
+                NNUE.RefreshAccumulator(pos);
+            }
+
+
+            static int RandomManhattanDist(Random rand, int startSq, int N)
+            {
+                IndexToCoord(startSq, out int sx, out int sy);
+
+                int dx, dy;
+                int newSq;
+                do
+                {
+                    dx = rand.Next(-N, N + 1);
+                    dy = (N - Math.Abs(dx)) * (rand.Next(2) == 0 ? 1 : -1);
+                    newSq = CoordToIndex(sx + dx, sy + dy);
+                }
+                while (Math.Abs(dx) + Math.Abs(dy) != N && !(newSq >= A1 && newSq <= H8));
+
+                return newSq;
+            }
+
+        }
+    }
+}

--- a/Logic/Datagen/DatagenParameters.cs
+++ b/Logic/Datagen/DatagenParameters.cs
@@ -8,15 +8,15 @@ namespace Lizard.Logic.Datagen
         public const int MinOpeningPly = 8;
         public const int MaxOpeningPly = 9;
 
-        public const int SoftNodeLimit = 5000;
-        public const int HardNodeLimit = 100000;
-        public const int DepthLimit = 10;
+        public const int SoftNodeLimit = 10000;
+        public const int HardNodeLimit = SoftNodeLimit * 20;
+        public const int DepthLimit = 24;
 
         public const int WritableDataLimit = 512;
 
-        public const int AdjudicateMoves = 2;
-        public const int AdjudicateScore = 4000;
-        public const int MaxFilteringScore = 5000;
+        public const int AdjudicateMoves = 4;
+        public const int AdjudicateScore = 3000;
+        public const int MaxFilteringScore = 6000;
 
         public const int MaxOpeningScore = 1200;
         public const int MaxScrambledOpeningScore = 600;

--- a/Logic/Datagen/DatagenParameters.cs
+++ b/Logic/Datagen/DatagenParameters.cs
@@ -8,8 +8,7 @@ namespace Lizard.Logic.Datagen
         public const int MinOpeningPly = 8;
         public const int MaxOpeningPly = 9;
 
-        public const int SoftNodeLimit = 10000;
-        public const int HardNodeLimit = SoftNodeLimit * 20;
+        public const int SoftNodeLimit = 5000;
         public const int DepthLimit = 24;
 
         public const int WritableDataLimit = 512;

--- a/Logic/Datagen/DatagenParameters.cs
+++ b/Logic/Datagen/DatagenParameters.cs
@@ -19,5 +19,6 @@ namespace Lizard.Logic.Datagen
         public const int MaxFilteringScore = 5000;
 
         public const int MaxOpeningScore = 1200;
+        public const int MaxScrambledOpeningScore = 600;
     }
 }

--- a/Logic/Datagen/DatagenParameters.cs
+++ b/Logic/Datagen/DatagenParameters.cs
@@ -1,0 +1,23 @@
+﻿
+namespace Lizard.Logic.Datagen
+{
+    public static class DatagenParameters
+    {
+        public const int HashSize = 8;
+
+        public const int MinOpeningPly = 8;
+        public const int MaxOpeningPly = 9;
+
+        public const int SoftNodeLimit = 5000;
+        public const int HardNodeLimit = 100000;
+        public const int DepthLimit = 10;
+
+        public const int WritableDataLimit = 512;
+
+        public const int AdjudicateMoves = 2;
+        public const int AdjudicateScore = 4000;
+        public const int MaxFilteringScore = 5000;
+
+        public const int MaxOpeningScore = 1200;
+    }
+}

--- a/Logic/Datagen/GameResult.cs
+++ b/Logic/Datagen/GameResult.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Lizard.Logic.Datagen
+{
+    public enum GameResult
+    {
+        WhiteWin = 0,
+        Draw = 1,
+        BlackWin = 2
+    }
+}

--- a/Logic/Datagen/GameResult.cs
+++ b/Logic/Datagen/GameResult.cs
@@ -3,8 +3,8 @@ namespace Lizard.Logic.Datagen
 {
     public enum GameResult
     {
-        WhiteWin = 0,
+        WhiteWin = 2,
         Draw = 1,
-        BlackWin = 2
+        BlackWin = 0
     }
 }

--- a/Logic/Datagen/OutputFormat.cs
+++ b/Logic/Datagen/OutputFormat.cs
@@ -1,18 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using static Lizard.Logic.Datagen.Selfplay;
-
-namespace Lizard.Logic.Datagen
+﻿namespace Lizard.Logic.Datagen
 {
     public interface TOutputFormat
     {
         public int Score { get; set; }
         public GameResult Result { get; set; }
-        public string GetWritableData();
+        public void SetResult(GameResult gr);
+        public void SetSTM(int stm);
+        public string GetWritableTextData();
         public void Fill(Position pos, int score);
 
         public static string ResultToMarlin(GameResult gr)

--- a/Logic/Datagen/OutputFormat.cs
+++ b/Logic/Datagen/OutputFormat.cs
@@ -7,7 +7,7 @@
         public void SetResult(GameResult gr);
         public void SetSTM(int stm);
         public string GetWritableTextData();
-        public void Fill(Position pos, int score);
+        public void Fill(Position pos, Move bestMove, int score);
 
         public static string ResultToMarlin(GameResult gr)
         {

--- a/Logic/Datagen/OutputFormat.cs
+++ b/Logic/Datagen/OutputFormat.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using static Lizard.Logic.Datagen.DatagenMatch;
+
+namespace Lizard.Logic.Datagen
+{
+    public interface TOutputFormat
+    {
+        public int Score { get; set; }
+        public GameResult Result { get; set; }
+        public string GetWritableData();
+        public void Fill(Position pos, int score);
+
+        public static string ResultToMarlin(GameResult gr)
+        {
+            return gr switch
+            {
+                GameResult.WhiteWin => "1.0",
+                GameResult.Draw => "0.5",
+                GameResult.BlackWin => "0.0",
+            };
+        }
+    }
+
+
+}

--- a/Logic/Datagen/OutputFormat.cs
+++ b/Logic/Datagen/OutputFormat.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using static Lizard.Logic.Datagen.DatagenMatch;
+using static Lizard.Logic.Datagen.Selfplay;
 
 namespace Lizard.Logic.Datagen
 {

--- a/Logic/Datagen/PlaintextData.cs
+++ b/Logic/Datagen/PlaintextData.cs
@@ -1,0 +1,36 @@
+﻿
+namespace Lizard.Logic.Datagen
+{
+    public unsafe struct PlaintextData : TOutputFormat
+    {
+        public const int BufferSize = 92;
+        public fixed char FEN[BufferSize];
+
+        public int Score { get; set; }
+        public GameResult Result { get; set; }
+
+        public string GetWritableData()
+        {
+            fixed (char* fen = FEN)
+            {
+                var fenStr = new string(fen);
+                return $"{fenStr} | {Score} | {TOutputFormat.ResultToMarlin(Result)}";
+            }
+        }
+
+        public void Fill(Position pos, int score)
+        {
+            var posSpan = pos.GetFEN().AsSpan();
+
+            fixed (char* fen = FEN)
+            {
+                var fenSpan = new Span<char>(fen, BufferSize);
+                fenSpan.Clear();
+
+                posSpan.CopyTo(fenSpan);
+            }
+
+            Score = score;
+        }
+    }
+}

--- a/Logic/Datagen/PlaintextDataFormat.cs
+++ b/Logic/Datagen/PlaintextDataFormat.cs
@@ -9,7 +9,16 @@ namespace Lizard.Logic.Datagen
         public int Score { get; set; }
         public GameResult Result { get; set; }
 
-        public string GetWritableData()
+        public void SetResult(GameResult gr) => Result = gr;
+
+        public void SetSTM(int stm)
+        {
+            throw new NotImplementedException();
+        }
+
+
+
+        public string GetWritableTextData()
         {
             fixed (char* fen = FEN)
             {
@@ -17,6 +26,8 @@ namespace Lizard.Logic.Datagen
                 return $"{fenStr} | {Score} | {TOutputFormat.ResultToMarlin(Result)}";
             }
         }
+
+
 
         public void Fill(Position pos, int score)
         {

--- a/Logic/Datagen/PlaintextDataFormat.cs
+++ b/Logic/Datagen/PlaintextDataFormat.cs
@@ -6,6 +6,7 @@ namespace Lizard.Logic.Datagen
         public const int BufferSize = 92;
         public fixed char FEN[BufferSize];
 
+        public Move BestMove { get; set; }
         public int Score { get; set; }
         public GameResult Result { get; set; }
 
@@ -29,7 +30,7 @@ namespace Lizard.Logic.Datagen
 
 
 
-        public void Fill(Position pos, int score)
+        public void Fill(Position pos, Move bestMove, int score)
         {
             var posSpan = pos.GetFEN().AsSpan();
 
@@ -42,6 +43,7 @@ namespace Lizard.Logic.Datagen
             }
 
             Score = score;
+            BestMove = bestMove;
         }
     }
 }

--- a/Logic/Datagen/PlaintextDataFormat.cs
+++ b/Logic/Datagen/PlaintextDataFormat.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace Lizard.Logic.Datagen
 {
-    public unsafe struct PlaintextData : TOutputFormat
+    public unsafe struct PlaintextDataFormat : TOutputFormat
     {
         public const int BufferSize = 92;
         public fixed char FEN[BufferSize];

--- a/Logic/Datagen/ProgressBroker.cs
+++ b/Logic/Datagen/ProgressBroker.cs
@@ -1,0 +1,71 @@
+﻿
+using Lizard.Logic.Core;
+using System.Collections.Concurrent;
+
+namespace Lizard.Logic.Datagen
+{
+    public static class ProgressBroker
+    {
+        private static readonly ConcurrentDictionary<int, ulong> ThreadGameTotals = new ConcurrentDictionary<int, ulong>();
+        private static readonly ConcurrentDictionary<int, ulong> ThreadPositionTotals = new ConcurrentDictionary<int, ulong>();
+        private static readonly ConcurrentDictionary<int, double> ThreadNPS = new ConcurrentDictionary<int, double>();
+        private static readonly CancellationTokenSource TokenSource = new CancellationTokenSource();
+
+        public static void StartMonitoring()
+        {
+            Task.Run(() => MonitorProgress(TokenSource.Token));
+        }
+
+        public static void StopMonitoring()
+        {
+            TokenSource.Cancel();
+        }
+
+        private static void MonitorProgress(CancellationToken token)
+        {
+            Console.WriteLine("\n");
+            Console.WriteLine("                   games       positions      pos/sec");
+            (int _, int top) = Console.GetCursorPosition();
+
+            while (!token.IsCancellationRequested)
+            {
+                Console.SetCursorPosition(0, top);
+                Console.CursorVisible = false;
+                for (int y = 0; y < Console.WindowHeight - top; y++)
+                    Console.Write(new string(' ', Console.WindowWidth));
+                Console.SetCursorPosition(0, top);
+                //Console.CursorVisible = true;
+
+                ulong totalGames = 0;
+                double totalNPS = 0;
+                ulong totalPositions = 0;
+
+                foreach (var kvp in ThreadGameTotals)
+                {
+                    int id = kvp.Key;
+                    var games = kvp.Value;
+                    var positions = ThreadPositionTotals[id];
+                    var nps = ThreadNPS[id];
+
+                    Console.WriteLine($"Thread {id,3}: {games,12} {positions,15:N0} {nps,12:N2}");
+
+                    totalGames += games;
+                    totalPositions += positions;
+                    totalNPS += nps;
+                }
+
+                Console.WriteLine($"           ------------------------------------------");
+                Console.WriteLine($"            {totalGames,12} {totalPositions,15:N0} {totalNPS,12:N2}");
+
+                Thread.Sleep(250);
+            }
+        }
+
+        public static void ReportProgress(int threadId, ulong gameNum, ulong totalPositions, double nps)
+        {
+            ThreadGameTotals[threadId] = gameNum;
+            ThreadPositionTotals[threadId] = totalPositions;
+            ThreadNPS[threadId] = nps;
+        }
+    }
+}

--- a/Logic/Datagen/Rescorer.cs
+++ b/Logic/Datagen/Rescorer.cs
@@ -6,9 +6,6 @@ using static Lizard.Logic.Datagen.DatagenParameters;
 
 using Lizard.Logic.Datagen;
 using Lizard.Logic.Threads;
-using System.Threading;
-using System.IO;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Lizard.Logic.Util
 {
@@ -153,46 +150,5 @@ namespace Lizard.Logic.Util
             }
         }
 
-    }
-
-    [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct BulletFormatEntry
-    {
-        public const int Size = 32;
-
-        public ulong occ;
-        public fixed byte pcs[16];
-        public short score;
-        public byte result;
-        public byte ksq;
-        public byte opp_ksq;
-        public fixed byte _pad[3];
-
-        public void FillBitboard(ref Bitboard bb)
-        {
-            bb.Reset();
-
-            bb.Occupancy = occ;
-
-            ulong temp = occ;
-            int idx = 0;
-            while (temp != 0)
-            {
-                int sq = poplsb(&temp);
-                int piece = (pcs[idx / 2] >> (4 * (idx & 1))) & 0b1111;
-
-                bb.AddPiece(sq, piece / 8, piece % 8);
-
-                idx++;
-            }
-        }
-
-        public void WriteToBuffer(Span<byte> buff)
-        {
-            fixed (void* buffPtr = &buff[0], thisPtr = &this)
-            {
-                Unsafe.CopyBlock(buffPtr, thisPtr, BulletFormatEntry.Size);
-            }
-        }
     }
 }

--- a/Logic/Datagen/Rescorer.cs
+++ b/Logic/Datagen/Rescorer.cs
@@ -89,7 +89,7 @@ namespace Lizard.Logic.Util
             SearchInformation info = new SearchInformation(pos)
             {
                 SoftNodeLimit = SoftNodeLimit,
-                MaxNodes = HardNodeLimit,
+                MaxNodes = SoftNodeLimit * 20,
                 MaxDepth = DepthLimit,
                 OnDepthFinish = null,
                 OnSearchFinish = null,

--- a/Logic/Datagen/Rescorer.cs
+++ b/Logic/Datagen/Rescorer.cs
@@ -1,0 +1,198 @@
+﻿
+using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
+
+using static Lizard.Logic.Datagen.DatagenParameters;
+
+using Lizard.Logic.Datagen;
+using Lizard.Logic.Threads;
+using System.Threading;
+using System.IO;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace Lizard.Logic.Util
+{
+    public unsafe static class Rescorer
+    {
+        private const int MaxEntriesInQueue = 64;
+        private const int ChunkSize = 1024;
+        private const int BytesToRead = BulletFormatEntry.Size * ChunkSize;
+        private const double BlendPercentage = 0.0;
+
+        static readonly ConcurrentQueue<byte[]> InputQueue = new ConcurrentQueue<byte[]>();
+        static readonly SemaphoreSlim QueueSignal = new SemaphoreSlim(MaxEntriesInQueue);
+        static bool readingCompleted = false;
+
+
+        public static void Start(string inputFile, int workerCount = 1)
+        {
+            SearchOptions.Hash = HashSize;
+
+            Task readerThread = Task.Run(() => ReaderTask(inputFile));
+
+            Parallel.For(0, workerCount, i =>
+            {
+                WorkerTask(inputFile, i);
+            });
+
+            readerThread.Wait();
+        }
+
+        static void ReaderTask(string inputDataFile)
+        {
+            long fileSize = new FileInfo(inputDataFile).Length;
+
+            using FileStream fs = new FileStream(inputDataFile, FileMode.Open, FileAccess.Read);
+            byte[] buffer = new byte[BytesToRead];
+            int bytesRead;
+            while ((bytesRead = fs.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                // If the last chunk is smaller than the buffer size, resize it
+                if (bytesRead < buffer.Length)
+                {
+                    Array.Resize(ref buffer, bytesRead);
+                }
+
+                Span<BulletFormatEntry> entries = MemoryMarshal.Cast<byte, BulletFormatEntry>(buffer);
+                for (int i = 0; i < entries.Length; i++)
+                {
+                    fixed (byte* b = entries[i]._pad)
+                    {
+                        (*(byte*)&b[0]) = 58;
+                        (*(short*)&b[1]) = 25395;
+                    }
+                }
+
+                Console.Title = $"Progress {((double)fs.Position / fs.Length) * 100:N4}%";
+
+                QueueSignal.Wait(); // Only allow MaxEntriesInQueue items to be in memory at any given time
+
+                InputQueue.Enqueue(buffer);
+                buffer = new byte[BytesToRead]; // Allocate a new buffer for the next chunk
+            }
+
+            readingCompleted = true;
+        }
+
+        static void WorkerTask(string inputDataFile, int workerId)
+        {
+            var finfo = new FileInfo(inputDataFile);
+            string outputFile = Path.Join(finfo.Directory.FullName, $"{finfo.Name[..finfo.Name.IndexOf(".bin")]}_rescored{workerId}.bin");
+
+            if (outputFile == inputDataFile) { throw new Exception($"Failed creating outputFile for thread {workerId}!"); }
+            Log($"{Environment.CurrentManagedThreadId,2}:{workerId,2} writing to {outputFile}");
+
+            using var file = File.Open(outputFile, FileMode.Create);
+            using BinaryWriter outputWriter = new BinaryWriter(file, System.Text.Encoding.UTF8);
+
+            SearchThreadPool pool = new SearchThreadPool(1);
+            Position pos = new Position(owner: pool.MainThread);
+            ref Bitboard bb = ref pos.bb;
+
+            SearchInformation info = new SearchInformation(pos)
+            {
+                SoftNodeLimit = SoftNodeLimit,
+                MaxNodes = HardNodeLimit,
+                MaxDepth = DepthLimit,
+                OnDepthFinish = null,
+                OnSearchFinish = null,
+            };
+
+            long numRescored = 0;
+            Stopwatch sw = Stopwatch.StartNew();
+
+            while (!readingCompleted || !InputQueue.IsEmpty)
+            {
+                if (InputQueue.TryDequeue(out byte[] data))
+                {
+                    QueueSignal.Release();
+                    Span<BulletFormatEntry> entries = MemoryMarshal.Cast<byte, BulletFormatEntry>(data);
+
+                    pos.LoadFromFEN(InitialFEN);
+
+                    int entryCount = data.Length / BulletFormatEntry.Size;
+                    //Log($"WorkerThread{workerId} got {entryCount} entries");
+                    for (int i = 0; i < entryCount; i++)
+                    {
+                        ref BulletFormatEntry e = ref entries[i];
+
+                        e.FillBitboard(ref bb);
+                        Selfplay.ResetPosition(pos);
+
+                        pool.TTable.Clear();
+                        pool.Clear();
+
+                        pool.StartSearch(pos, ref info);
+                        pool.BlockCallerUntilFinished();
+
+                        int score = pool.GetBestThread().RootMoves[0].Score;
+
+                        if (Math.Abs(score) > MaxFilteringScore)
+                        {
+                            //  If the score is outside the acceptable bounds, leave the entry as it was
+                            continue;
+                        }
+
+                        //Log($"{pos.GetFEN(),-72}\t{e.score}\t->\t{score}");
+
+                        //  Adjust scores based on BlendPercentage, where:
+                        //        0% will save the score as returned by search
+                        //      100% will save the existing, unchanged score
+                        int blendedScore = (int)((score * (1 - BlendPercentage)) + (e.score * BlendPercentage));
+                        e.score = (short)int.Clamp(blendedScore, short.MinValue, short.MaxValue);
+                    }
+                    numRescored += entryCount;
+
+                    var posPerSec = (double)numRescored / sw.Elapsed.TotalSeconds;
+                    Log($"{Environment.CurrentManagedThreadId,2}:{workerId,2}\t" +
+                        $"{numRescored,9}" +
+                        $"{posPerSec,10:N1}/sec");
+
+                    outputWriter.Write(data, 0, data.Length);
+                }
+            }
+        }
+
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct BulletFormatEntry
+    {
+        public const int Size = 32;
+
+        public ulong occ;
+        public fixed byte pcs[16];
+        public short score;
+        public byte result;
+        public byte ksq;
+        public byte opp_ksq;
+        public fixed byte _pad[3];
+
+        public void FillBitboard(ref Bitboard bb)
+        {
+            bb.Reset();
+
+            bb.Occupancy = occ;
+
+            ulong temp = occ;
+            int idx = 0;
+            while (temp != 0)
+            {
+                int sq = poplsb(&temp);
+                int piece = (pcs[idx / 2] >> (4 * (idx & 1))) & 0b1111;
+
+                bb.AddPiece(sq, piece / 8, piece % 8);
+
+                idx++;
+            }
+        }
+
+        public void WriteToBuffer(Span<byte> buff)
+        {
+            fixed (void* buffPtr = &buff[0], thisPtr = &this)
+            {
+                Unsafe.CopyBlock(buffPtr, thisPtr, BulletFormatEntry.Size);
+            }
+        }
+    }
+}

--- a/Logic/Datagen/Selfplay.cs
+++ b/Logic/Datagen/Selfplay.cs
@@ -1,6 +1,7 @@
 ﻿
 //#define DBG
 //#define WRITE_PGN
+#define BIND
 
 using System.Runtime.InteropServices;
 
@@ -8,6 +9,7 @@ using static Lizard.Logic.Datagen.DatagenParameters;
 
 using Lizard.Logic.NN;
 using Lizard.Logic.Threads;
+using System.Diagnostics;
 
 namespace Lizard.Logic.Datagen
 {
@@ -19,9 +21,22 @@ namespace Lizard.Logic.Datagen
         public static long CumulativeGames = 0;
 
 
+
         public static void RunGames(int gamesToRun = 1, int threadID = 0, bool scramble = true)
         {
             SearchOptions.Hash = HashSize;
+
+#if BIND
+            var thisId = GetCurrentThreadId();
+            foreach (ProcessThread td in Process.GetCurrentProcess().Threads)
+            {
+                if (td.Id == thisId)
+                {
+                    td.IdealProcessor = (1 << threadID);
+                    break;
+                }
+            }
+#endif
 
             SearchThreadPool pool = new SearchThreadPool(1);
             Position pos = new Position(owner: pool.MainThread);
@@ -387,5 +402,10 @@ namespace Lizard.Logic.Datagen
 
             NNUE.RefreshAccumulator(pos);
         }
+
+
+
+        [DllImport("kernel32.dll")]
+        static extern uint GetCurrentThreadId();
     }
 }

--- a/Logic/Datagen/Selfplay.cs
+++ b/Logic/Datagen/Selfplay.cs
@@ -152,7 +152,7 @@ namespace Lizard.Logic.Datagen
                     bool badScore = Math.Abs(bestMoveScore) > MaxFilteringScore;
                     if (!(inCheck || bmCap || badScore))
                     {
-                        datapoints[toWrite].Fill(pos, bestMoveScore);
+                        datapoints[toWrite].Fill(pos, bestMove, bestMoveScore);
                         toWrite++;
                     }
                     else

--- a/Logic/Magic/MagicBitboards.cs
+++ b/Logic/Magic/MagicBitboards.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
 namespace Lizard.Logic.Magic
@@ -85,22 +87,30 @@ namespace Lizard.Logic.Magic
                     for (int m = 0; m < 100; m++)
                         foreach ((int sq, ulong blockers) in pextTests)
                             temp ^= TestPextFancy(blockers, sq);
-
-                    sw.Stop();
-                    if (n > 0)
-                        fancyElapsed += sw.ElapsedTicks;
-
+                    if (n > 0) fancyElapsed += sw.ElapsedTicks;
 
                     sw.Restart();
                     for (int m = 0; m < 100; m++)
                         foreach ((int sq, ulong blockers) in pextTests)
                             temp ^= TestPextNormal(blockers, sq);
-                    sw.Stop();
-                    if (n > 0)
-                        normalElapsed += sw.ElapsedTicks;
+                    if (n > 0) normalElapsed += sw.ElapsedTicks;
+
+                    sw.Restart();
+                    for (int m = 0; m < 100; m++)
+                        foreach ((int sq, ulong blockers) in pextTests)
+                            temp ^= TestPextFancy(blockers, sq);
+                    if (n > 0) fancyElapsed += sw.ElapsedTicks;
+
+                    sw.Restart();
+                    for (int m = 0; m < 100; m++)
+                        foreach ((int sq, ulong blockers) in pextTests)
+                            temp ^= TestPextNormal(blockers, sq);
+                    if (n > 0) normalElapsed += sw.ElapsedTicks;
                 }
 
                 UsePext = (fancyElapsed < normalElapsed);
+
+                if (UsePext) Log($"Pext enabled for a {normalElapsed / (double)fancyElapsed:N3}x speedup");
             }
 
             if (UsePext)
@@ -136,6 +146,7 @@ namespace Lizard.Logic.Magic
         /// and the returned mask treats the mask <paramref name="boardAll"/> as if every piece can be captured.
         /// Friendly pieces will need to be masked out so we aren't able to capture them.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetRookMoves(ulong boardAll, int idx)
         {
             if (UsePext)
@@ -157,6 +168,7 @@ namespace Lizard.Logic.Magic
         /// and the returned mask treats the mask <paramref name="boardAll"/> as if every piece can be captured.
         /// Friendly pieces will need to be masked out so we aren't able to capture them.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetBishopMoves(ulong boardAll, int idx)
         {
             if (UsePext)

--- a/Logic/NN/Accumulator.cs
+++ b/Logic/NN/Accumulator.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
 namespace Lizard.Logic.NN
@@ -28,6 +29,7 @@ namespace Lizard.Logic.NN
 
         public Vector256<short>* this[int perspective] => (perspective == Color.White) ? (Vector256<short>*)White : (Vector256<short>*)Black;
 
+        [MethodImpl(Inline)]
         public void CopyTo(Accumulator* target)
         {
             Unsafe.CopyBlock(target->White, White, ByteSize);
@@ -38,6 +40,7 @@ namespace Lizard.Logic.NN
 
         }
 
+        [MethodImpl(Inline)]
         public void CopyTo(ref Accumulator target, int perspective)
         {
             Unsafe.CopyBlock(target[perspective], this[perspective], ByteSize);

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
 using Lizard.Logic.Threads;
@@ -268,6 +269,7 @@ namespace Lizard.Logic.NN
             return (output / QA + LayerBiases[outputBucket]) * OutputScale / (QA * QB);
         }
 
+        [MethodImpl(Inline)]
         private static int FeatureIndexSingle(int pc, int pt, int sq, int kingSq, int perspective)
         {
             const int ColorStride = 64 * 6;
@@ -288,6 +290,7 @@ namespace Lizard.Logic.NN
             return ((768 * KingBuckets[kingSq]) + ((pc ^ perspective) * ColorStride) + (pt * PieceStride) + (sq)) * HiddenSize;
         }
 
+        [MethodImpl(Inline)]
         private static (int, int) FeatureIndex(int pc, int pt, int sq, int wk, int bk)
         {
             const int ColorStride = 64 * 6;
@@ -408,6 +411,7 @@ namespace Lizard.Logic.NN
             }
         }
 
+        [MethodImpl(Inline)]
         public static void MakeNullMove(Position pos)
         {
             pos.State->Accumulator->CopyTo(pos.NextState->Accumulator);
@@ -421,6 +425,7 @@ namespace Lizard.Logic.NN
 
         //  The general concept here is based off of Stormphrax's implementation:
         //  https://github.com/Ciekce/Stormphrax/commit/9b76f2a35531513239ed7078acc21294a11e75c6
+        [MethodImpl(Inline)]
         public static void ProcessUpdates(Position pos)
         {
             StateInfo* st = pos.State;
@@ -462,6 +467,7 @@ namespace Lizard.Logic.NN
             }
         }
 
+        [MethodImpl(Inline)]
         public static void UpdateSingle(Accumulator* prev, Accumulator* curr, int perspective)
         {
             ref var updates = ref curr->Update[perspective];

--- a/Logic/NN/NNUE.cs
+++ b/Logic/NN/NNUE.cs
@@ -236,7 +236,7 @@ namespace Lizard.Logic.NN
             }
 
             //  White king on A1, black king on H8
-            Position pos = new Position("7k/8/8/8/8/8/8/K7 w - - 0 1", true, owner: SearchPool.MainThread);
+            Position pos = new Position("7k/8/8/8/8/8/8/K7 w - - 0 1", true, owner: GlobalSearchPool.MainThread);
             int baseEval = GetEvaluation(pos);
 
             Log("\nNNUE evaluation: " + baseEval + "\n");

--- a/Logic/Search/SearchInformation.cs
+++ b/Logic/Search/SearchInformation.cs
@@ -38,6 +38,8 @@ namespace Lizard.Logic.Search
         /// </summary>
         public ulong MaxNodes = MaxSearchNodes;
 
+        public ulong SoftNodeLimit = MaxSearchNodes;
+
 
         /// <summary>
         /// Set to true the first time that OnSearchFinish is invoked.
@@ -100,7 +102,7 @@ namespace Lizard.Logic.Search
         /// </summary>
         private void PrintBestMove(ref SearchInformation info)
         {
-            Move bestThreadMove = SearchPool.GetBestThread().RootMoves[0].Move;
+            Move bestThreadMove = info.Position.Owner.AssocPool.GetBestThread().RootMoves[0].Move;
             Log("bestmove " + bestThreadMove.ToString());
         }
 

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -32,6 +32,11 @@
         public static bool UCI_Chess960 = false;
 
 
+#if DATAGEN
+        public const bool ShallowPruning = true;
+#else
+        public const bool ShallowPruning = true;
+#endif
 
         /// <summary>
         /// Whether or not to extend searches if there is only one good move in a position.

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Runtime.CompilerServices;
+using System.Text;
 
 using Lizard.Logic.Datagen;
 using Lizard.Logic.NN;
@@ -40,6 +41,7 @@ namespace Lizard.Logic.Search
         ///     The depth to search to, which is then extended by QSearch.
         /// </param>
         /// <returns>The evaluation of the best move.</returns>
+        [SkipLocalsInit]
         public static int Negamax<NodeType>(Position pos, SearchStackEntry* ss, int alpha, int beta, int depth, bool cutNode) where NodeType : SearchNodeType
         {
             bool isRoot = typeof(NodeType) == typeof(RootNode);
@@ -259,6 +261,16 @@ namespace Lizard.Logic.Search
             }
 
 
+            if (ttMove.Equals(Move.Null)
+                && (cutNode || isPV)
+                && depth >= ExtraCutNodeReductionMinDepth)
+            {
+                //  We expected this node to be a bad one, so give it an extra depth reduction
+                //  if the depth is at or above a threshold (currently 4).
+                depth--;
+            }
+
+
             //  Try ProbCut for:
             //  non-PV nodes
             //  that aren't a response to a previous singular extension search
@@ -318,16 +330,6 @@ namespace Lizard.Logic.Search
                         return score;
                     }
                 }
-            }
-
-
-            if (ttMove.Equals(Move.Null)
-                && (cutNode || isPV)
-                && depth >= ExtraCutNodeReductionMinDepth)
-            {
-                //  We expected this node to be a bad one, so give it an extra depth reduction
-                //  if the depth is at or above a threshold (currently 4).
-                depth--;
             }
 
 
@@ -716,6 +718,7 @@ namespace Lizard.Logic.Search
         /// This is similar to Negamax, but there is far less pruning going on here, and we are only interested in ensuring that
         /// the score for a particular Negamax node is reasonable if we look at the forcing moves that can be made after that node.
         /// </summary>
+        [SkipLocalsInit]
         public static int QSearch<NodeType>(Position pos, SearchStackEntry* ss, int alpha, int beta, int depth) where NodeType : SearchNodeType
         {
             bool isPV = typeof(NodeType) != typeof(NonPVNode);

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -88,7 +88,7 @@ namespace Lizard.Logic.Search
                 }
             }
 #else
-            if (isPV && (thisThread.Nodes >= DatagenParameters.HardNodeLimit && thisThread.RootDepth > 2))
+            if (isPV && (thisThread.Nodes >= thisThread.HardNodeLimit && thisThread.RootDepth > 2))
             {
                 thisThread.AssocPool.StopThreads = true;
             }

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -340,6 +340,7 @@ namespace Lizard.Logic.Search
             int captureCount = 0;   //  Number of capture moves that have been played, to a max of 16.
 
             bool didSkip = false;
+            int lmpMoves = LMPTable[improving ? 1 : 0][depth];
 
             Move* captureMoves = stackalloc Move[16];
             Move* quietMoves = stackalloc Move[16];
@@ -387,13 +388,14 @@ namespace Lizard.Logic.Search
                 //  we have a non-mate score for at least one move,
                 //  and we have non-pawn material:
                 //  We can start skipping quiet moves if we have already seen enough of them at this depth.
-                if (!isRoot
+                if (ShallowPruning
+                    && !isRoot
                     && bestScore > ScoreMatedMax
                     && pos.HasNonPawnMaterial(pos.ToMove))
                 {
                     if (skipQuiets == false)
                     {
-                        skipQuiets = legalMoves >= LMPTable[improving ? 1 : 0][depth];
+                        skipQuiets = legalMoves >= lmpMoves;
                     }
 
                     bool givesCheck = ((pos.State->CheckSquares[ourPiece] & SquareBB[moveTo]) != 0);

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -88,7 +88,7 @@ namespace Lizard.Logic.Search
                 }
             }
 #else
-            if (isPV && thisThread.Nodes >= DatagenMatch.HardNodeLimit)
+            if (isPV && (thisThread.Nodes >= DatagenMatch.HardNodeLimit && thisThread.RootDepth > 2))
             {
                 thisThread.AssocPool.StopThreads = true;
             }

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -88,7 +88,7 @@ namespace Lizard.Logic.Search
                 }
             }
 #else
-            if (isPV && (thisThread.Nodes >= DatagenMatch.HardNodeLimit && thisThread.RootDepth > 2))
+            if (isPV && (thisThread.Nodes >= DatagenParameters.HardNodeLimit && thisThread.RootDepth > 2))
             {
                 thisThread.AssocPool.StopThreads = true;
             }

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -31,6 +31,8 @@ namespace Lizard.Logic.Threads
         /// </summary>
         public ulong Nodes;
 
+        public ulong HardNodeLimit;
+
         /// <summary>
         /// The index of this thread within the SearchPool, which starts at 0 for the MainSearchThread, 
         /// 1 for the first non-main thread, etc.
@@ -352,6 +354,8 @@ namespace Lizard.Logic.Threads
             SearchInformation info = AssocPool.SharedInfo;
 
             TimeManager tm = info.TimeManager;
+
+            HardNodeLimit = info.MaxNodes;
 
             //  And set it's Position to this SearchThread's unique copy.
             //  (The Position that AssocPool.SharedInfo has right now has the same FEN, but its "Owner" field might not be correct.)

--- a/Logic/Threads/SearchThreadPool.cs
+++ b/Logic/Threads/SearchThreadPool.cs
@@ -17,13 +17,15 @@
         /// <summary>
         /// Global ThreadPool.
         /// </summary>
-        public static SearchThreadPool SearchPool;
+        public static SearchThreadPool GlobalSearchPool;
 
         public int ThreadCount = SearchOptions.Threads;
 
         public SearchInformation SharedInfo;
         public SearchThread[] Threads;
         public SearchThread MainThread => Threads[0];
+
+        public TranspositionTable TTable;
 
         /// <summary>
         /// Set to true by the main thread when we are nearing the maximum search time / maximum node count,
@@ -35,13 +37,13 @@
 
         static SearchThreadPool()
         {
-            //  Initialize the global threadpool here
-            SearchPool = new SearchThreadPool(SearchOptions.Threads);
+            GlobalSearchPool = new SearchThreadPool(SearchOptions.Threads);
         }
 
         public SearchThreadPool(int threadCount)
         {
             Blocker = new Barrier(1);
+            TTable = new TranspositionTable(Hash);
             Resize(threadCount);
         }
 
@@ -70,6 +72,8 @@
             for (int i = 0; i < ThreadCount; i++)
             {
                 Threads[i] = new SearchThread(i);
+                Threads[i].AssocPool = this;
+                Threads[i].TT = TTable;
             }
 
             MainThread.WaitForThreadFinished();

--- a/Logic/Transposition/TTEntry.cs
+++ b/Logic/Transposition/TTEntry.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 using static Lizard.Logic.Transposition.TranspositionTable;
 
@@ -40,7 +41,7 @@ namespace Lizard.Logic.Transposition
         public readonly TTNodeType NodeType => (TTNodeType)(_AgePVType & TT_BOUND_MASK);
         public readonly int Bound => _AgePVType & TT_BOUND_MASK;
 
-
+        [MethodImpl(Inline)]
         public readonly sbyte RelAge(byte age) => (sbyte)((TT_AGE_CYCLE + age - _AgePVType) & TT_AGE_MASK);
         public readonly bool IsEmpty => _Depth == 0;
 
@@ -73,22 +74,13 @@ namespace Lizard.Logic.Transposition
         /// </summary>
         public static short MakeNormalScore(short ttScore, int ply)
         {
-            if (ttScore == ScoreNone)
+            return ttScore switch
             {
-                return ttScore;
-            }
-
-            if (ttScore >= ScoreTTWin)
-            {
-                return (short)(ttScore - ply);
-            }
-
-            if (ttScore <= ScoreTTLoss)
-            {
-                return (short)(ttScore + ply);
-            }
-
-            return ttScore;
+                   ScoreNone   => ttScore,
+                >= ScoreTTWin  => (short)(ttScore - ply),
+                <= ScoreTTLoss => (short)(ttScore + ply),
+                   _           => ttScore
+            };
         }
 
         /// <summary>
@@ -100,22 +92,13 @@ namespace Lizard.Logic.Transposition
         /// </summary>
         public static short MakeTTScore(short score, int ply)
         {
-            if (score == ScoreNone)
+            return score switch
             {
-                return score;
-            }
-
-            if (score >= ScoreTTWin)
-            {
-                return (short)(score + ply);
-            }
-
-            if (score <= ScoreTTLoss)
-            {
-                return (short)(score - ply);
-            }
-
-            return score;
+                   ScoreNone   => score,
+                >= ScoreTTWin  => (short)(score + ply),
+                <= ScoreTTLoss => (short)(score - ply),
+                   _           => score
+            };
         }
 
         public override string ToString()

--- a/Logic/Transposition/TTEntry.cs
+++ b/Logic/Transposition/TTEntry.cs
@@ -44,7 +44,7 @@ namespace Lizard.Logic.Transposition
         public readonly sbyte RelAge(byte age) => (sbyte)((TT_AGE_CYCLE + age - _AgePVType) & TT_AGE_MASK);
         public readonly bool IsEmpty => _Depth == 0;
 
-        public void Update(ulong key, short score, TTNodeType nodeType, int depth, Move move, short statEval, bool isPV = false)
+        public void Update(ulong key, short score, TTNodeType nodeType, int depth, Move move, short statEval, byte age, bool isPV = false)
         {
             var k = (ushort)key;
             if (move != Move.Null || k != Key)
@@ -60,7 +60,7 @@ namespace Lizard.Logic.Transposition
                 _Score = score;
                 _StatEval = statEval;
                 _Depth = (byte)(depth - DepthOffset);
-                _AgePVType = (byte)(TranspositionTable.Age | ((isPV ? 1u : 0u) << 2) | (uint)nodeType);
+                _AgePVType = (byte)(age | ((isPV ? 1u : 0u) << 2) | (uint)nodeType);
 
                 Assert(score == ScoreNone || (score <= ScoreMate && score >= -ScoreMate),
                     $"WARN the score {score} is outside of bounds for normal TT entries!");

--- a/Logic/Util/Interop.cs
+++ b/Logic/Util/Interop.cs
@@ -96,9 +96,12 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns <paramref name="value"/> with the most significant bit set to 0.
         /// </summary>
-        public static ulong popmsb(ulong value)
+        [MethodImpl(Inline)]
+        public static unsafe int popmsb(ulong* value)
         {
-            return value ^ (1UL << msb(value));
+            int sq = (int)(63 - ulong.LeadingZeroCount(*value));
+            *value = *value & ~(1UL << sq);
+            return sq;
         }
 
 

--- a/Logic/Util/SearchBench.cs
+++ b/Logic/Util/SearchBench.cs
@@ -5,7 +5,7 @@
 
         public static void Go(int depth = 12, bool openBench = false)
         {
-            Position pos = new Position(InitialFEN, owner: SearchPool.MainThread);
+            Position pos = new Position(InitialFEN, owner: GlobalSearchPool.MainThread);
 
             Stopwatch sw = Stopwatch.StartNew();
 
@@ -14,26 +14,26 @@
             info.OnDepthFinish = null;
             info.OnSearchFinish = null;
 
-            SearchPool.MainThread.WaitForThreadFinished();
-            TranspositionTable.Clear();
-            Search.Searches.HandleNewGame();
+            GlobalSearchPool.MainThread.WaitForThreadFinished();
+            GlobalSearchPool.TTable.Clear();
+            GlobalSearchPool.Clear();
 
             foreach (string fen in BenchFENs)
             {
                 pos.LoadFromFEN(fen);
-                SearchPool.StartSearch(pos, ref info);
+                GlobalSearchPool.StartSearch(pos, ref info);
 
-                SearchPool.MainThread.WaitForThreadFinished();
+                GlobalSearchPool.MainThread.WaitForThreadFinished();
 
-                ulong thisNodeCount = SearchPool.GetNodeCount();
+                ulong thisNodeCount = GlobalSearchPool.GetNodeCount();
                 totalNodes += thisNodeCount;
                 if (!openBench)
                 {
                     Log(fen.PadRight(76, ' ') + "\t" + thisNodeCount);
                 }
 
-                TranspositionTable.Clear();
-                Search.Searches.HandleNewGame();
+                GlobalSearchPool.TTable.Clear();
+                GlobalSearchPool.Clear();
             }
             sw.Stop();
 

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -622,6 +622,56 @@ namespace Lizard.Logic.Util
         }
 
 
+
+        public static unsafe void FillWithScharnaglNumber(int n, int* types)
+        {
+            int n2 = n / 4;
+            int b1 = n % 4;
+
+            int n3 = n2 / 4;
+            int b2 = n2 % 4;
+
+            int n4 = n3 / 6;
+            int  q = n3 % 6;
+
+            (int knight1, int knight2) = N5N[n4];
+
+            types[b1 * 2 + 1] = Bishop;
+            types[b2 * 2 + 0] = Bishop;
+
+            PlaceInSpot(Queen, q);
+
+            PlaceInSpot(Knight, knight1);
+            PlaceInSpot(Knight, knight2);
+
+            PlaceInSpot(Rook);
+            PlaceInSpot(King);
+            PlaceInSpot(Rook);
+
+            void PlaceInSpot(int pt, int skip = 0)
+            {
+                int skips = 0;
+                for (int i = 0; i < 8; i++)
+                {
+                    if (types[i] == 0 && skips++ >= skip)
+                    {
+                        types[i] = pt;
+                        break;
+                    }
+                }
+            }
+
+        }
+
+        private static readonly (int a, int b)[] N5N =
+        [
+            (0, 0), (0, 1), (0, 2), (0, 3),
+            (1, 1), (1, 2), (1, 3),
+            (2, 2), (2, 3),
+            (3, 3),
+        ];
+
+
         public static int AsInt(this bool v) => v ? 1 : 0;
         public static bool AsBool(this int v) => v != 0;
     }

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -84,8 +84,8 @@ namespace Lizard.Logic.Util
         {
             StringBuilder sb = new StringBuilder();
 
-#if DEV
-            sb.Append("DEV ");
+#if DATAGEN
+            sb.Append("Datagen ");
 #endif
 
 #if DEBUG
@@ -499,7 +499,7 @@ namespace Lizard.Logic.Util
             int multiPV = Math.Min(MultiPV, rootMoves.Count);
 
             double time = Math.Max(1, Math.Round(info.TimeManager.GetSearchTime()));
-            double nodes = SearchPool.GetNodeCount();
+            double nodes = thisThread.AssocPool.GetNodeCount();
             int nodesPerSec = (int)(nodes / (time / 1000));
 
             int lastValidScore = 0;
@@ -544,7 +544,7 @@ namespace Lizard.Logic.Util
                 sb.Append(" score " + score);
                 sb.Append(" nodes " + nodes);
                 sb.Append(" nps " + nodesPerSec);
-                sb.Append(" hashfull " + TranspositionTable.GetHashFull());
+                sb.Append(" hashfull " + thisThread.TT.GetHashFull());
 
                 sb.Append(" pv");
                 for (int j = 0; j < MaxPly; j++)

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
@@ -120,12 +121,14 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the <see cref="Direction"/> that the <paramref name="color"/> pawns move in, white pawns up, black pawns down.
         /// </summary>
+        [MethodImpl(Inline)]
         public static int ShiftUpDir(int color) => (color == Color.White) ? Direction.NORTH : Direction.SOUTH;
 
 
         /// <summary>
         /// Shifts the bits in <paramref name="b"/> in the direction <paramref name="dir"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong Shift(int dir, ulong b)
         {
             return dir switch
@@ -148,6 +151,7 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns a ulong with bits set along whichever file <paramref name="idx"/> is in.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetFileBB(int idx)
         {
             return FileABB << GetIndexFile(idx);
@@ -157,6 +161,7 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns a ulong with bits set along whichever rank <paramref name="idx"/> is on.
         /// </summary>
+        [MethodImpl(Inline)]
         public static ulong GetRankBB(int idx)
         {
             return Rank1BB << (8 * GetIndexRank(idx));
@@ -309,24 +314,28 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the number of the file with the letter <paramref name="fileLetter"/>, so GetFileInt('a') returns 0.
         /// </summary>
+        [MethodImpl(Inline)] 
         public static int GetFileInt(char fileLetter) => fileLetter - 97;
 
 
         /// <summary>
         /// Returns the file (x coordinate) for the index, which is between A=0 and H=7.
         /// </summary>
+        [MethodImpl(Inline)] 
         public static int GetIndexFile(int index) => index & 7;
 
 
         /// <summary>
         /// Returns the rank (y coordinate) for the index, which is between 0 and 7.
         /// </summary>
+        [MethodImpl(Inline)] 
         public static int GetIndexRank(int index) => index >> 3;
 
 
         /// <summary>
         /// Sets <paramref name="x"/> to the file of <paramref name="index"/>, and <paramref name="y"/> to its rank.
         /// </summary>
+        [MethodImpl(Inline)]
         public static void IndexToCoord(in int index, out int x, out int y)
         {
             x = index % 8;
@@ -337,6 +346,7 @@ namespace Lizard.Logic.Util
         /// <summary>
         /// Returns the index of the square with the rank <paramref name="x"/> and file <paramref name="y"/>.
         /// </summary>
+        [MethodImpl(Inline)]
         public static int CoordToIndex(int x, int y)
         {
             return (y * 8) + x;

--- a/Program.cs
+++ b/Program.cs
@@ -547,27 +547,27 @@ namespace Lizard
         {
             int numGames = 200;
             int threads = 1;
-            bool scramble = false;
+            bool dfrc = false;
 
             if (args.Length > 1 && int.TryParse(args[1], out int selNumGames)) numGames = selNumGames;
             if (args.Length > 2 && int.TryParse(args[2], out int selThreads)) threads = selThreads;
-            if (args.Length > 3 && (args[3].StartsWithIgnoreCase("s") || args[3].EqualsIgnoreCase("yes"))) scramble = true;
+            if (args.Length > 3 && args[3].ContainsIgnoreCase("frc")) dfrc = true;
 
             Log($"Will play {numGames * (long)threads} total games, {numGames}/thread with {threads} thread(s)" +
-                $"{(scramble ? ", scrambling positions" : string.Empty)}.");
+                $"{(dfrc ? ", DFRC" : string.Empty)}.");
             Log($"Hit enter to begin...");
             _ = Console.ReadLine();
 
             if (threads == 1)
             {
                 //  Let this run on the main thread to allow for debugging
-                Selfplay.RunGames(gamesToRun: numGames, threadID: 0, scramble: scramble);
+                Selfplay.RunGames(gamesToRun: numGames, threadID: 0, dfrc: dfrc);
             }
             else
             {
                 Parallel.For(0, threads, new() { MaxDegreeOfParallelism = threads }, (int i) =>
                 {
-                    Selfplay.RunGames(gamesToRun: numGames, threadID: i, scramble: scramble);
+                    Selfplay.RunGames(gamesToRun: numGames, threadID: i, dfrc: dfrc);
                 });
             }
 

--- a/Program.cs
+++ b/Program.cs
@@ -542,18 +542,27 @@ namespace Lizard
         {
             int numGames = 200;
             int threads = 1;
+            bool scramble = false;
+
             if (args.Length > 1 && int.TryParse(args[1], out int selNumGames)) numGames = selNumGames;
             if (args.Length > 2 && int.TryParse(args[2], out int selThreads)) threads = selThreads;
+            if (args.Length > 3 && (args[3].StartsWithIgnoreCase("s") || args[3].EqualsIgnoreCase("yes"))) scramble = true;
+
+            Log($"Will play {numGames * (long)threads} total games, {numGames}/thread with {threads} thread(s)" +
+                $"{(scramble ? ", scrambling positions" : string.Empty)}.");
+            Log($"Hit enter to begin...");
+            _ = Console.ReadLine();
 
             if (threads == 1)
             {
-                DatagenMatch.RunGames(numGames, threadID: 0);
+                //  Let this run on the main thread to allow for debugging
+                DatagenMatch.RunGames(gamesToRun: numGames, threadID: 0, scramble: scramble);
             }
             else
             {
                 Parallel.For(0, threads, new() { MaxDegreeOfParallelism = threads }, (int i) =>
                 {
-                    DatagenMatch.RunGames(numGames, threadID: i);
+                    DatagenMatch.RunGames(gamesToRun: numGames, threadID: i, scramble: scramble);
                 });
             }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,7 @@
-﻿using System.Text;
+﻿using System.Data;
+using System.Text;
 
+using Lizard.Logic.Datagen;
 using Lizard.Logic.NN;
 using Lizard.Logic.Threads;
 
@@ -13,7 +15,7 @@ namespace Lizard
 
         public static void Main(string[] args)
         {
-            if (args.Length == 1)
+            if (args.Length != 0)
             {
                 if (args[0] == "bench")
                 {
@@ -25,11 +27,16 @@ namespace Lizard
                     Console.WriteLine(GetCompilerInfo());
                     Environment.Exit(0);
                 }
+                else if (args[0] == "datagen")
+                {
+                    HandleDatagenCommand(args);
+                    Environment.Exit(0);
+                }
             }
 
             InitializeAll();
 
-            p = new Position(owner: SearchPool.MainThread);
+            p = new Position(owner: GlobalSearchPool.MainThread);
             info = new SearchInformation(p);
 
             DoInputLoop();
@@ -44,10 +51,10 @@ namespace Lizard
 
 
             Console.CancelKeyPress += delegate (object sender, ConsoleCancelEventArgs e) {
-                if (!SearchPool.StopThreads)
+                if (!GlobalSearchPool.StopThreads)
                 {
                     //  If a search is ongoing, stop it instead of closing the console.
-                    SearchPool.StopThreads = true;
+                    GlobalSearchPool.StopThreads = true;
                     e.Cancel = true;
                 }
 
@@ -102,8 +109,8 @@ namespace Lizard
                 }
                 else if (input.EqualsIgnoreCase("ucinewgame"))
                 {
-                    p = new Position(InitialFEN, owner: SearchPool.MainThread);
-                    Searches.HandleNewGame();
+                    p = new Position(InitialFEN, owner: GlobalSearchPool.MainThread);
+                    p.Owner.AssocPool.Clear();
                 }
                 else if (input.Equals("listmoves"))
                 {
@@ -119,7 +126,7 @@ namespace Lizard
                 }
                 else if (input.StartsWithIgnoreCase("stop"))
                 {
-                    SearchPool.StopThreads = true;
+                    GlobalSearchPool.StopThreads = true;
                 }
                 else if (input.EqualsIgnoreCase("eval"))
                 {
@@ -145,7 +152,7 @@ namespace Lizard
                 {
                     if (int.TryParse(param[1], out int threadCount))
                     {
-                        SearchPool.Resize(threadCount);
+                        GlobalSearchPool.Resize(threadCount);
                     }
                 }
                 else if (input.ContainsIgnoreCase("searchinfo"))
@@ -159,6 +166,11 @@ namespace Lizard
                 else if (input.EqualsIgnoreCase("compiler"))
                 {
                     Log(GetCompilerInfo());
+                }
+                else if (input.StartsWithIgnoreCase("datagen"))
+                {
+                    string[] splits = input.ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    HandleDatagenCommand(splits);
                 }
                 else if (input.StartsWithIgnoreCase("quit") || input.StartsWithIgnoreCase("exit"))
                 {
@@ -266,7 +278,7 @@ namespace Lizard
         {
             Log(info.ToString());
             Log("\r\n");
-            TranspositionTable.PrintClusterStatus();
+            p.Owner.TT.PrintClusterStatus();
         }
 
         /// <summary>
@@ -383,7 +395,7 @@ namespace Lizard
                     {
                         Task.Run(() =>
                         {
-                            Position temp = new Position(p.GetFEN(), false, owner: SearchPool.MainThread);
+                            Position temp = new Position(p.GetFEN(), false, owner: GlobalSearchPool.MainThread);
                             temp.PerftParallel(depth, true);
                         });
                     }
@@ -424,8 +436,8 @@ namespace Lizard
                 return;
             }
 
-            TranspositionTable.Clear();
-            Searches.HandleNewGame();
+            p.Owner.TT.Clear();
+            p.Owner.AssocPool.Clear();
 
             info = new SearchInformation(p, MaxDepth);
             info.TimeManager.MaxSearchTime = SearchConstants.MaxSearchTime;
@@ -450,7 +462,7 @@ namespace Lizard
                 }
             }
 
-            SearchPool.StartSearch(p, ref info, setup);
+            GlobalSearchPool.StartSearch(p, ref info, setup);
         }
 
         private static void HandlePositionCommand(string input, ThreadSetup setup)
@@ -525,6 +537,30 @@ namespace Lizard
             Log("Loaded fen '" + p.GetFEN() + "'");
         }
 
+
+        private static void HandleDatagenCommand(string[] args)
+        {
+            int numGames = 200;
+            int threads = 1;
+            if (args.Length > 1 && int.TryParse(args[1], out int selNumGames)) numGames = selNumGames;
+            if (args.Length > 2 && int.TryParse(args[2], out int selThreads)) threads = selThreads;
+
+            if (threads == 1)
+            {
+                DatagenMatch.RunGames(numGames, threadID: 0);
+            }
+            else
+            {
+                Parallel.For(0, threads, new() { MaxDegreeOfParallelism = threads }, (int i) =>
+                {
+                    DatagenMatch.RunGames(numGames, threadID: i);
+                });
+            }
+
+            Console.WriteLine($"Total: {DatagenMatch.CumulativeGames}");
+            Environment.Exit(0);
+        }
+
         private static void HandleBenchCommand(string input)
         {
             if (input.ContainsIgnoreCase("perft"))
@@ -575,8 +611,8 @@ namespace Lizard
 #if JB
             JetBrains.Profiler.Api.MeasureProfiler.StartCollectingData();
 #endif
-            SearchPool.StartSearch(p, ref info);
-            SearchPool.BlockCallerUntilFinished();
+            GlobalSearchPool.StartSearch(p, ref info);
+            GlobalSearchPool.BlockCallerUntilFinished();
 
 #if JB
             JetBrains.Profiler.Api.MeasureProfiler.SaveData();


### PR DESCRIPTION
Required moderate changes to search threads and the TT, but without a measurable performance impact.

```
Elo   | -0.20 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 34798 W: 8480 L: 8500 D: 17818
Penta | [101, 3161, 10889, 3153, 95]
http://somelizard.pythonanywhere.com/test/1267/
```