### PR TITLE
Prevent explosions during LMR research

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -539,7 +539,7 @@ namespace Lizard.Logic.Search
 
                         if (newDepth - 1 > reducedDepth)
                         {
-                            score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth, !cutNode);
+                            score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, newDepth - 1, !cutNode);
                         }
 
                         int bonus = 0;


### PR DESCRIPTION
This hasn't been a problem before but occurred fairly frequently when testing more complicated NNUE architectures. 
```
Elo   | 0.35 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 23066 W: 5560 L: 5537 D: 11969
Penta | [97, 2729, 5847, 2774, 86]
```
http://somelizard.pythonanywhere.com/test/1783/