### PR TITLE
Use CaptureHistory in LMR

### DIFF
--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -36,7 +36,7 @@ namespace Lizard.Logic.Search.Ordering
                 else if (bb.GetPieceAtIndex(moveTo) != None && !m.IsCastle)
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
-                    sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
+                    sm.Score = (OrderingVictimMult * GetPieceValue(capturedPiece)) + 
                                (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece]);
                 }
                 else
@@ -52,7 +52,7 @@ namespace Lizard.Logic.Search.Ordering
 
                     if ((pos.State->CheckSquares[pt] & SquareBB[moveTo]) != 0)
                     {
-                        sm.Score += OrderingGivesCheckBonus;
+                        sm.Score += OrderingCheckBonus;
                     }
                 }
             }
@@ -84,7 +84,7 @@ namespace Lizard.Logic.Search.Ordering
                 else if (bb.GetPieceAtIndex(moveTo) != None && !m.IsCastle)
                 {
                     int capturedPiece = bb.GetPieceAtIndex(moveTo);
-                    sm.Score = (OrderingVictimValueMultiplier * GetPieceValue(capturedPiece)) + 
+                    sm.Score = (OrderingVictimMult * GetPieceValue(capturedPiece)) + 
                                (history.CaptureHistory[pc, bb.GetPieceAtIndex(moveFrom), moveTo, capturedPiece]);
                 }
                 else
@@ -100,7 +100,7 @@ namespace Lizard.Logic.Search.Ordering
 
                     if ((pos.State->CheckSquares[pt] & SquareBB[moveTo]) != 0)
                     {
-                        sm.Score += OrderingGivesCheckBonus;
+                        sm.Score += OrderingCheckBonus;
                     }
                 }
             }

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -28,199 +28,7 @@
         public static int Hash = 32;
 
 
-
         public static bool UCI_Chess960 = false;
