### PR TITLE
Added 50mr scaling

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -1024,6 +1024,8 @@ namespace Lizard.Logic.Search
         {
             Position pos = thread.RootPosition;
 
+            rawEval = (short)(rawEval * (200 - pos.State->HalfmoveClock) / 200);
+
             var pch = thread.History.PawnCorrection[pos, us] / CorrectionGrain;
             var mchW = thread.History.NonPawnCorrection[pos, us, White] / CorrectionGrain;
             var mchB = thread.History.NonPawnCorrection[pos, us, Black] / CorrectionGrain;

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -9,7 +9,7 @@ namespace Lizard.Logic.Util
 {
     public static class Utilities
     {
-        public const string EngineBuildVersion = "11.0.12";
+        public const string EngineBuildVersion = "11.0.13";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;


### PR DESCRIPTION
```
Elo   | 1.74 +- 1.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 63868 W: 15234 L: 14915 D: 33719
Penta | [197, 7531, 16164, 7840, 202]
```
http://somelizard.pythonanywhere.com/test/1942/