### PR TITLE
Added low-ply history

### DIFF
--- a/Logic/Search/History/PlyHistoryTable.cs
+++ b/Logic/Search/History/PlyHistoryTable.cs
@@ -1,0 +1,54 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Lizard.Logic.Search.History
+{
+    public unsafe readonly struct PlyHistoryTable
+    {
+        private readonly PlyHistEntry* _History;
+        private const int Clamp = 8192;
+
+        public const int MaxPlies = 4;
+        private const int HistoryElements = MaxPlies * SquareNB * SquareNB;
+
+        public PlyHistoryTable()
+        {
+            _History = AlignedAllocZeroed<PlyHistEntry>(HistoryElements);
+        }
+
+        public PlyHistEntry this[int idx]
+        {
+            get => _History[idx];
+            set => _History[idx] = value;
+        }
+
+        public PlyHistEntry this[int pc, Move m]
+        {
+            get => _History[HistoryIndex(pc, m)];
+            set => _History[HistoryIndex(pc, m)] = value;
+        }
+
+        public void Dispose()
+        {
+            NativeMemory.AlignedFree(_History);
+        }
+
+        public void Clear()
+        {
+            NativeMemory.Clear(_History, (nuint)sizeof(PlyHistEntry) * HistoryElements);
+        }
+
+        public static int HistoryIndex(int ply, Move m)
+        {
+            return (ply * 4096) + m.MoveMask;
+        }
+
+        public readonly struct PlyHistEntry(short v)
+        {
+            public readonly short Value = v;
+
+            public static implicit operator short(PlyHistEntry entry) => entry.Value;
+            public static implicit operator PlyHistEntry(short s) => new(s);
+            public static PlyHistEntry operator <<(PlyHistEntry entry, int bonus) => (PlyHistEntry)(entry + (bonus - (entry * Math.Abs(bonus) / Clamp)));
+        }
+    }
+}

--- a/Logic/Search/Ordering/HistoryTable.cs
+++ b/Logic/Search/Ordering/HistoryTable.cs
@@ -19,6 +19,8 @@ namespace Lizard.Logic.Search.History
         /// </summary>
         public readonly CaptureHistoryTable CaptureHistory;
 
+        public readonly PlyHistoryTable PlyHistory;
+
         /// <summary>
         /// Stores history for how far off the static evaluation was from the result of a search for either color,
         /// indexed by a position's pawn PSQT hash.
@@ -46,6 +48,7 @@ namespace Lizard.Logic.Search.History
         {
             MainHistory = new MainHistoryTable();
             CaptureHistory = new CaptureHistoryTable();
+            PlyHistory = new PlyHistoryTable();
             PawnCorrection = new PawnCorrectionTable();
             NonPawnCorrection = new NonPawnCorrectionTable();
 
@@ -60,7 +63,7 @@ namespace Lizard.Logic.Search.History
 
             cont1[0] = new ContinuationHistory();
             cont1[1] = new ContinuationHistory();
-            
+
             Continuations[0] = cont0;
             Continuations[1] = cont1;
         }
@@ -69,6 +72,7 @@ namespace Lizard.Logic.Search.History
         {
             MainHistory.Dispose();
             CaptureHistory.Dispose();
+            PlyHistory.Dispose();
             PawnCorrection.Dispose();
             NonPawnCorrection.Dispose();
 
@@ -85,6 +89,7 @@ namespace Lizard.Logic.Search.History
         {
             MainHistory.Clear();
             CaptureHistory.Clear();
+            PlyHistory.Clear();
             PawnCorrection.Clear();
             NonPawnCorrection.Clear();
 

--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -52,7 +52,7 @@ namespace Lizard.Logic.Search.Ordering
 
                     if (ss->Ply < PlyHistoryTable.MaxPlies)
                     {
-                        sm.Score += ((PlyHistoryTable.MaxPlies + 1) * history.PlyHistory[ss->Ply, m]) / (ss->Ply + 1);
+                        sm.Score += ((2 * PlyHistoryTable.MaxPlies + 1) * history.PlyHistory[ss->Ply, m]) / (2 * ss->Ply + 1);
                     }
 
                     if ((pos.State->CheckSquares[pt] & SquareBB[moveTo]) != 0)

--- a/Logic/Search/Ordering/MoveOrdering.cs
+++ b/Logic/Search/Ordering/MoveOrdering.cs
@@ -50,6 +50,11 @@ namespace Lizard.Logic.Search.Ordering
                     sm.Score +=     (*(ss - 4)->ContinuationHistory)[contIdx];
                     sm.Score +=     (*(ss - 6)->ContinuationHistory)[contIdx];
 
+                    if (ss->Ply < PlyHistoryTable.MaxPlies)
+                    {
+                        sm.Score += ((PlyHistoryTable.MaxPlies + 1) * history.PlyHistory[ss->Ply, m]) / (ss->Ply + 1);
+                    }
+
                     if ((pos.State->CheckSquares[pt] & SquareBB[moveTo]) != 0)
                     {
                         sm.Score += OrderingCheckBonus;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -997,6 +997,9 @@ namespace Lizard.Logic.Search
                 }
 
                 history.MainHistory[thisColor, bestMove] <<= bonus;
+                if (ss->Ply < PlyHistoryTable.MaxPlies)
+                    history.PlyHistory[ss->Ply, bestMove] <<= bonus;
+
                 UpdateContinuations(ss, thisColor, thisPiece, moveTo, bonus);
 
                 for (int i = 0; i < quietCount; i++)
@@ -1005,6 +1008,9 @@ namespace Lizard.Logic.Search
                     thisPiece = bb.GetPieceAtIndex(m.From);
 
                     history.MainHistory[thisColor, m] <<= -malus;
+                    if (ss->Ply < PlyHistoryTable.MaxPlies)
+                        history.PlyHistory[ss->Ply, m] <<= -malus;
+
                     UpdateContinuations(ss, thisColor, thisPiece, m.To, -malus);
                 }
             }


### PR DESCRIPTION
```
Elo   | 2.71 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31358 W: 7512 L: 7267 D: 16579
Penta | [86, 3652, 7963, 3887, 91]
```
http://somelizard.pythonanywhere.com/test/1987/