-
-
-#if DATAGEN
-        public const bool ShallowPruning = true;
-#else
-        public const bool ShallowPruning = true;
-#endif
-
-        /// <summary>
-        /// Whether or not to extend searches if there is only one good move in a position.
-        /// <para></para>
-        /// This does reduce search speed (in terms of nodes/second), but the accuracy of the additional nodes 
-        /// that are searched make this well worth the speed hit.
-        /// </summary>
-        public const bool UseSingularExtensions = true;
-
-        /// <summary>
-        /// The depth must be greater than or equal to this for singular extensions to be considered.
-        /// </summary>
-        public static int SingularExtensionsMinDepth = 5;
-
-        /// <summary>
-        /// This number is multiplied by the depth to determine the singular beta value.
-        /// </summary>
-        public static int SingularExtensionsNumerator = 11;
-
-        /// <summary>
-        /// If the score from a singular search is below the singular beta value by this amount,
-        /// the depth will be extended by 2 instead of by 1.
-        /// </summary>
-        public static int SingularExtensionsBeta = 24;
-
-        /// <summary>
-        /// This amount will be added to the current depth when determining the depth for a singular extension search.
-        /// </summary>
-        public static int SingularExtensionsDepthAugment = -1;
-
-
-
-        /// <summary>
-        /// Whether or not to prune sequences of moves that don't improve the position evaluation enough 
-        /// even when if we give our opponent a free move.
-        /// </summary>
-        public const bool UseNMP = true;
-
-        /// <summary>
-        /// Nodes need to be at this depth of higher to be considered for pruning.
-        /// This also influences the reduced depth that the following nodes are searched
-        /// at, which is calculated by adding this flat amount to a node's depth divided by this amount.
-        /// i.e. R = <see cref="NMPMinDepth"/> + (depth / <see cref="NMPMinDepth"/>)
-        /// </summary>
-        public static int NMPMinDepth = 6;
-
-        /// <summary>
-        /// The base reduction is always set to this amount.
-        /// </summary>
-        public static int NMPReductionBase = 4;
-
-        /// <summary>
-        /// The reduction is increased by the current depth divided by this amount.
-        /// </summary>
-        public static int NMPReductionDivisor = 4;
-
-        public static int NMPEvalDivisor = 181;
-        public static int NMPEvalMin = 2;
-
-
-
-        /// <summary>
-        /// Whether or not to ignore moves that don't improve the position evaluation enough.
-        /// <br></br>
-        /// This is very aggressive in reducing the node count of searches, and generally looks at 2-4x fewer nodes than without RFP.
-        /// <para></para>
-        /// However, this can cause it to miss some moves (particularly "waiting" moves) until the depth is high enough.
-        /// <br></br>For example: 
-        /// <see href="https://lichess.org/analysis/fromPosition/n1N3br/2p1Bpkr/1pP2R1b/pP3Pp1/P5P1/1P1p4/p2P4/K7_w_-_-_0_1">this position</see> 
-        /// is a mate in 2, but RFP will miss it until depth 8 (regardless of ReverseFutilityPruningMaxDepth).
-        /// <br></br>
-        /// This is counteracted by the fact that RFP searches are still significantly faster than otherwise, 
-        /// so speed-wise this isn't a huge issue.
-        /// </summary>
-        public const bool UseRFP = true;
-
-        /// <summary>
-        /// The depth must be less than or equal to this for reverse futility pruning to be considered.
-        /// </summary>
-        public static int RFPMaxDepth = 6;
-
-        /// <summary>
-        /// This amount is added to reverse futility pruning's margin per depth.
-        /// </summary>
-        public static int RFPMargin = 47;
-
-
-
-        /// <summary>
-        /// Whether or not to exclude nodes that give our opponent a seemingly good capture.
-        /// <br></br>
-        /// ProbCut will test all available captures with a reduced depth and a modified beta,
-        /// and if a cutoff occurs we can assume that it would cause a cutoff at the full depth and normal beta value.
-        /// </summary>
-        public const bool UseProbCut = true;
-
-        /// <summary>
-        /// This margin is added to the current beta to determine the modified window if the side to move is NOT improving.
-        /// </summary>
-        public static int ProbCutBeta = 256;
-
-        /// <summary>
-        /// This margin is added to the current beta to determine the modified window if the side to move is improving.
-        /// </summary>
-        public static int ProbCutBetaImproving = 101;
-
-        /// <summary>
-        /// The depth must be greater than or equal to this for ProbCut to be considered.
-        /// </summary>
-        public static int ProbCutMinDepth = 2;
-
-
-
-        /// <summary>
-        /// If an LMR search returns a score that is above the current best score by this amount, 
-        /// the following verification search will be extended by 1.
-        /// </summary>
-        public static int LMRExtensionThreshold = 128;
-
-        /// <summary>
-        /// In Negamax, non-evasion moves that lose (this amount * depth) will be skipped.
-        /// <para></para>
-        /// This generally prunes moves that hang a piece.
-        /// </summary>
-        public static int LMRExchangeBase = 216;
-
-
-
-        /// <summary>
-        /// For LMR, the reduction of a move is modified by it's history divided by (1024 * this value).
-        /// </summary>
-        public static int LMRHistDivisor = 12288;
-
-
-
-        /// <summary>
-        /// The margin to add to the current best score in QSearch.
-        /// <para></para>
-        /// This is used to determine the minimum score a move must have to NOT be considered futile,
-        /// as low scoring moves are generally a waste of time to search.
-        /// </summary>
-        public static int FutilityExchangeBase = 183;
-
-
-
-        /// <summary>
-        /// Cut nodes without transposition table entries will have a reduction applied to them if the search depth is at or above this.
-        /// </summary>
-        public static int ExtraCutNodeReductionMinDepth = 4;
-
-
-        public static int SkipQuietsMaxDepth = 9;
-        public static int QSSeeThreshold = 81;
-
-
-        /// <summary>
-        /// If the evaluation at the next depth is within this margin from the previous evaluation,
-        /// we use the next depth's evaluation as the starting point for our Alpha/Beta values.
-        /// <para></para>
-        /// Smaller margins will eliminate more nodes from the search (saves time), but if the margin is too small
-        /// we will be forced to redo the search which can waste more time than it saves at high depths.
-        /// </summary>
-        public static int AspirationWindowMargin = 12;
-
-
-
-        /// <summary>
-        /// The best move will get a slightly larger bonus if it's score is this much above beta.
-        /// </summary>
-        public static int HistoryCaptureBonusMargin = 167;
-
-
-
-        /// <summary>
-        /// Quiet moves that give check will be given this additional bonus.
-        /// </summary>
-        public static int OrderingGivesCheckBonus = 9546;
-
-        /// <summary>
-        /// The multiplier for the value of a piece being captured to add to a capturing move's score.
-        /// <para></para>
-        /// This establishes a good baseline for a move's value, and is then modified by history.
-        /// </summary>
-        public static int OrderingVictimValueMultiplier = 14;
 
 
         public const int CorrectionScale = 1024;
