### PR TITLE
Different IIR conditions

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -77,7 +77,7 @@
         public static int OrderingCheckBonus = 9546;
         public static int OrderingVictimMult = 14;
 
-        public static int IIRMinDepth = 4;
+        public static int IIRMinDepth = 3;
         public static int AspWindow = 12;
 
         public static int StatBonusMult = 184;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -243,13 +243,17 @@ namespace Lizard.Logic.Search
             }
 
 
-            if (ttMove.Equals(Move.Null)
-                && (cutNode || isPV)
-                && depth >= IIRMinDepth)
+            if (ttMove.Equals(Move.Null))
             {
-                //  We expected this node to be a bad one, so give it an extra depth reduction
-                //  if the depth is at or above a threshold (currently 4).
-                depth--;
+                if (cutNode && depth >= IIRMinDepth + 2)
+                {
+                    depth--;
+                }
+
+                if (isPV && depth >= IIRMinDepth)
+                {
+                    depth--;
+                }
             }
 
 

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -10,7 +10,7 @@ namespace Lizard.Logic.Util
     public static class Utilities
     {
 
-        public const string EngineBuildVersion = "11.1.2";
+        public const string EngineBuildVersion = "11.1.3";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;


### PR DESCRIPTION
```
Elo   | 2.56 +- 1.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 34908 W: 8326 L: 8069 D: 18513
Penta | [117, 4099, 8771, 4344, 123]
```
http://somelizard.pythonanywhere.com/test/2006/