### PR TITLE
Added optional C++ P/Invoke for evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /*.nnue
 /data
 /.vs/ProjectEvaluation
+*.dll
+*.so

--- a/Bindings/SIMD.cpp
+++ b/Bindings/SIMD.cpp
@@ -1,0 +1,165 @@
+
+#include <immintrin.h>
+#include <xmmintrin.h>
+#include <stdint.h>
+#include <iostream>
+#include <array>
+#include <span>
+#include <bit>
+
+#include "simd.h"
+#include "arch.h"
+#include "defs.h"
+
+#if defined(_MSC_VER)
+#define DLL_EXPORT extern "C" __declspec(dllexport)
+#else
+#define DLL_EXPORT extern "C"
+#endif
+
+DLL_EXPORT void SetupNNZ();
+
+DLL_EXPORT void EvaluateBound(const i16* us, const i16* them,
+                              const    i8* L1Weights, const float* L1Biases,
+                              const float* L2Weights, const float* L2Biases,
+                              const float* L3weights, const float  L3bias,
+                              int& L3Output);
+
+struct NNZTable {
+    __m128i Entries[256];
+};
+NNZTable nnzTable;
+
+DLL_EXPORT void SetupNNZ()  {
+    for (u32 i = 0; i < 256; i++) {
+        u16* ptr = reinterpret_cast<u16*>(&nnzTable.Entries[i]);
+
+        u32 j = i;
+        u32 k = 0;
+        while (j != 0) {
+            u32 lsbIndex = std::countr_zero(j);
+            j &= j - 1;
+            ptr[k++] = (u16)lsbIndex;
+        }
+    }
+}
+
+DLL_EXPORT void EvaluateBound(const i16* us, const i16* them, 
+                              const i8* L1Weights, const float* L1Biases, 
+                              const float* L2Weights, const float* L2Biases, 
+                              const float* L3weights, const float L3bias, 
+                              i32& L3Output) {
+    
+    i32 nnzCount = 0;
+    u16 nnzIndices[L1_SIZE / L1_CHUNK_PER_32] alignas(32);
+    i8 FTOutputs[L1_SIZE] alignas(32);
+
+    vec_i32 L1Temp[L2_SIZE / I32_CHUNK_SIZE] alignas(32) = {};
+    float L1Outputs[L2_SIZE] alignas(32);
+
+    vec_ps L2Outputs[L3_SIZE / F32_CHUNK_SIZE] alignas(32);
+
+    //  FT
+    {
+        const auto ft_zero = vec_setzero_epi16();
+        const auto ft_one = vec_set1_epi16(FT_QUANT);
+        const vec_128i baseInc = _mm_set1_epi16(u16(8));
+        vec_128i baseVec = _mm_setzero_si128();
+        i32 offset = 0;
+
+        for (const auto acc : { us, them }) {
+            for (i32 i = 0; i < L1_PAIR_COUNT; i += (I16_CHUNK_SIZE * 2)) {
+                const auto input0a = vec_load_epi16(reinterpret_cast<const vec_i16*>(&acc[i + 0 * I16_CHUNK_SIZE + 0]));
+                const auto input0b = vec_load_epi16(reinterpret_cast<const vec_i16*>(&acc[i + 1 * I16_CHUNK_SIZE + 0]));
+
+                const auto input1a = vec_load_epi16(reinterpret_cast<const vec_i16*>(&acc[i + 0 * I16_CHUNK_SIZE + L1_PAIR_COUNT]));
+                const auto input1b = vec_load_epi16(reinterpret_cast<const vec_i16*>(&acc[i + 1 * I16_CHUNK_SIZE + L1_PAIR_COUNT]));
+
+                const auto clipped0a = vec_min_epi16(vec_max_epi16(input0a, ft_zero), ft_one);
+                const auto clipped0b = vec_min_epi16(vec_max_epi16(input0b, ft_zero), ft_one);
+
+                const auto clipped1a = vec_min_epi16(input1a, ft_one);
+                const auto clipped1b = vec_min_epi16(input1b, ft_one);
+
+                const auto producta = vec_mulhi_epi16(vec_slli_epi16(clipped0a, 16 - FT_SHIFT), clipped1a);
+                const auto productb = vec_mulhi_epi16(vec_slli_epi16(clipped0b, 16 - FT_SHIFT), clipped1b);
+
+                const auto product_one = vec_packus_epi16(producta, productb);
+                vec_storeu_epi8(reinterpret_cast<vec_i8*>(&FTOutputs[offset + i]), product_one);
+
+                const auto nnz_mask = vec_nnz_mask(product_one);
+
+                for (i32 j = 0; j < NNZ_OUTPUTS_PER_CHUNK; j++) {
+                    i32 lookup = (nnz_mask >> (j * 8)) & 0xFF;
+                    auto offsets = nnzTable.Entries[lookup];
+                    _mm_storeu_si128(reinterpret_cast<vec_128i*>(&nnzIndices[nnzCount]), _mm_add_epi16(baseVec, offsets));
+
+                    nnzCount += std::popcount(static_cast<u32>(lookup));
+                    baseVec = _mm_add_epi16(baseVec, baseInc);
+                }
+
+            }
+
+            offset += L1_PAIR_COUNT;
+        }
+    }
+
+
+    //  L1
+    {
+        i8* L1Inputs = FTOutputs;
+        const auto inputs32 = (i32*)(FTOutputs);
+        for (i32 i = 0; i < nnzCount; i++) {
+            const auto index = nnzIndices[i];
+            const auto input32 = vec_set1_epi32(inputs32[index]);
+            const auto weight = reinterpret_cast<const vec_i8*>(&L1Weights[index * L1_CHUNK_PER_32 * L2_SIZE]);
+            for (i32 k = 0; k < L2_SIZE / F32_CHUNK_SIZE; k++)
+                L1Temp[k] = vec_dpbusd_epi32(L1Temp[k], input32, weight[k]);
+        }
+
+        const auto zero = vec_set1_ps(0.0f);
+        const auto one = vec_set1_ps(1.0f);
+        const auto sumMul = vec_set1_ps(L1_MUL);
+        for (i32 i = 0; i < L2_SIZE / F32_CHUNK_SIZE; ++i) {
+            const auto biasVec = vec_loadu_ps(&L1Biases[i * F32_CHUNK_SIZE]);
+            const auto sumPs = vec_fmadd_ps(vec_cvtepi32_ps(L1Temp[i]), sumMul, biasVec);
+            const auto clipped = vec_min_ps(vec_max_ps(sumPs, zero), one);
+            const auto squared = vec_mul_ps(clipped, clipped);
+            vec_storeu_ps(&L1Outputs[i * F32_CHUNK_SIZE], squared);
+        }
+    }
+
+
+    //  L2
+    {
+        float* L2Inputs = L1Outputs;
+        for (i32 i = 0; i < L3_SIZE / F32_CHUNK_SIZE; ++i)
+            L2Outputs[i] = vec_loadu_ps(&L2Biases[i * F32_CHUNK_SIZE]);
+
+        for (i32 i = 0; i < L2_SIZE; ++i) {
+            const auto inputVec = vec_set1_ps(L2Inputs[i]);
+            const auto weight = reinterpret_cast<const vec_ps*>(&L2Weights[i * L3_SIZE]);
+            for (i32 j = 0; j < L3_SIZE / F32_CHUNK_SIZE; ++j)
+                L2Outputs[j] = vec_fmadd_ps(inputVec, weight[j], L2Outputs[j]);
+        }
+    }
+
+
+    //  L3
+    {
+        auto l3Sum = vec_set1_ps(0.0f);
+        const auto zero = vec_set1_ps(0.0f);
+        const auto one = vec_set1_ps(1.0f);
+        for (i32 i = 0; i < L3_SIZE / F32_CHUNK_SIZE; ++i) {
+            const auto clipped = vec_min_ps(vec_max_ps(L2Outputs[i], zero), one);
+            const auto squared = vec_mul_ps(clipped, clipped);
+
+            const auto weightVec = vec_loadu_ps(&L3weights[i * F32_CHUNK_SIZE]);
+            l3Sum = vec_fmadd_ps(squared, weightVec, l3Sum);
+        }
+
+        L3Output = static_cast<i32>((L3bias + vec_hsum_ps(l3Sum)) * OutputScale);
+    }
+}
+
+

--- a/Bindings/arch.h
+++ b/Bindings/arch.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "defs.h"
+#include "simd.h"
+
+constexpr auto INPUT_BUCKETS = 14;
+constexpr auto INPUT_SIZE = 768;
+constexpr auto L1_SIZE = 2048;
+constexpr auto L2_SIZE = 16;
+constexpr auto L3_SIZE = 32;
+constexpr auto OUTPUT_BUCKETS = 8;
+
+constexpr auto FT_QUANT = 255;
+constexpr auto FT_SHIFT = 10;
+constexpr auto L1_QUANT = 132;
+constexpr auto OutputScale = 400;
+
+constexpr auto U8_CHUNK_SIZE = sizeof(vec_i8) / sizeof(u8);
+constexpr auto I16_CHUNK_SIZE = sizeof(vec_i16) / sizeof(i16);
+constexpr auto I32_CHUNK_SIZE = sizeof(vec_i32) / sizeof(i32);
+constexpr auto F32_CHUNK_SIZE = sizeof(vec_ps) / sizeof(float);
+
+constexpr auto NNZ_INPUT_SIMD_WIDTH = sizeof(vec_i32) / sizeof(i32);
+constexpr auto NNZ_CHUNK_SIZE = (NNZ_INPUT_SIMD_WIDTH > 8) ? NNZ_INPUT_SIMD_WIDTH : 8;
+constexpr auto NNZ_OUTPUTS_PER_CHUNK = NNZ_CHUNK_SIZE / 8;
+
+constexpr auto L1_CHUNK_PER_32 = sizeof(i32) / sizeof(i8);
+constexpr auto L1_PAIR_COUNT = L1_SIZE / 2;
+
+constexpr auto SIMD_CHUNKS = L1_SIZE / (sizeof(vec_i16) / sizeof(i16));
+
+constexpr float L1_MUL = (1 << FT_SHIFT) / static_cast<float>(FT_QUANT * FT_QUANT * L1_QUANT);
+
+constexpr auto N_FTW = INPUT_SIZE * L1_SIZE * INPUT_BUCKETS;
+constexpr auto N_FTB = L1_SIZE;
+constexpr auto N_L1W = OUTPUT_BUCKETS * L1_SIZE * L2_SIZE;
+constexpr auto N_L1B = OUTPUT_BUCKETS * L2_SIZE;
+constexpr auto N_L2W = OUTPUT_BUCKETS * L2_SIZE * L3_SIZE;
+constexpr auto N_L2B = OUTPUT_BUCKETS * L3_SIZE;
+constexpr auto N_L3W = OUTPUT_BUCKETS * L3_SIZE;
+constexpr auto N_L3B = OUTPUT_BUCKETS;

--- a/Bindings/defs.h
+++ b/Bindings/defs.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include <span>
+
+using nuint = std::size_t;
+
+using i8 = std::int8_t;
+using i16 = std::int16_t;
+using i32 = std::int32_t;
+using i64 = std::int64_t;
+
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;

--- a/Bindings/simd.h
+++ b/Bindings/simd.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <immintrin.h>
+#include "defs.h"
+
+#if defined(AVX512) && defined(TODO_SOME_DAY)
+
+using vec_i8 = __m512i;
+using vec_i16 = __m512i;
+using vec_i32 = __m512i;
+using vec_ps = __m512;
+using vec_128i = __m128i;
+
+inline vec_i8 vec_packus_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_packus_epi16(a, b); }
+inline void vec_storeu_epi8(vec_i8* a, const vec_i8 b) { _mm512_storeu_si512(a, b); }
+
+inline vec_ps vec_set1_ps(const float a) { return _mm512_set1_ps(a); }
+inline vec_ps vec_fmadd_ps(const vec_ps a, const vec_ps b, const vec_ps c) { return _mm512_fmadd_ps(a, b, c); }
+inline vec_ps vec_min_ps(const vec_ps a, const vec_ps b) { return _mm512_min_ps(a, b); }
+inline vec_ps vec_max_ps(const vec_ps a, const vec_ps b) { return _mm512_max_ps(a, b); }
+inline vec_ps vec_mul_ps(const vec_ps a, const vec_ps b) { return _mm512_mul_ps(a, b); }
+inline vec_ps vec_cvtepi32_ps(const vec_i32 a) { return _mm512_cvtepi32_ps(a); }
+inline vec_ps vec_loadu_ps(const float* a) { return _mm512_loadu_ps(a); }
+inline void vec_storeu_ps(float* a, const vec_ps b) { _mm512_storeu_ps(a, b); }
+
+inline vec_i16 vec_set1_epi16(const i16 a) { return _mm512_set1_epi16(a); }
+inline vec_i16 vec_setzero_epi16() { return _mm512_setzero_si512(); }
+inline vec_i16 vec_add_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_add_epi16(a, b); }
+inline vec_i16 vec_sub_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_sub_epi16(a, b); }
+inline vec_i16 vec_maddubs_epi16(const vec_i8 a, const vec_i8 b) { return _mm512_maddubs_epi16(a, b); }
+inline vec_i16 vec_mulhi_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_mulhi_epi16(a, b); }
+inline vec_i16 vec_slli_epi16(const vec_i16 a, const i16 i) { return _mm512_slli_epi16(a, i); }
+inline vec_i16 vec_min_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_min_epi16(a, b); }
+inline vec_i16 vec_max_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_max_epi16(a, b); }
+inline vec_i16 vec_load_epi16(const vec_i16* a) { return _mm512_load_si512(a); }
+inline void vec_storeu_i16(vec_i16* a, const vec_i16 b) { _mm512_storeu_si512(a, b); }
+
+inline vec_i32 vec_set1_epi32(const i32 a) { return _mm512_set1_epi32(a); }
+inline vec_i32 vec_add_epi32(const vec_i32 a, const vec_i32 b) { return _mm512_add_epi32(a, b); }
+inline vec_i32 vec_madd_epi16(const vec_i16 a, const vec_i16 b) { return _mm512_madd_epi16(a, b); }
+
+inline uint16_t vec_nnz_mask(const vec_i32 vec) { return _mm512_cmpgt_epi32_mask(vec, _mm512_setzero_si512()); }
+
+inline float vec_hsum_ps(const vec_ps v) {
+    return _mm512_reduce_add_ps(v);
+}
+
+inline vec_i32 vec_dpbusd_epi32(const vec_i32 sum, const vec_i8 vec0, const vec_i8 vec1) {
+    const vec_i16 product16 = vec_maddubs_epi16(vec0, vec1);
+    const vec_i32 product32 = vec_madd_epi16(product16, vec_set1_epi16(1));
+    return vec_add_epi32(sum, product32);
+}
+
+
+#else
+
+using vec_i8 = __m256i;
+using vec_i16 = __m256i;
+using vec_i32 = __m256i;
+using vec_ps = __m256;
+using vec_128i = __m128i;
+
+inline vec_i8 vec_packus_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_packus_epi16(a, b); }
+inline void vec_storeu_epi8(vec_i8* a, const vec_i8 b) { _mm256_storeu_si256(a, b); }
+
+inline vec_ps vec_set1_ps(const float a) { return _mm256_set1_ps(a); }
+inline vec_ps vec_fmadd_ps(const vec_ps a, const vec_ps b, const vec_ps c) { return _mm256_fmadd_ps(a, b, c); }
+inline vec_ps vec_min_ps(const vec_ps a, const vec_ps b) { return _mm256_min_ps(a, b); }
+inline vec_ps vec_max_ps(const vec_ps a, const vec_ps b) { return _mm256_max_ps(a, b); }
+inline vec_ps vec_mul_ps(const vec_ps a, const vec_ps b) { return _mm256_mul_ps(a, b); }
+inline vec_ps vec_cvtepi32_ps(const vec_i32 a) { return _mm256_cvtepi32_ps(a); }
+inline vec_ps vec_loadu_ps(const float* a) { return _mm256_loadu_ps(a); }
+inline void vec_storeu_ps(float* a, const vec_ps b) { _mm256_storeu_ps(a, b); }
+
+inline vec_i16 vec_set1_epi16(const i16 a) { return _mm256_set1_epi16(a); }
+inline vec_i16 vec_setzero_epi16() { return _mm256_setzero_si256(); }
+inline vec_i16 vec_maddubs_epi16(const vec_i8 a, const vec_i8 b) { return _mm256_maddubs_epi16(a, b); }
+inline vec_i16 vec_add_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_add_epi16(a, b); }
+inline vec_i16 vec_sub_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_sub_epi16(a, b); }
+inline vec_i16 vec_mulhi_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_mulhi_epi16(a, b); }
+inline vec_i16 vec_slli_epi16(const vec_i16 a, const i16 i) { return _mm256_slli_epi16(a, i); }
+inline vec_i16 vec_min_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_min_epi16(a, b); }
+inline vec_i16 vec_max_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_max_epi16(a, b); }
+inline vec_i16 vec_load_epi16(const vec_i16* a) { return _mm256_load_si256(a); }
+inline void vec_storeu_i16(vec_i16* a, const vec_i16 b) { _mm256_storeu_si256(a, b); }
+
+inline vec_i32 vec_set1_epi32(const i32 a) { return _mm256_set1_epi32(a); }
+inline vec_i32 vec_add_epi32(const vec_i32 a, const vec_i32 b) { return _mm256_add_epi32(a, b); }
+inline vec_i32 vec_madd_epi16(const vec_i16 a, const vec_i16 b) { return _mm256_madd_epi16(a, b); }
+
+inline uint16_t vec_nnz_mask(const vec_i32 vec) { return _mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(vec, _mm256_setzero_si256()))); }
+
+inline float vec_hsum_ps(const vec_ps v) {
+    __m128 sum128 = _mm_add_ps(_mm256_castps256_ps128(v), _mm256_extractf128_ps(v, 1));
+    sum128 = _mm_hadd_ps(sum128, sum128);
+    sum128 = _mm_hadd_ps(sum128, sum128);
+    return _mm_cvtss_f32(sum128);
+}
+
+inline vec_i32 vec_dpbusd_epi32(const vec_i32 sum, const vec_i8 vec0, const vec_i8 vec1) {
+    const vec_i16 product16 = vec_maddubs_epi16(vec0, vec1);
+    const vec_i32 product32 = vec_madd_epi16(product16, vec_set1_epi16(1));
+    return vec_add_epi32(sum, product32);
+}
+
+#endif

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -182,6 +182,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Bindings\" />
     <Folder Include="obj\" />
   </ItemGroup>
 

--- a/Lizard.csproj
+++ b/Lizard.csproj
@@ -126,7 +126,12 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  
+  <!-- Embed the BINDINGS file if it's defined and the file actually exists
+  -->
+  <ItemGroup>
+    <EmbeddedResource Condition="'$(BINDINGS)' != '' AND Exists('$(BINDINGS)')" Include="$(BINDINGS)" />
+  </ItemGroup>
+
   <!-- Targeting the "aot" recipe in the makefile will set this to true.
   -->
   <ItemGroup>

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -99,7 +99,7 @@ namespace Lizard.Logic.NN
 
             if (HorsieBindings.HasBindings)
             {
-                HorsieBindings.HorsieSetupNNZ();
+                HorsieBindings.DoSetupNNZ();
             }
             else
             {
@@ -393,7 +393,7 @@ namespace Lizard.Logic.NN
             {
                 int L3Output = 0;
 
-                HorsieBindings.HorsieGetEvaluation(us, them,
+                HorsieBindings.DoGetEvaluation(us, them,
                     Net.L1Weights[outputBucket], Net.L1Biases[outputBucket],
                     Net.L2Weights[outputBucket], Net.L2Biases[outputBucket],
                     Net.L3Weights[outputBucket], Net.L3Biases[outputBucket], ref L3Output);

--- a/Logic/NN/Bucketed768.cs
+++ b/Logic/NN/Bucketed768.cs
@@ -96,8 +96,16 @@ namespace Lizard.Logic.NN
         static Bucketed768()
         {
             Net = new NetContainer<short, sbyte, float>();
-            NNZLookup = AlignedAllocZeroed<Vector128<ushort>>(256);
-            SetupNNZ();
+
+            if (HorsieBindings.HasBindings)
+            {
+                HorsieBindings.HorsieSetupNNZ();
+            }
+            else
+            {
+                NNZLookup = AlignedAllocZeroed<Vector128<ushort>>(256);
+                SetupNNZ();
+            }
 
 #if NO_PERM
             PermuteIndices = Enumerable.Range(0, L1_PAIR_COUNT).ToArray();
@@ -376,21 +384,35 @@ namespace Lizard.Logic.NN
         public static short GetEvaluation(Position pos, int outputBucket)
         {
             ref Accumulator accumulator = ref *pos.State->Accumulator;
-
             Bucketed768.ProcessUpdates(pos);
-
-            float* L1Outputs = stackalloc float[L2_SIZE];
-            float* L2Outputs = stackalloc float[L3_SIZE];
-            float L3Output = 0;
 
             var us   = (short*)(accumulator[pos.ToMove]);
             var them = (short*)(accumulator[Not(pos.ToMove)]);
 
-            ActivateFTSparse(us, them, Net.L1Weights[outputBucket], Net.L1Biases[outputBucket], L1Outputs);
-            ActivateL2(L1Outputs, Net.L2Weights[outputBucket], Net.L2Biases[outputBucket], L2Outputs);
-            ActivateL3(L2Outputs, Net.L3Weights[outputBucket], Net.L3Biases[outputBucket], ref L3Output);
+            if (HorsieBindings.HasBindings)
+            {
+                int L3Output = 0;
 
-            return (short)(L3Output * OutputScale);
+                HorsieBindings.HorsieGetEvaluation(us, them,
+                    Net.L1Weights[outputBucket], Net.L1Biases[outputBucket],
+                    Net.L2Weights[outputBucket], Net.L2Biases[outputBucket],
+                    Net.L3Weights[outputBucket], Net.L3Biases[outputBucket], ref L3Output);
+
+                return (short)L3Output;
+            }
+            else
+            {
+                float L3Output = 0;
+
+                float* L1Outputs = stackalloc float[L2_SIZE];
+                float* L2Outputs = stackalloc float[L3_SIZE];
+
+                ActivateFTSparse(us, them, Net.L1Weights[outputBucket], Net.L1Biases[outputBucket], L1Outputs);
+                ActivateL2(L1Outputs, Net.L2Weights[outputBucket], Net.L2Biases[outputBucket], L2Outputs);
+                ActivateL3(L2Outputs, Net.L3Weights[outputBucket], Net.L3Biases[outputBucket], ref L3Output);
+
+                return (short)(L3Output * OutputScale);
+            }
         }
 
         private static void ActivateFTSparse(short* us, short* them, sbyte* weights, float* biases, float* output)

--- a/Logic/Util/HorsieBindings.cs
+++ b/Logic/Util/HorsieBindings.cs
@@ -1,0 +1,79 @@
+﻿
+using System.Reflection;
+using System.Runtime.InteropServices;
+using static System.Runtime.InteropServices.RuntimeInformation;
+
+namespace Lizard.Logic.Util
+{
+    public static unsafe partial class HorsieBindings
+    {
+        public static readonly bool HasBindings;
+        private static readonly nint Handle;
+
+        private const string DEST_NAME = "HorsieBindings.dll";
+
+        static HorsieBindings()
+        {
+            HasBindings = false;
+            if (!IsOSPlatform(OSPlatform.Windows) || IsOSPlatform(OSPlatform.Linux))
+                return;
+
+            string fExt = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dll" : "so";
+            string asmName = Assembly.GetExecutingAssembly().GetName().Name;
+            string resName = $"{asmName}.HorsieBindings.{fExt}";
+
+            string exePath = Path.GetDirectoryName(AppContext.BaseDirectory);
+            string absPath = Path.Combine(exePath, DEST_NAME);
+
+            try
+            {
+                if (!File.Exists(absPath) && !ExtractEmbeddedLibrary(resName, DEST_NAME))
+                {
+                    return;
+                }
+
+                Handle = NativeLibrary.Load(absPath);
+            }
+            catch (Exception e)
+            {
+                Log("Failed loading Horsie bindings! :(");
+                Log(e.Message);
+                return;
+            }
+
+            HasBindings = true;
+            Log("Loaded Horsie bindings!");
+        }
+
+        private static bool ExtractEmbeddedLibrary(string resName, string fileName)
+        {
+            var asm = Assembly.GetExecutingAssembly();
+            Debug.WriteLine($"looking for {resName} in [{string.Join(", ", asm.GetManifestResourceNames())}]");
+            using Stream stream = asm.GetManifestResourceStream(resName);
+
+            if (stream == null)
+            {
+                Log("Running without Horsie bindings");
+                return false;
+            }
+
+            string exePath = Path.GetDirectoryName(AppContext.BaseDirectory);
+            string dllPath = Path.Combine(exePath, fileName);
+
+            using FileStream fs = new FileStream(dllPath, FileMode.Create, FileAccess.Write);
+            stream.CopyTo(fs);
+
+            return true;
+        }
+
+
+
+        [LibraryImport("HorsieBindings.dll", EntryPoint = "SetupNNZ")]
+        public static partial void HorsieSetupNNZ();
+
+        [LibraryImport("HorsieBindings.dll", EntryPoint = "EvaluateBound")]
+        public static partial void HorsieGetEvaluation(short* us, short* them, sbyte* L1Weights, float* L1Biases,
+            float* L2Weights, float* L2Biases, float* L3weights, float L3bias, ref int L3Output);
+
+    }
+}

--- a/Logic/Util/Utilities.cs
+++ b/Logic/Util/Utilities.cs
@@ -10,7 +10,7 @@ namespace Lizard.Logic.Util
 {
     public static class Utilities
     {
-        public const string EngineBuildVersion = "11.1.8";
+        public const string EngineBuildVersion = "11.1.9";
 
         public const int NormalListCapacity = 128;
         public const int MoveListSize = 256;


### PR DESCRIPTION
Makefile will attempt to compile the c++ code into a dll/so, and include it in the binary. This are an improvement on the existing Avx2 implementation, and the fallbacks will still work if your system doesn't have `g++`.


```
Elo   | 24.86 +- 6.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 2436 W: 657 L: 483 D: 1296
Penta | [4, 198, 640, 372, 4]
```
https://somelizard.pythonanywhere.com/test/2208/