@@ -228,39 +36,55 @@
         public const short CorrectionMax = CorrectionGrain * 64;
 
 
-        /// <summary>
-        /// The value multiplied by the depth
-        /// </summary>
+        public const bool ShallowPruning = true;
+        public const bool UseSingularExtensions = true;
+        public const bool UseNMP = true;
+        public const bool UseRFP = true; 
+        public const bool UseProbCut = true;
+
+
+        public static int SEMinDepth = 5;
+        public static int SENumerator = 11;
+        public static int SEBeta = 24;
+        public static int SEDepthAdj = -1;
+
+        public static int NMPMinDepth = 6;
+        public static int NMPBaseRed = 4;
+        public static int NMPDepthDiv = 4;
+        public static int NMPEvalDiv = 181;
+        public static int NMPEvalMin = 2;
+
+        public static int RFPMaxDepth = 6;
+        public static int RFPMargin = 47;
+
+        public static int ProbcutBeta = 256;
+        public static int ProbcutBetaImp = 101;
+        public static int ProbcutMinDepth = 2;
+
+        public static int ShallowSEEMargin = 216;
+        public static int ShallowMaxDepth = 9;
+
+        public static int LMRQuietDiv = 12288;
+        public static int LMRCaptureDiv = 10288;
+        public static int LMRExtMargin = 128;
+
+        public static int QSFutileMargin = 183;
+        public static int QSSeeMargin = 81;
+
+        public static int OrderingCheckBonus = 9546;
+        public static int OrderingVictimMult = 14;
+
+        public static int IIRMinDepth = 4;
+        public static int AspWindow = 12;
+        public static int CaptureBonusMargin = 167;
+
         public static int StatBonusMult = 184;
-
-        /// <summary>
-        /// The value to subtract from (StatBonusMult * depth)
-        /// </summary>
         public static int StatBonusSub = 80;
-
-        /// <summary>
-        /// The maximum value that a bonus can be.
-        /// </summary>
         public static int StatBonusMax = 1667;
 
-
-
-        /// <summary>
-        /// The value to multiply by the depth
-        /// </summary>
         public static int StatMalusMult = 611;
-
-        /// <summary>
-        /// The value to subtract from (StatMalusMult * depth)
-        /// </summary>
         public static int StatMalusSub = 111;
-
-        /// <summary>
-        /// The maximum value that a malus can be.
-        /// </summary>
         public static int StatMalusMax = 1663;
-
-
 
         public static int SEEValue_Pawn = 105;
         public static int SEEValue_Knight = 900;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -536,12 +536,22 @@ namespace Lizard.Logic.Search
                     //  Extend killer moves
                     R -= (m == ss->KillerMove).AsInt();
 
-                    var histScore = 2 * history.MainHistory[us, m] + 
-                                    2 * (*(ss - 1)->ContinuationHistory)[histIdx] + 
-                                        (*(ss - 2)->ContinuationHistory)[histIdx] + 
+
+                    var histScore = 2 * (*(ss - 1)->ContinuationHistory)[histIdx] +
+                                        (*(ss - 2)->ContinuationHistory)[histIdx] +
                                         (*(ss - 4)->ContinuationHistory)[histIdx];
 
-                    R -= (histScore / LMRHistDivisor);
+                    if (isCapture)
+                    {
+                        histScore += 2 * history.CaptureHistory[us, ourPiece, moveTo, theirPiece];
+                        R -= (histScore / (LMRHistDivisor - 2000));
+                    }
+                    else
+                    {
+                        histScore += 2 * history.MainHistory[us, m];
+                        R -= (histScore / LMRHistDivisor);
+                    }
+
 
                     //  Clamp the reduction so that the new depth is somewhere in [1, depth + extend]
                     //  If we don't reduce at all, then we will just be searching at (depth + extend - 1) as normal.

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -402,7 +402,7 @@ namespace Lizard.Logic.Threads
 
                     if (usedDepth >= 5)
                     {
-                        window = AspirationWindowMargin;
+                        window = AspWindow;
                         alpha = Math.Max(AlphaStart, score - window);
                         beta = Math.Min(BetaStart, score + window);
                     }

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -580,41 +580,40 @@ namespace Lizard.Logic.UCI
             Options[nameof(MultiPV)].SetMinMax(1, 256);
             Options[nameof(Hash)].SetMinMax(1, 1048576);
 
