### PR TITLE
8 input buckets with a factorizer

### DIFF
--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -11,7 +11,7 @@ namespace Lizard.Logic.NN
 {
     public static unsafe partial class Bucketed768
     {
-        public const int InputBuckets = 4;
+        public const int InputBuckets = 8;
         public const int InputSize = 768;
         public const int HiddenSize = 2048;
         public const int OutputBuckets = 8;
@@ -48,14 +48,14 @@ namespace Lizard.Logic.NN
 
         private static ReadOnlySpan<int> KingBuckets =>
         [
-            0, 0, 1, 1, 5, 5, 4, 4,
-            0, 0, 1, 1, 5, 5, 4, 4,
-            2, 2, 2, 2, 6, 6, 6, 6,
-            2, 2, 2, 2, 6, 6, 6, 6,
-            3, 3, 3, 3, 7, 7, 7, 7,
-            3, 3, 3, 3, 7, 7, 7, 7,
-            3, 3, 3, 3, 7, 7, 7, 7,
-            3, 3, 3, 3, 7, 7, 7, 7,
+            0, 1, 2, 3, 11, 10,  9,  8,
+            4, 4, 5, 5, 13, 13, 12, 12,
+            6, 6, 6, 6, 14, 14, 14, 14,
+            6, 6, 6, 6, 14, 14, 14, 14,
+            7, 7, 7, 7, 15, 15, 15, 15,
+            7, 7, 7, 7, 15, 15, 15, 15,
+            7, 7, 7, 7, 15, 15, 15, 15,
+            7, 7, 7, 7, 15, 15, 15, 15,
         ];
 
         public static int BucketForPerspective(int ksq, int perspective) => (KingBuckets[perspective == Black ? (ksq ^ 56) : ksq]);

--- a/network.txt
+++ b/network.txt
@@ -1,1 +1,1 @@
-net-011-4l8-pair
+net-012-8l8-fact


### PR DESCRIPTION
Significantly helps DFRC
```
Elo   | 82.28 +- 15.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 1114 W: 429 L: 170 D: 515
Penta | [6, 84, 207, 165, 95]
```
http://somelizard.pythonanywhere.com/test/1866/


Also had a decent gain in fixed-nodes in standard:
```
Elo   | 14.66 +- 4.73 (95%)
Conf  | N=25000 Threads=1 Hash=16MB
Games | N: 10006 W: 3334 L: 2912 D: 3760
Penta | [261, 1070, 2014, 1302, 356]
```
http://somelizard.pythonanywhere.com/test/1860/