### PR TITLE
Added score stability TM component

### DIFF
--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -357,6 +357,9 @@ namespace Lizard.Logic.Threads
             //  MultiPV searches will only consider the lesser between the number of legal moves and the requested MultiPV number.
             int multiPV = Math.Min(SearchOptions.MultiPV, RootMoves.Count);
 
+            Span<int> searchScores = stackalloc int[MaxPly];
+            int scoreIdx = 0;
+
             RootMove lastBestRootMove = new RootMove(Move.Null);
             int stability = 0;
 
@@ -472,7 +475,9 @@ namespace Lizard.Logic.Threads
                     }
                 }
 
-                if (SoftTimeUp(tm, stability))
+                searchScores[scoreIdx++] = RootMoves[0].Score;
+
+                if (SoftTimeUp(tm, stability, searchScores[..scoreIdx]))
                 {
                     break;
                 }
@@ -501,7 +506,7 @@ namespace Lizard.Logic.Threads
         private static ReadOnlySpan<double> StabilityCoefficients => [2.2, 1.6, 1.4, 1.1, 1, 0.95, 0.9];
         private static int StabilityMax = StabilityCoefficients.Length - 1;
 
-        private bool SoftTimeUp(TimeManager tm, int stability)
+        private bool SoftTimeUp(TimeManager tm, int stability, Span<int> searchScores)
         {
             if (!tm.HasSoftTime)
                 return false;
@@ -510,8 +515,15 @@ namespace Lizard.Logic.Threads
             double multFactor = 1.0;
             if (RootDepth > 7)
             {
-                double proportion = NodeTable[RootMoves[0].Move.From][RootMoves[0].Move.To] / (double)Nodes;
-                multFactor = ((1.5 - proportion) * 1.75) * StabilityCoefficients[Math.Min(stability, StabilityMax)];
+                double nodeTM = ((1.5 - NodeTable[RootMoves[0].Move.From][RootMoves[0].Move.To] / (double)Nodes) * 1.75);
+                double bmStability = StabilityCoefficients[Math.Min(stability, StabilityMax)];
+                
+                double scoreStability = searchScores[searchScores.Length - 1 - 3] 
+                                      - searchScores[searchScores.Length - 1 - 0];
+                
+                scoreStability = Math.Max(0.85, Math.Min(1.15, 0.034 * scoreStability));
+
+                multFactor = nodeTM * bmStability * scoreStability;
             }
 
             if (tm.GetSearchTime() >= tm.SoftTimeLimit * multFactor)


### PR DESCRIPTION
```
Elo   | 4.22 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 17052 W: 4189 L: 3982 D: 8881
Penta | [50, 1794, 4652, 1959, 71]
```
http://somelizard.pythonanywhere.com/test/1430/