### PR TITLE
Standardize values in SEE

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1161,7 +1161,7 @@ namespace Lizard.Logic.Search
                 if ((temp = stmAttackers & bb.Pieces[Pawn]) != 0)
                 {
                     occ ^= SquareBB[lsb(temp)];
-                    if ((swap = GetPieceValue(Pawn) - swap) < res)
+                    if ((swap = SEEValue_Pawn - swap) < res)
                         break;
 
                     attackers |= GetBishopMoves(occ, to) & (bb.Pieces[Bishop] | bb.Pieces[Queen]);
@@ -1169,13 +1169,13 @@ namespace Lizard.Logic.Search
                 else if ((temp = stmAttackers & bb.Pieces[Knight]) != 0)
                 {
                     occ ^= SquareBB[lsb(temp)];
-                    if ((swap = GetPieceValue(Knight) - swap) < res)
+                    if ((swap = SEEValue_Knight - swap) < res)
                         break;
                 }
                 else if ((temp = stmAttackers & bb.Pieces[Bishop]) != 0)
                 {
                     occ ^= SquareBB[lsb(temp)];
-                    if ((swap = GetPieceValue(Bishop) - swap) < res)
+                    if ((swap = SEEValue_Bishop - swap) < res)
                         break;
 
                     attackers |= GetBishopMoves(occ, to) & (bb.Pieces[Bishop] | bb.Pieces[Queen]);
@@ -1183,7 +1183,7 @@ namespace Lizard.Logic.Search
                 else if ((temp = stmAttackers & bb.Pieces[Rook]) != 0)
                 {
                     occ ^= SquareBB[lsb(temp)];
-                    if ((swap = GetPieceValue(Rook) - swap) < res)
+                    if ((swap = SEEValue_Rook - swap) < res)
                         break;
 
                     attackers |= GetRookMoves(occ, to) & (bb.Pieces[Rook] | bb.Pieces[Queen]);
@@ -1191,7 +1191,7 @@ namespace Lizard.Logic.Search
                 else if ((temp = stmAttackers & bb.Pieces[Queen]) != 0)
                 {
                     occ ^= SquareBB[lsb(temp)];
-                    if ((swap = GetPieceValue(Queen) - swap) < res)
+                    if ((swap = SEEValue_Queen - swap) < res)
                         break;
 
                     attackers |= (GetBishopMoves(occ, to) & (bb.Pieces[Bishop] | bb.Pieces[Queen])) | (GetRookMoves(occ, to) & (bb.Pieces[Rook] | bb.Pieces[Queen]));


### PR DESCRIPTION
```
Elo   | -0.24 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.74 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 32308 W: 7584 L: 7606 D: 17118
Penta | [114, 3901, 8151, 3869, 119]
```
http://somelizard.pythonanywhere.com/test/1822/