### PR TITLE
Added Probcut-like evasion pruning

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -347,6 +347,22 @@ namespace Lizard.Logic.Search
 
             MovesLoop:
 
+            //  "Small probcut idea" from SF: 
+            //  https://github.com/official-stockfish/Stockfish/blob/7ccde25baf03e77926644b282fed68ba0b5ddf95/src/search.cpp#L878
+            probBeta = beta + 435;
+            if (ss->InCheck
+                && !isPV
+                && (ttMove != Move.Null && bb.GetPieceAtIndex(ttMove.To) != None)
+                && ((tte->Bound & BoundLower) != 0)
+                && tte->Depth >= depth - 4
+                && ttScore >= probBeta
+                && Math.Abs(ttScore) < ScoreTTWin
+                && Math.Abs(beta) < ScoreTTWin)
+            {
+                return probBeta;
+            }
+
+
             int legalMoves = 0;     //  Number of legal moves that have been encountered so far in the loop.
             int playedMoves = 0;    //  Number of moves that have been MakeMove'd so far.
 


### PR DESCRIPTION
Idea first tried in Stockfish by Vizvezdenec here: https://github.com/official-stockfish/Stockfish/commit/7c30091a92abddb8265e53768b32751c49642040

```
Elo   | 4.17 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18980 W: 4652 L: 4424 D: 9904
Penta | [71, 2248, 4675, 2374, 122]
```
http://somelizard.pythonanywhere.com/test/1683/