### PR TITLE
Factor both sides for non-pawn correction

### DIFF
--- a/Logic/Search/History/CorrectionTables.cs
+++ b/Logic/Search/History/CorrectionTables.cs
@@ -4,10 +4,9 @@ namespace Lizard.Logic.Search.History
 
     public unsafe class PawnCorrectionTable : ICorrectionTable
     {
-        public override ref StatEntry this[Position pos, int pc] => ref _History[CorrectionIndex(pos, pc)];
-        public override ref StatEntry this[Position pos, int pc, int side] => throw new NotImplementedException();
+        public ref StatEntry this[Position pos, int pc] => ref _History[CorrectionIndex(pos, pc)];
 
-        public override int CorrectionIndex(Position pos, int pc, int side = 0)
+        public int CorrectionIndex(Position pos, int pc)
         {
             return (pc * TableSize) + (int)((pos.PawnHash) & ((ulong)TableSize - 1));
         }
@@ -18,10 +17,9 @@ namespace Lizard.Logic.Search.History
     /// https://zzzzz151.pythonanywhere.com/test/729/
     public unsafe class NonPawnCorrectionTable : ICorrectionTable
     {
-        public override ref StatEntry this[Position pos, int pc] => throw new NotImplementedException();
-        public override ref StatEntry this[Position pos, int pc, int side] => ref _History[CorrectionIndex(pos, pc, side)];
+        public ref StatEntry this[Position pos, int pc, int side] => ref _History[CorrectionIndex(pos, pc, side)];
 
-        public override int CorrectionIndex(Position pos, int pc, int side)
+        public int CorrectionIndex(Position pos, int pc, int side)
         {
             return (pc * TableSize) + (int)((pos.NonPawnHash(side)) & ((ulong)TableSize - 1));
         }

--- a/Logic/Search/History/CorrectionTables.cs
+++ b/Logic/Search/History/CorrectionTables.cs
@@ -2,9 +2,12 @@
 namespace Lizard.Logic.Search.History
 {
 
-    public class PawnCorrectionTable : ICorrectionTable
+    public unsafe class PawnCorrectionTable : ICorrectionTable
     {
-        public override int CorrectionIndex(Position pos, int pc)
+        public override ref StatEntry this[Position pos, int pc] => ref _History[CorrectionIndex(pos, pc)];
+        public override ref StatEntry this[Position pos, int pc, int side] => throw new NotImplementedException();
+
+        public override int CorrectionIndex(Position pos, int pc, int side = 0)
         {
             return (pc * TableSize) + (int)((pos.PawnHash) & ((ulong)TableSize - 1));
         }
@@ -13,11 +16,14 @@ namespace Lizard.Logic.Search.History
 
     /// Idea from Starzix:
     /// https://zzzzz151.pythonanywhere.com/test/729/
-    public class NonPawnCorrectionTable : ICorrectionTable
+    public unsafe class NonPawnCorrectionTable : ICorrectionTable
     {
-        public override int CorrectionIndex(Position pos, int pc)
+        public override ref StatEntry this[Position pos, int pc] => throw new NotImplementedException();
+        public override ref StatEntry this[Position pos, int pc, int side] => ref _History[CorrectionIndex(pos, pc, side)];
+
+        public override int CorrectionIndex(Position pos, int pc, int side)
         {
-            return (pc * TableSize) + (int)((pos.NonPawnHash(pc)) & ((ulong)TableSize - 1));
+            return (pc * TableSize) + (int)((pos.NonPawnHash(side)) & ((ulong)TableSize - 1));
         }
     }
 }

--- a/Logic/Search/History/ICorrectionTable.cs
+++ b/Logic/Search/History/ICorrectionTable.cs
@@ -20,12 +20,7 @@ namespace Lizard.Logic.Search.History
             _History = (StatEntry*)AlignedAllocZeroed((nuint)(sizeof(StatEntry) * TableElements), AllocAlignment);
         }
 
-        public abstract ref StatEntry this[Position pos, int pc] { get; }
-        public abstract ref StatEntry this[Position pos, int pc, int side] { get; }
-
         public void Dispose() => NativeMemory.AlignedFree(_History);
         public void Clear() => NativeMemory.Clear(_History, (nuint)(sizeof(StatEntry) * TableElements));
-
-        public abstract int CorrectionIndex(Position pos, int pc, int side = 0);
     }
 }

