### PR TITLE
Added NMP verification search

### DIFF
--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -216,10 +216,11 @@ namespace Lizard.Logic.Search
 
             if (UseNMP
                 && !isPV
+                && !doSkip
                 && depth >= NMPMinDepth
+                && ss->Ply >= thisThread.NMPPly
                 && eval >= beta
                 && eval >= ss->StaticEval
-                && !doSkip
                 && (ss - 1)->CurrentMove != Move.Null
                 && pos.HasNonPawnMaterial(pos.ToMove))
             {
@@ -230,15 +231,24 @@ namespace Lizard.Logic.Search
                 //  Skip our turn, and see if the our opponent is still behind even with a free move.
                 pos.MakeNullMove();
                 prefetch(TT.GetCluster(pos.State->Hash));
-
                 score = -Negamax<NonPVNode>(pos, ss + 1, -beta, -beta + 1, depth - reduction, !cutNode);
-
                 pos.UnmakeNullMove();
 
                 if (score >= beta)
                 {
-                    //  Null moves are not allowed to return mate or TT win scores, so ensure the score is below that.
-                    return score < ScoreTTWin ? score : beta;
+                    if (thisThread.NMPPly > 0 || depth <= 15)
+                    {
+                        return score > ScoreWin ? beta : score;
+                    }
+
+                    thisThread.NMPPly = (3 * (depth - reduction) / 4) + ss->Ply;
+                    int verification = Negamax<NonPVNode>(pos, ss, beta - 1, beta, depth - reduction, false);
+                    thisThread.NMPPly = 0;
+
+                    if (verification >= beta)
+                    {
+                        return score;
+                    }
                 }
             }
 

--- a/Logic/Threads/SearchThread.cs
+++ b/Logic/Threads/SearchThread.cs
@@ -61,6 +61,8 @@ namespace Lizard.Logic.Threads
         /// </summary>
         public int CompletedDepth;
 
+        public int NMPPly;
+
         /// <summary>
         /// When this number reaches <see cref="CheckupMax"/>, the main thread will check to see if the search 
         /// needs to stop because of max time or max node constraints.

--- a/Logic/Threads/SearchThreadPool.cs
+++ b/Logic/Threads/SearchThreadPool.cs
@@ -122,6 +122,7 @@
                 td.CompletedDepth = 0;
                 td.RootDepth = 0;
                 td.SelDepth = 0;
+                td.NMPPly = 0;
 
                 //  Each thread gets its own copy of each of the root position's "RootMoves" since the thread will be sorting these
                 //  and doing that simultaneously would cause data races

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -10,7 +10,7 @@ namespace Lizard.Logic.Util
     public static class Utilities
     {
 
-        public const string EngineBuildVersion = "11.1.3";
+        public const string EngineBuildVersion = "11.1.4";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;


### PR DESCRIPTION
This mainly helps with zugzwang in endgames
```
Elo   | 2.02 +- 1.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 47528 W: 11308 L: 11032 D: 25188
Penta | [102, 5376, 12563, 5590, 133]
```
http://somelizard.pythonanywhere.com/test/2024/