### PR TITLE
Adjusted Probcut evasion depth

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -354,7 +354,7 @@ namespace Lizard.Logic.Search
                 && !isPV
                 && (ttMove != Move.Null && bb.GetPieceAtIndex(ttMove.To) != None)
                 && ((tte->Bound & BoundLower) != 0)
-                && tte->Depth >= depth - 4
+                && tte->Depth >= depth - 6
                 && ttScore >= probBeta
                 && Math.Abs(ttScore) < ScoreTTWin
                 && Math.Abs(beta) < ScoreTTWin)


### PR DESCRIPTION
```
Elo   | 3.94 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19748 W: 4866 L: 4642 D: 10240
Penta | [85, 2266, 4950, 2486, 87]
```
http://somelizard.pythonanywhere.com/test/1695/