### PR TITLE
LMR tweak

### DIFF
--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -69,7 +69,7 @@
 
         public static int LMRQuietDiv = 12288;
         public static int LMRCaptureDiv = 10288;
-        public static int LMRExtMargin = 128;
+        public static int LMRExtMargin = 48;
 
         public static int QSFutileMargin = 183;
         public static int QSSeeMargin = 81;

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -524,7 +524,7 @@ namespace Lizard.Logic.Search
                     R -= (histScore / (isCapture ? LMRCaptureDiv : LMRQuietDiv));
 
 
-                    int reducedDepth = Math.Clamp(newDepth - R, 1, newDepth);
+                    int reducedDepth = Math.Clamp(newDepth - R, 0, newDepth);
                     score = -Negamax<NonPVNode>(pos, ss + 1, -alpha - 1, -alpha, reducedDepth, true);
 
                     if (score > alpha && reducedDepth < newDepth)

--- a/Logic/Search/Searches.cs
+++ b/Logic/Search/Searches.cs
@@ -502,18 +502,11 @@ namespace Lizard.Logic.Search
 
                     int R = LogarithmicReductionTable[depth][legalMoves];
 
-                    //  Reduce if our static eval is declining
                     R += (!improving).AsInt();
-
-                    //  Reduce if we think that this move is going to be a bad one
                     R += cutNode.AsInt() * 2;
 
                     R -= ss->TTPV.AsInt();
-
-                    //  Extend for PV searches
                     R -= isPV.AsInt();
-
-                    //  Extend killer moves
                     R -= (m == ss->KillerMove).AsInt();
 
                     var histScore = 2 * (isCapture ? history.CaptureHistory[us, ourPiece, moveTo, theirPiece] : history.MainHistory[us, m]) +
@@ -552,8 +545,6 @@ namespace Lizard.Logic.Search
 
                 if (isPV && (playedMoves == 1 || score > alpha))
                 {
-                    //  Do a new PV search here.
-                    //  TODO: Is it fine to use (newDepth - 1) here since it could've been changed in the LMR logic section?
                     (ss + 1)->PV[0] = Move.Null;
                     score = -Negamax<PVNode>(pos, ss + 1, -beta, -alpha, newDepth, false);
                 }

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -10,7 +10,7 @@ namespace Lizard.Logic.Util
     public static class Utilities
     {
 
-        public const string EngineBuildVersion = "11.1.4";
+        public const string EngineBuildVersion = "11.1.6";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;


### PR DESCRIPTION
```
Elo   | 1.78 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 59946 W: 14100 L: 13793 D: 32053
Penta | [158, 7040, 15289, 7309, 177]
```
http://somelizard.pythonanywhere.com/test/2037/