### PR TITLE
Base Probcut SEE on beta and eval

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -304,7 +304,7 @@ namespace Lizard.Logic.Search
                 for (int i = 0; i < numCaps; i++)
                 {
                     Move m = OrderNextMove(captures, numCaps, i);
-                    if (!pos.IsLegal(m) || !SEE_GE(pos, m, seeThreshold))
+                    if (!pos.IsLegal(m) || !SEE_GE(pos, m, Math.Max(seeThreshold, probBeta - ss->StaticEval)))
                     {
                         //  Skip illegal moves, and captures/promotions that don't result in a positive material trade
                         continue;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -287,7 +287,6 @@ namespace Lizard.Logic.Search
             //  or the TT hit's depth is well below the current depth,
             //  or the TT hit's score is above beta + ProbCutBeta(Improving).
             int probBeta = beta + (improving ? ProbCutBetaImproving : ProbCutBeta);
-            const int seeThreshold = 1;
             if (UseProbCut
                 && !isPV
                 && !doSkip
@@ -304,7 +303,7 @@ namespace Lizard.Logic.Search
                 for (int i = 0; i < numCaps; i++)
                 {
                     Move m = OrderNextMove(captures, numCaps, i);
-                    if (!pos.IsLegal(m) || !SEE_GE(pos, m, Math.Max(seeThreshold, probBeta - ss->StaticEval)))
+                    if (!pos.IsLegal(m) || !SEE_GE(pos, m, Math.Max(1, probBeta - ss->StaticEval)))
                     {
                         //  Skip illegal moves, and captures/promotions that don't result in a positive material trade
                         continue;


### PR DESCRIPTION
```
Elo   | 2.67 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 32404 W: 7855 L: 7606 D: 16943
Penta | [123, 3691, 8361, 3868, 159]
```
http://somelizard.pythonanywhere.com/test/1474/