### PR TITLE
Removed QSearch depth logic

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -10,22 +10,11 @@ namespace Lizard.Logic.Search
 {
     public static unsafe class Searches
     {
-        /// <summary>
-        /// If the depth is at or above this, then QSearch will allow non-capture, non-evasion moves that GIVE check.
-        /// </summary>
-        public const int DepthQChecks = 0;
-
-        /// <summary>
-        /// If the depth is at or below this, then QSearch will ignore non-capture, non-evasion moves that GIVE check.
-        /// </summary>
-        public const int DepthQNoChecks = -1;
-
 
         /// <summary>
         /// Finds the best move according to the Evaluation function, looking at least <paramref name="depth"/> moves in the future.
         /// </summary>
         /// <typeparam name="NodeType">One of <see cref="RootNode"/>, <see cref="PVNode"/>, or <see cref="NonPVNode"/></typeparam>
-        /// <param name="info">Reference to the current search's SearchInformation</param>
         /// <param name="alpha">
         ///     The evaluation of the lower bound move. 
         ///     This will eventually be set equal to the evaluation of the best move we can make.

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -9,7 +9,7 @@ namespace Lizard.Logic.Util
 {
     public static class Utilities
     {
-        public const string EngineBuildVersion = "11.0.3";
+        public const string EngineBuildVersion = "11.0.4";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;


### PR DESCRIPTION
The inclusion of non-capture moves that give check during initial QSearch calls likely hurt probcut and LMR reductions by a significant amount.
A surprise, to be sure, but a welcome one.

```
Elo   | 21.43 +- 6.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 3068 W: 840 L: 651 D: 1577
Penta | [11, 271, 789, 444, 19]
```
http://somelizard.pythonanywhere.com/test/1820/