### PR TITLE
Allow triple extensions

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -45,7 +45,9 @@
 
         public static int SEMinDepth = 5;
         public static int SENumerator = 11;
-        public static int SEBeta = 24;
+        public static int SEDoubleMargin = 24;
+        public static int SETripleMargin = 96;
+        public static int SETripleCapSub = 75;
         public static int SEDepthAdj = -1;
 
         public static int NMPMinDepth = 6;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -464,19 +464,11 @@ namespace Lizard.Logic.Search
 
                     if (score < singleBeta)
                     {
+                        bool doubleExt = !isPV && ss->DoubleExtensions <= 8 && (score < singleBeta - SEDoubleMargin);
+                        bool tripleExt = doubleExt && (score < singleBeta - SETripleMargin - (isCapture.AsInt() * SETripleCapSub));
+
                         //  This move seems to be good, so extend it.
-                        extend = 1;
-
-                        if (!isPV
-                            && score < singleBeta - SEBeta
-                            && ss->DoubleExtensions <= 8)
-                        {
-                            int tripleMargin = singleBeta - (SEBeta * 4) - (isCapture ? 75 : 0);
-
-                            //  If this isn't a PV, and this move is was a good deal better than any other one,
-                            //  then extend by 2 so long as we've double extended less than 8 times.
-                            extend = 2 + (score < tripleMargin).AsInt();
-                        }
+                        extend = 1 + doubleExt.AsInt() + tripleExt.AsInt();
                     }
                     else if (singleBeta >= beta)
                     {

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -471,9 +471,11 @@ namespace Lizard.Logic.Search
                             && score < singleBeta - SEBeta
                             && ss->DoubleExtensions <= 8)
                         {
+                            int tripleMargin = singleBeta - (SEBeta * 4) - (isCapture ? 75 : 0);
+
                             //  If this isn't a PV, and this move is was a good deal better than any other one,
                             //  then extend by 2 so long as we've double extended less than 8 times.
-                            extend = 2;
+                            extend = 2 + (score < tripleMargin).AsInt();
                         }
                     }
                     else if (singleBeta >= beta)

--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -582,7 +582,9 @@ namespace Lizard.Logic.UCI
 
             Options[nameof(SEMinDepth)].AutoMinMax();
             Options[nameof(SENumerator)].AutoMinMax();
-            Options[nameof(SEBeta)].AutoMinMax();
+            Options[nameof(SEDoubleMargin)].AutoMinMax();
+            Options[nameof(SETripleMargin)].AutoMinMax();
+            Options[nameof(SETripleCapSub)].AutoMinMax();
             Options[nameof(SEDepthAdj)].SetMinMax(-3, 2);
 
             Options[nameof(NMPMinDepth)].AutoMinMax();


### PR DESCRIPTION
The current margin is 4x the double margin, and is increased by a further ~3x for captures

```
Elo   | 2.82 +- 1.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 27466 W: 6769 L: 6546 D: 14151
Penta | [29, 2981, 7490, 3204, 29]
```
http://somelizard.pythonanywhere.com/test/1558/