### PR TITLE
Reduce cutnodes more, extend ttpv

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -168,7 +168,7 @@
         /// <summary>
         /// For LMR, the reduction of a move is modified by it's history divided by (1024 * this value).
         /// </summary>
-        public static int HistoryReductionMultiplier = 12;
+        public static int LMRHistDivisor = 12288;
 
 
 

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -528,6 +528,8 @@ namespace Lizard.Logic.Search
                     //  Reduce if we think that this move is going to be a bad one
                     R += cutNode.AsInt() * 2;
 
+                    R -= ss->TTPV.AsInt();
+
                     //  Extend for PV searches
                     R -= isPV.AsInt();
 

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -523,27 +523,23 @@ namespace Lizard.Logic.Search
                     int R = LogarithmicReductionTable[depth][legalMoves];
 
                     //  Reduce if our static eval is declining
-                    if (!improving)
-                        R++;
+                    R += (!improving).AsInt();
 
                     //  Reduce if we think that this move is going to be a bad one
-                    if (cutNode)
-                        R++;
+                    R += cutNode.AsInt() * 2;
 
                     //  Extend for PV searches
-                    if (isPV)
-                        R--;
+                    R -= isPV.AsInt();
 
                     //  Extend killer moves
-                    if (m.Equals(ss->KillerMove))
-                        R--;
+                    R -= (m == ss->KillerMove).AsInt();
 
                     var histScore = 2 * history.MainHistory[us, m] + 
                                     2 * (*(ss - 1)->ContinuationHistory)[histIdx] + 
                                         (*(ss - 2)->ContinuationHistory)[histIdx] + 
                                         (*(ss - 4)->ContinuationHistory)[histIdx];
 
-                    R -= (histScore / (1024 * HistoryReductionMultiplier));
+                    R -= (histScore / LMRHistDivisor);
 
                     //  Clamp the reduction so that the new depth is somewhere in [1, depth + extend]
                     //  If we don't reduce at all, then we will just be searching at (depth + extend - 1) as normal.

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -604,7 +604,7 @@ namespace Lizard.Logic.UCI
             Options[nameof(LMRExtensionThreshold)].AutoMinMax();
             Options[nameof(LMRExchangeBase)].AutoMinMax();
 
-            Options[nameof(HistoryReductionMultiplier)].AutoMinMax();
+            Options[nameof(LMRHistDivisor)].AutoMinMax();
 
             Options[nameof(FutilityExchangeBase)].AutoMinMax();
 


### PR DESCRIPTION
```
Elo   | 2.74 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31658 W: 7952 L: 7702 D: 16004
Penta | [151, 3573, 8120, 3845, 140]
```
http://somelizard.pythonanywhere.com/test/1537/