### PR TITLE
Disable CET

### DIFF
--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -102,6 +102,9 @@
     -->
     <ServerGarbageCollection>false</ServerGarbageCollection>
 
+
+    <!--https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support-->
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <!-- The "instruction-set" argument is required for AOT to generate code with intrinsics -->

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -103,7 +103,9 @@
     <ServerGarbageCollection>false</ServerGarbageCollection>
 
 
-    <!--https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support-->
+    <!-- CET is enabled for .NET 9 by default, which can cause a performance regression
+         (https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support)
+    -->
     <CETCompat>false</CETCompat>
   </PropertyGroup>
 


### PR DESCRIPTION
[CET](https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support) is enabled by default in .NET 9, and it's known to be the potential cause of performance issues.

It was indeed the case for Lynx, and after seeing [your dotnet9 branch test](https://somelizard.pythonanywhere.com/test/2027/), it might also happen in Lizard.

Feel free to give this a try when you get a chance.