-            Options[nameof(SingularExtensionsMinDepth)].AutoMinMax();
-            Options[nameof(SingularExtensionsNumerator)].AutoMinMax();
-            Options[nameof(SingularExtensionsBeta)].AutoMinMax();
-            Options[nameof(SingularExtensionsDepthAugment)].SetMinMax(-3, 2);
+            Options[nameof(SEMinDepth)].AutoMinMax();
+            Options[nameof(SENumerator)].AutoMinMax();
+            Options[nameof(SEBeta)].AutoMinMax();
+            Options[nameof(SEDepthAdj)].SetMinMax(-3, 2);
 
             Options[nameof(NMPMinDepth)].AutoMinMax();
-            Options[nameof(NMPReductionBase)].AutoMinMax();
-            Options[nameof(NMPReductionDivisor)].AutoMinMax();
-            Options[nameof(NMPEvalDivisor)].AutoMinMax();
+            Options[nameof(NMPBaseRed)].AutoMinMax();
+            Options[nameof(NMPDepthDiv)].AutoMinMax();
+            Options[nameof(NMPEvalDiv)].AutoMinMax();
             Options[nameof(NMPEvalMin)].SetMinMax(0, 6);
 
             Options[nameof(RFPMaxDepth)].AutoMinMax();
             Options[nameof(RFPMargin)].AutoMinMax();
 
-            Options[nameof(ProbCutMinDepth)].SetMinMax(1, 5);
-            Options[nameof(ProbCutBeta)].AutoMinMax();
-            Options[nameof(ProbCutBetaImproving)].AutoMinMax();
+            Options[nameof(ProbcutBeta)].AutoMinMax();
+            Options[nameof(ProbcutBetaImp)].AutoMinMax();
+            Options[nameof(ProbcutMinDepth)].SetMinMax(1, 5);
 
-            Options[nameof(LMRExtensionThreshold)].AutoMinMax();
-            Options[nameof(LMRExchangeBase)].AutoMinMax();
+            Options[nameof(ShallowSEEMargin)].AutoMinMax();
+            Options[nameof(ShallowMaxDepth)].AutoMinMax();
 
-            Options[nameof(LMRHistDivisor)].AutoMinMax();
+            Options[nameof(LMRQuietDiv)].AutoMinMax();
+            Options[nameof(LMRCaptureDiv)].AutoMinMax();
+            Options[nameof(LMRExtMargin)].AutoMinMax();
 
-            Options[nameof(FutilityExchangeBase)].AutoMinMax();
+            Options[nameof(QSFutileMargin)].AutoMinMax();
+            Options[nameof(QSSeeMargin)].AutoMinMax();
 
-            Options[nameof(ExtraCutNodeReductionMinDepth)].SetMinMax(2, 6);
-            Options[nameof(SkipQuietsMaxDepth)].AutoMinMax();
-            Options[nameof(QSSeeThreshold)].AutoMinMax();
+            Options[nameof(OrderingCheckBonus)].AutoMinMax();
+            Options[nameof(OrderingVictimMult)].AutoMinMax();
 
-            Options[nameof(AspirationWindowMargin)].AutoMinMax();
-
-            Options[nameof(HistoryCaptureBonusMargin)].AutoMinMax();
-
-            Options[nameof(OrderingGivesCheckBonus)].AutoMinMax();
-            Options[nameof(OrderingVictimValueMultiplier)].AutoMinMax();
+            Options[nameof(IIRMinDepth)].SetMinMax(2, 6);
+            Options[nameof(AspWindow)].AutoMinMax();
+            Options[nameof(CaptureBonusMargin)].AutoMinMax();
 
             Options[nameof(StatBonusMult)].AutoMinMax();
             Options[nameof(StatBonusSub)].AutoMinMax();


### PR DESCRIPTION
The capture divisor was arbitrarily chosen to be 2000 less than the normal divisor, so it's currently about 5/6th of the value.
The names of most UCI options were also shortened and their unhelpful comments were removed because they were getting a bit out of hand.
```
Elo   | 2.51 +- 1.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 37018 W: 9512 L: 9245 D: 18261
Penta | [192, 4313, 9254, 4536, 214]
```
http://somelizard.pythonanywhere.com/test/1548/