--- a/Logic/Search/History/ICorrectionTable.cs
+++ b/Logic/Search/History/ICorrectionTable.cs
@@ -6,7 +6,7 @@ namespace Lizard.Logic.Search.History
 {
     public unsafe abstract class ICorrectionTable
     {
-        private readonly StatEntry* _History;
+        protected readonly StatEntry* _History;
 
         public readonly int TableSize;
         public readonly int TableCount;
@@ -20,11 +20,12 @@ namespace Lizard.Logic.Search.History
             _History = (StatEntry*)AlignedAllocZeroed((nuint)(sizeof(StatEntry) * TableElements), AllocAlignment);
         }
 
-        public ref StatEntry this[Position pos, int pc] => ref _History[CorrectionIndex(pos, pc)];
+        public abstract ref StatEntry this[Position pos, int pc] { get; }
+        public abstract ref StatEntry this[Position pos, int pc, int side] { get; }
 
         public void Dispose() => NativeMemory.AlignedFree(_History);
         public void Clear() => NativeMemory.Clear(_History, (nuint)(sizeof(StatEntry) * TableElements));
 
-        public abstract int CorrectionIndex(Position pos, int pc);
+        public abstract int CorrectionIndex(Position pos, int pc, int side = 0);
     }
 }

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1058,9 +1058,10 @@ namespace Lizard.Logic.Search
             Position pos = thread.RootPosition;
 
             var pch = thread.History.PawnCorrection[pos, us] / CorrectionGrain;
-            var mch = thread.History.NonPawnCorrection[pos, us] / CorrectionGrain;
+            var mchW = thread.History.NonPawnCorrection[pos, us, White] / CorrectionGrain;
+            var mchB = thread.History.NonPawnCorrection[pos, us, Black] / CorrectionGrain;
 
-            var corr = (pch + mch) / 2;
+            var corr = (pch * 200 + mchW * 100 + mchB * 100) / 400;
 
             return (short)(rawEval + corr);
         }
@@ -1074,9 +1075,13 @@ namespace Lizard.Logic.Search
             var pawnBonus = (pawnCh * (CorrectionScale - scaledWeight) + (diff * CorrectionGrain * scaledWeight)) / CorrectionScale;
             pawnCh = (StatEntry)Math.Clamp(pawnBonus, -CorrectionMax, CorrectionMax);
 
-            ref var nonPawnCh = ref pos.Owner.History.NonPawnCorrection[pos, pos.ToMove];
-            var nonPawnBonus = (nonPawnCh * (CorrectionScale - scaledWeight) + (diff * CorrectionGrain * scaledWeight)) / CorrectionScale;
-            nonPawnCh = (StatEntry)Math.Clamp(nonPawnBonus, -CorrectionMax, CorrectionMax);
+            ref var nonPawnChW = ref pos.Owner.History.NonPawnCorrection[pos, pos.ToMove, White];
+            var nonPawnBonusW = (nonPawnChW * (CorrectionScale - scaledWeight) + (diff * CorrectionGrain * scaledWeight)) / CorrectionScale;
+            nonPawnChW = (StatEntry)Math.Clamp(nonPawnBonusW, -CorrectionMax, CorrectionMax);
+
+            ref var nonPawnChB = ref pos.Owner.History.NonPawnCorrection[pos, pos.ToMove, Black];
+            var nonPawnBonusB = (nonPawnChB * (CorrectionScale - scaledWeight) + (diff * CorrectionGrain * scaledWeight)) / CorrectionScale;
+            nonPawnChB = (StatEntry)Math.Clamp(nonPawnBonusB, -CorrectionMax, CorrectionMax);
         }
 
 

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1061,7 +1061,7 @@ namespace Lizard.Logic.Search
             var mchW = thread.History.NonPawnCorrection[pos, us, White] / CorrectionGrain;
             var mchB = thread.History.NonPawnCorrection[pos, us, Black] / CorrectionGrain;
 
-            var corr = (pch * 200 + mchW * 100 + mchB * 100) / 400;
+            var corr = (pch * 200 + mchW * 100 + mchB * 100) / 300;
 
             return (short)(rawEval + corr);
         }


### PR DESCRIPTION
```
Elo   | 2.57 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 36478 W: 8952 L: 8682 D: 18844
Penta | [195, 4296, 9040, 4460, 248]
```
http://somelizard.pythonanywhere.com/test/1615/