### PR TITLE
Force GC before entering UCI

### DIFF
--- a/Logic/UCI/UCIClient.cs
+++ b/Logic/UCI/UCIClient.cs
@@ -10,28 +10,25 @@ namespace Lizard.Logic.UCI
 {
     public unsafe class UCIClient
     {
-
         private Position pos;
         private SearchInformation info;
         private ThreadSetup setup;
 
-        private static readonly string LogFileName = $".\\ucilog_{ProcessID}.txt";
-
         private static Dictionary<string, UCIOption> Options;
-
-        private static object LogFileLock = new object();
 
         public static bool Active = false;
 
-        public UCIClient()
+        public UCIClient(Position pos)
         {
             ProcessUCIOptions();
 
-            setup = new ThreadSetup();
-            pos = new Position(owner: GlobalSearchPool.MainThread);
+            this.pos = pos;
+
             info = new SearchInformation(pos);
             info.OnDepthFinish = OnDepthDone;
             info.OnSearchFinish = OnSearchDone;
+
+            setup = new ThreadSetup();
         }
 
         /// <summary>

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -68,6 +68,17 @@ namespace Lizard.Logic.Util
         }
 
 
+        public static void ForceGC()
+        {
+            //  This is only being used to keep memory usage as low as possible when running multiple instances concurrently,
+            //  and this won't be an issue if there are multiple threads.
+            if (SearchOptions.Threads > 3)
+                return;
+
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
+            GC.WaitForPendingFinalizers();
+        }
+
         public static string GetCompilerInfo()
         {
             StringBuilder sb = new StringBuilder();

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -9,7 +9,7 @@ namespace Lizard.Logic.Util
 {
     public static class Utilities
     {
-        public const string EngineBuildVersion = "11.1.0";
+        public const string EngineBuildVersion = "11.1.2";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;

--- a/Program.cs
+++ b/Program.cs
@@ -72,18 +72,14 @@ namespace Lizard
 
             //  Give the VS debugger a friendly name for the main program thread
             Thread.CurrentThread.Name = "MainThread";
-
-            //  The GC seems to drag its feet collecting some of the now unneeded memory (random strings and RunClassConstructor junk).
-            //  This doesn't HAVE to be done now, and generally it isn't productive to force GC collections,
-            //  but it will inevitably occur at some point later so we can take a bit of pressure off of it by doing this now.
-            GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
-            GC.WaitForPendingFinalizers();
         }
 
 
         private static void DoInputLoop()
         {
             Log($"Lizard version {EngineBuildVersion}\r\n");
+
+            ForceGC();
 
             ThreadSetup setup = new ThreadSetup();
             while (true)
@@ -97,7 +93,7 @@ namespace Lizard
 
                 if (input.EqualsIgnoreCase("uci"))
                 {
-                    new UCIClient().Run();
+                    new UCIClient(p).Run();
                 }
                 else if (input.EqualsIgnoreCase("ucinewgame"))
                 {


### PR DESCRIPTION
This should free the ~50mb used by the byte[] when decompressing a zstd file, among other smaller things. The garbage collector runs so infrequently that this memory would sometimes never be collected at all, which is a waste.