### PR TITLE
Don't factor low depth cutoffs in history

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1019,11 +1019,13 @@ namespace Lizard.Logic.Search
             }
             else
             {
-                if (ss->KillerMove != bestMove && !bestMove.IsEnPassant)
+                if (!bestMove.IsEnPassant)
                 {
                     ss->KillerMove = bestMove;
                 }
 
+                //  Idea from Ethereal:
+                //  Don't reward/punish moves resulting from a trivial, low-depth cutoff
                 if (quietCount == 0 && depth <= 3)
                 {
                     return;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1024,6 +1024,11 @@ namespace Lizard.Logic.Search
                     ss->KillerMove = bestMove;
                 }
 
+                if (quietCount == 0 && depth <= 3)
+                {
+                    return;
+                }
+
                 history.MainHistory[thisColor, bestMove] <<= bonus;
                 UpdateContinuations(ss, thisColor, thisPiece, moveTo, bonus);
 


### PR DESCRIPTION
```
Elo   | 7.01 +- 3.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10410 W: 2638 L: 2428 D: 5344
Penta | [51, 1201, 2502, 1389, 62]
```
http://somelizard.pythonanywhere.com/test/1666/